### PR TITLE
User and Team Management

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,9 @@ pipeline:
     - |
       export TKN=$(curl -X POST 'http://keycloak:8080/auth/realms/master/protocol/openid-connect/token' -H "Content-Type: application/x-www-form-urlencoded" -d "username=admin" -d 'password=password1' -d 'grant_type=password' -d 'client_id=admin-cli' | jq -r '.access_token')
     - |
-      echo $TKN
+      curl -vX POST http://keycloak:8080/auth/admin/realms -d @keycloak/local-realm.json \
+      --header "Authorization: Bearer $TKN" \
+      --header "Content-Type: application/json"
 
   build-project:
     image: quay.io/ukhomeofficedigital/openjdk8

--- a/.drone.yml
+++ b/.drone.yml
@@ -111,58 +111,58 @@ pipeline:
       environment: prod
 
 
-  services:
-    postgres:
-      image: quay.io/ukhomeofficedigital/postgres
-      environment:
-        POSTGRES_USER: root
-        POSTGRES_PASSWORD: dev
-    localstack:
-      image: localstack/localstack:latest
-      environment:
-        HOSTNAME_EXTERNAL: localstack
-        DEFAULT_REGION: eu-west-2
-        SERVICES: sqs,s3
-    aws_cli:
-      image: garland/aws-cli-docker
-      command:
-      - /bin/sh
-      - -c
-      - |
-        aws --endpoint-url=http://localstack:4572 s3 mb s3://untrusted-bucket
-        aws --endpoint-url=http://localstack:4572 s3 mb s3://trusted-bucket
-        aws --endpoint-url=http://localstack:4576 sqs create-queue --queue-name case-queue
-        aws --endpoint-url=http://localstack:4576 sqs create-queue --queue-name case-queue-dlq
-        aws --endpoint-url=http://localstack:4576 sqs create-queue --queue-name document-queue
-        aws --endpoint-url=http://localstack:4576 sqs create-queue --queue-name document-queue-dlq
-        aws --endpoint-url=http://localstack:4576 sqs create-queue --queue-name reporting-queue
-        aws --endpoint-url=http://localstack:4576 sqs create-queue --queue-name reporting-queue-dlq
-      environment:
-        AWS_ACCESS_KEY_ID: UNSET
-        AWS_SECRET_ACCESS_KEY: UNSET
-        AWS_DEFAULT_REGION: 'eu-west-2'
-    selenium:
-      image: selenium/hub
+services:
+  postgres:
+    image: quay.io/ukhomeofficedigital/postgres
+    environment:
+      POSTGRES_USER: root
+      POSTGRES_PASSWORD: dev
+  localstack:
+    image: localstack/localstack:latest
+    environment:
+      HOSTNAME_EXTERNAL: localstack
+      DEFAULT_REGION: eu-west-2
+      SERVICES: sqs,s3
+  aws_cli:
+    image: garland/aws-cli-docker
+    command:
+    - /bin/sh
+    - -c
+    - |
+      aws --endpoint-url=http://localstack:4572 s3 mb s3://untrusted-bucket
+      aws --endpoint-url=http://localstack:4572 s3 mb s3://trusted-bucket
+      aws --endpoint-url=http://localstack:4576 sqs create-queue --queue-name case-queue
+      aws --endpoint-url=http://localstack:4576 sqs create-queue --queue-name case-queue-dlq
+      aws --endpoint-url=http://localstack:4576 sqs create-queue --queue-name document-queue
+      aws --endpoint-url=http://localstack:4576 sqs create-queue --queue-name document-queue-dlq
+      aws --endpoint-url=http://localstack:4576 sqs create-queue --queue-name reporting-queue
+      aws --endpoint-url=http://localstack:4576 sqs create-queue --queue-name reporting-queue-dlq
+    environment:
+      AWS_ACCESS_KEY_ID: UNSET
+      AWS_SECRET_ACCESS_KEY: UNSET
+      AWS_DEFAULT_REGION: 'eu-west-2'
+  selenium:
+    image: selenium/hub
 
-    chrome:
-      image: selenium/node-chrome
-      environment:
-        HUB_PORT_4444_TCP_ADDR: selenium
-        HUB_PORT_4444_TCP_PORT: "4444"
-        DISPLAY: ":99.0"
+  chrome:
+    image: selenium/node-chrome
+    environment:
+      HUB_PORT_4444_TCP_ADDR: selenium
+      HUB_PORT_4444_TCP_PORT: "4444"
+      DISPLAY: ":99.0"
 
-    firefox:
-      image: selenium/node-firefox
-      environment:
-        HUB_PORT_4444_TCP_ADDR: selenium
-        HUB_PORT_4444_TCP_PORT: "4444"
-        DISPLAY: ":98.0"
+  firefox:
+    image: selenium/node-firefox
+    environment:
+      HUB_PORT_4444_TCP_ADDR: selenium
+      HUB_PORT_4444_TCP_PORT: "4444"
+      DISPLAY: ":98.0"
 
-    keycloak:
-      image: jboss/keycloak
-      environment:
-        KEYCLOAK_USER: admin
-        KEYCLOAK_PASSWORD: password1
-        KEYCLOAK_IMPORT: keycloak/local-realm.json
-        DB_VENDOR: h2
+  keycloak:
+    image: jboss/keycloak
+    environment:
+      KEYCLOAK_USER: admin
+      KEYCLOAK_PASSWORD: password1
+      KEYCLOAK_IMPORT: keycloak/local-realm.json
+      DB_VENDOR: h2
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -3,10 +3,8 @@ pipeline:
     image: quay.io/ukhomeofficedigital/hocs-docker-tools
     commands:
     - |
-      curl http://keycloak:8080/auth/realms/master/.well-known/openid-configuration
-    - |
-      until $(curl http://keycloak:8080/auth/realms/master/.well-known/openid-configuration); do
-        sleep 20
+      until $(curl --output /dev/null --silent --head --fail http://keycloak:8080/auth/realms/master/.well-known/openid-configuration); do
+        sleep 5
       done
     - |
       export TKN=$(curl -X POST 'http://keycloak:8080/auth/realms/master/protocol/openid-connect/token' -H "Content-Type: application/x-www-form-urlencoded" -d "username=admin" -d 'password=password1' -d 'grant_type=password' -d 'client_id=admin-cli' | jq -r '.access_token')

--- a/.drone.yml
+++ b/.drone.yml
@@ -3,8 +3,8 @@ pipeline:
     image: quay.io/ukhomeofficedigital/hocs-docker-tools
     commands:
     - |
-      until $(curl --output /dev/null --silent --head --fail http://keycloak:8080/auth/realms/master/.well-known/openid-configuration); do
-        sleep 5
+      until $(curl http://keycloak:8080/auth/realms/master/.well-known/openid-configuration); do
+        sleep 20
       done
     - |
       export TKN=$(curl -X POST 'http://keycloak:8080/auth/realms/master/protocol/openid-connect/token' -H "Content-Type: application/x-www-form-urlencoded" -d "username=admin" -d 'password=password1' -d 'grant_type=password' -d 'client_id=admin-cli' | jq -r '.access_token')

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,4 +1,13 @@
 pipeline:
+  wait-for-keycloak:
+    image: quay.io/ukhomeofficedigital/hocs-docker-tools
+    commands:
+    - |
+      until http://keycloak:8080/auth >/dev/null 2>&1; do sleep 2; done
+    - |
+      export TKN=$(curl -X POST 'http://keycloak:8080/auth/realms/master/protocol/openid-connect/token' -H "Content-Type: application/x-www-form-urlencoded" -d "username=admin" -d 'password=password1' -d 'grant_type=password' -d 'client_id=admin-cli' | jq -r '.access_token')
+    - |
+      echo $TKN
 
   build-project:
     image: quay.io/ukhomeofficedigital/openjdk8
@@ -40,19 +49,6 @@ pipeline:
     when:
       branch: master
       event: push
-
-  tag-docker-image-with-git-tag:
-    image: docker:17.09.1
-    environment:
-      - DOCKER_HOST=tcp://172.17.0.1:2375
-    secrets:
-      - docker_password
-    commands:
-      - docker login -u="ukhomeofficedigital+hocs" -p=$${DOCKER_PASSWORD} quay.io
-      - docker tag hocs-info-service quay.io/ukhomeofficedigital/hocs-info-service:$${DRONE_TAG}
-      - docker push quay.io/ukhomeofficedigital/hocs-info-service:$${DRONE_TAG}
-    when:
-      event: tag
 
   clone-kube-project:
     image: plugins/git
@@ -112,6 +108,12 @@ pipeline:
 
 
 services:
+  keycloak:
+    image: jboss/keycloak
+    environment:
+      KEYCLOAK_USER: admin
+      KEYCLOAK_PASSWORD: password1
+      DB_VENDOR: h2
   postgres:
     image: quay.io/ukhomeofficedigital/postgres
     environment:
@@ -124,7 +126,7 @@ services:
       DEFAULT_REGION: eu-west-2
       SERVICES: sqs,s3
   aws_cli:
-    image: garland/aws-cli-docker
+    image: quay.io/ukhomeofficedigital/hocs-docker-tools
     command:
     - /bin/sh
     - -c
@@ -137,6 +139,7 @@ services:
       aws --endpoint-url=http://localstack:4576 sqs create-queue --queue-name document-queue-dlq
       aws --endpoint-url=http://localstack:4576 sqs create-queue --queue-name reporting-queue
       aws --endpoint-url=http://localstack:4576 sqs create-queue --queue-name reporting-queue-dlq
+
     environment:
       AWS_ACCESS_KEY_ID: UNSET
       AWS_SECRET_ACCESS_KEY: UNSET
@@ -158,13 +161,5 @@ services:
       HUB_PORT_4444_TCP_PORT: "4444"
       DISPLAY: ":98.0"
 
-  keycloak:
-    image: jboss/keycloak
-    volumes:
-      - keycloak:/tmp/keycloak
-    environment:
-      KEYCLOAK_USER: admin
-      KEYCLOAK_PASSWORD: password1
-      KEYCLOAK_IMPORT: /tmp/keycloak/local-realm.json
-      DB_VENDOR: h2
+
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -160,7 +160,8 @@ services:
 
   keycloak:
     image: jboss/keycloak
-    volumes: [ keycloak:/tmp/keycloak ]
+    volumes:
+      - keycloak:/tmp/keycloak
     environment:
       KEYCLOAK_USER: admin
       KEYCLOAK_PASSWORD: password1

--- a/.drone.yml
+++ b/.drone.yml
@@ -3,7 +3,9 @@ pipeline:
     image: quay.io/ukhomeofficedigital/hocs-docker-tools
     commands:
     - |
-      until http://keycloak:8080/auth >/dev/null 2>&1; do sleep 2; done
+      until $(curl --output /dev/null --silent --head --fail http://keycloak:8080/auth); do
+        sleep 5
+      done
     - |
       export TKN=$(curl -X POST 'http://keycloak:8080/auth/realms/master/protocol/openid-connect/token' -H "Content-Type: application/x-www-form-urlencoded" -d "username=admin" -d 'password=password1' -d 'grant_type=password' -d 'client_id=admin-cli' | jq -r '.access_token')
     - |

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,6 @@
 pipeline:
   wait-for-keycloak:
-    image: quay.io/ukhomeofficedigital/hocs-docker-tools
+    image: quay.io/ukhomeofficedigital/hocs-docker-tools:build-4
     commands:
     - |
       until $(curl --output /dev/null --silent --head --fail http://keycloak:8080/auth/realms/master/.well-known/openid-configuration); do

--- a/.drone.yml
+++ b/.drone.yml
@@ -3,6 +3,9 @@ pipeline:
   build-project:
     image: quay.io/ukhomeofficedigital/openjdk8
     commands:
+      - export SPRING_PROFILES_ACTIVE='development, local'
+      - export DB_HOST='postgres'
+      - export AWS_LOCAL_HOST='localstack'
       - ./gradlew build
     when:
       event: [push, pull_request, tag]
@@ -106,3 +109,60 @@ pipeline:
     when:
       event: deployment
       environment: prod
+
+
+  services:
+    postgres:
+      image: quay.io/ukhomeofficedigital/postgres
+      environment:
+        POSTGRES_USER: root
+        POSTGRES_PASSWORD: dev
+    localstack:
+      image: localstack/localstack:latest
+      environment:
+        HOSTNAME_EXTERNAL: localstack
+        DEFAULT_REGION: eu-west-2
+        SERVICES: sqs,s3
+    aws_cli:
+      image: garland/aws-cli-docker
+      command:
+      - /bin/sh
+      - -c
+      - |
+        aws --endpoint-url=http://localstack:4572 s3 mb s3://untrusted-bucket
+        aws --endpoint-url=http://localstack:4572 s3 mb s3://trusted-bucket
+        aws --endpoint-url=http://localstack:4576 sqs create-queue --queue-name case-queue
+        aws --endpoint-url=http://localstack:4576 sqs create-queue --queue-name case-queue-dlq
+        aws --endpoint-url=http://localstack:4576 sqs create-queue --queue-name document-queue
+        aws --endpoint-url=http://localstack:4576 sqs create-queue --queue-name document-queue-dlq
+        aws --endpoint-url=http://localstack:4576 sqs create-queue --queue-name reporting-queue
+        aws --endpoint-url=http://localstack:4576 sqs create-queue --queue-name reporting-queue-dlq
+      environment:
+        AWS_ACCESS_KEY_ID: UNSET
+        AWS_SECRET_ACCESS_KEY: UNSET
+        AWS_DEFAULT_REGION: 'eu-west-2'
+    selenium:
+      image: selenium/hub
+
+    chrome:
+      image: selenium/node-chrome
+      environment:
+        HUB_PORT_4444_TCP_ADDR: selenium
+        HUB_PORT_4444_TCP_PORT: "4444"
+        DISPLAY: ":99.0"
+
+    firefox:
+      image: selenium/node-firefox
+      environment:
+        HUB_PORT_4444_TCP_ADDR: selenium
+        HUB_PORT_4444_TCP_PORT: "4444"
+        DISPLAY: ":98.0"
+
+    keycloak:
+      image: jboss/keycloak
+      environment:
+        KEYCLOAK_USER: admin
+        KEYCLOAK_PASSWORD: password1
+        KEYCLOAK_IMPORT: keycloak/local-realm.json
+        DB_VENDOR: h2
+

--- a/.drone.yml
+++ b/.drone.yml
@@ -3,7 +3,7 @@ pipeline:
     image: quay.io/ukhomeofficedigital/hocs-docker-tools
     commands:
     - |
-      until $(curl --output /dev/null --silent --head --fail http://keycloak:8080/auth); do
+      until $(curl --output /dev/null --silent --head --fail http://keycloak:8080/auth/realms/master/.well-known/openid-configuration); do
         sleep 5
       done
     - |

--- a/.drone.yml
+++ b/.drone.yml
@@ -9,9 +9,7 @@ pipeline:
     - |
       export TKN=$(curl -X POST 'http://keycloak:8080/auth/realms/master/protocol/openid-connect/token' -H "Content-Type: application/x-www-form-urlencoded" -d "username=admin" -d 'password=password1' -d 'grant_type=password' -d 'client_id=admin-cli' | jq -r '.access_token')
     - |
-      curl -vX POST http://keycloak:8080/auth/admin/realms -d @keycloak/local-realm.json \
-      --header "Authorization: Bearer $TKN" \
-      --header "Content-Type: application/json"
+      curl -vX POST http://keycloak:8080/auth/admin/realms -d @keycloak/local-realm.json --header "Authorization: Bearer $TKN" --header "Content-Type: application/json"
 
   build-project:
     image: quay.io/ukhomeofficedigital/openjdk8

--- a/.drone.yml
+++ b/.drone.yml
@@ -3,6 +3,8 @@ pipeline:
     image: quay.io/ukhomeofficedigital/hocs-docker-tools
     commands:
     - |
+      curl http://keycloak:8080/auth/realms/master/.well-known/openid-configuration
+    - |
       until $(curl http://keycloak:8080/auth/realms/master/.well-known/openid-configuration); do
         sleep 20
       done

--- a/.drone.yml
+++ b/.drone.yml
@@ -160,9 +160,10 @@ services:
 
   keycloak:
     image: jboss/keycloak
+    volumes: [ keycloak:/tmp/keycloak ]
     environment:
       KEYCLOAK_USER: admin
       KEYCLOAK_PASSWORD: password1
-      KEYCLOAK_IMPORT: keycloak/local-realm.json
+      KEYCLOAK_IMPORT: /tmp/keycloak/local-realm.json
       DB_VENDOR: h2
 

--- a/keycloak/local-realm.json
+++ b/keycloak/local-realm.json
@@ -247,37 +247,38 @@
   },
   "groups" : [ {
     "id" : "516e05ec-ed79-4a48-aa2e-35f174fe9034",
-    "name" : "DCU",
-    "path" : "/DCU",
+    "name" : "UNIT2",
+    "path" : "/UNIT2",
     "attributes" : { },
     "realmRoles" : [ ],
     "clientRoles" : { },
     "subGroups" : [ {
       "id" : "abf7617c-058c-4287-9f41-b95384fdbc7d",
-      "name" : "44444444-2222-2222-2222-222222222222",
-      "path" : "/DCU/44444444-2222-2222-2222-222222222222",
+      "name" : "434a4e33-437f-4e6d-8f04-14ea40fdbfa2",
+      "path" : "/UNIT2/434a4e33-437f-4e6d-8f04-14ea40fdbfa2",
       "attributes" : { },
       "realmRoles" : [ ],
       "clientRoles" : { },
       "subGroups" : [ {
         "id" : "a6f5c195-b625-4a95-9789-6609ef87cb38",
-        "name" : "MIN",
-        "path" : "/DCU/44444444-2222-2222-2222-222222222222/MIN",
+        "name" : "CT2",
+        "path" : "/UNIT2/434a4e33-437f-4e6d-8f04-14ea40fdbfa2/CT2",
         "attributes" : { },
         "realmRoles" : [ ],
         "clientRoles" : { },
         "subGroups" : [ {
           "id" : "a9faabdd-4e39-47c0-94ee-6548bf5b3547",
-          "name" : "OWNER",
-          "path" : "/DCU/44444444-2222-2222-2222-222222222222/MIN/OWNER",
+          "name" : "WRITE",
+          "path" : "/UNIT2/434a4e33-437f-4e6d-8f04-14ea40fdbfa2/CT2/WRITE",
           "attributes" : { },
           "realmRoles" : [ ],
           "clientRoles" : { },
           "subGroups" : [ ]
         } ]
       } ]
-    } ]
-  } ],
+    }]
+  }
+  ],
   "defaultRoles" : [ "uma_authorization", "offline_access" ],
   "requiredCredentials" : [ "password" ],
   "otpPolicyType" : "totp",
@@ -314,7 +315,7 @@
       "account" : [ "view-profile", "manage-account" ]
     },
     "notBefore" : 0,
-    "groups" : [ "/DCU/44444444-2222-2222-2222-222222222222/MIN/OWNER" ]
+    "groups" : [ "/UNIT2/434a4e33-437f-4e6d-8f04-14ea40fdbfa2/CT2/WRITE" ]
   } ],
   "scopeMappings" : [ {
     "clientScope" : "offline_access",

--- a/src/main/java/uk/gov/digital/ho/hocs/info/RestResponseExceptionHandler.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/RestResponseExceptionHandler.java
@@ -1,0 +1,28 @@
+package uk.gov.digital.ho.hocs.info;
+
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import uk.gov.digital.ho.hocs.info.exception.EntityNotFoundException;
+import uk.gov.digital.ho.hocs.info.security.KeycloakException;
+
+import static org.springframework.http.HttpStatus.*;
+
+@ControllerAdvice
+@Slf4j
+public class RestResponseExceptionHandler {
+
+    @ExceptionHandler(KeycloakException.class)
+    public ResponseEntity handle(KeycloakException e) {
+        log.error("Keycloak exception: {}", e.getMessage());
+        return new ResponseEntity<>(e.getMessage(), INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity handle(EntityNotFoundException e) {
+        log.error("Keycloak exception: {}", e.getMessage());
+        return new ResponseEntity<>(e.getMessage(), NOT_FOUND);
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/info/dto/TeamDto.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/dto/TeamDto.java
@@ -24,6 +24,9 @@ public class TeamDto {
     @JsonProperty("type")
     private UUID uuid;
 
+    @JsonProperty("active")
+    private boolean active;
+
     @JsonProperty("permissions")
     private Set<PermissionDto> permissions;
 
@@ -35,7 +38,7 @@ public class TeamDto {
     }
 
     public static TeamDto from (Team team) {
-        return new TeamDto(team.getDisplayName(), team.getUuid(),
+        return new TeamDto(team.getDisplayName(), team.getUuid(), team.isActive(),
                 team.getPermissions().stream().map(permission ->
                         PermissionDto.from(permission)).collect(Collectors.toSet())); }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/info/dto/UpdateTeamNameRequest.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/dto/UpdateTeamNameRequest.java
@@ -1,0 +1,19 @@
+package uk.gov.digital.ho.hocs.info.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@EqualsAndHashCode
+public class UpdateTeamNameRequest {
+
+
+        private String displayName;
+
+        @JsonCreator
+        public UpdateTeamNameRequest(@JsonProperty("displayName") String displayName) {
+                this.displayName = displayName;
+        }
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/info/dto/UpdateTeamPermissionsRequest.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/dto/UpdateTeamPermissionsRequest.java
@@ -1,0 +1,24 @@
+package uk.gov.digital.ho.hocs.info.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+@Getter
+@EqualsAndHashCode
+public class UpdateTeamPermissionsRequest {
+
+        @JsonProperty("permissions")
+        private Set<PermissionDto> permissions;
+
+        @JsonCreator
+        public UpdateTeamPermissionsRequest(@JsonProperty("permissions") Set<PermissionDto> permissions) {
+                this.permissions = Optional.ofNullable(permissions).orElse(new HashSet<>());
+        }
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/info/entities/CaseTypeEntity.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/entities/CaseTypeEntity.java
@@ -1,6 +1,7 @@
 package uk.gov.digital.ho.hocs.info.entities;
 
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,6 +13,7 @@ import java.io.Serializable;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@EqualsAndHashCode(of = {"type"})
 public class CaseTypeEntity implements Serializable {
 
     @Id
@@ -27,5 +29,8 @@ public class CaseTypeEntity implements Serializable {
 
     @Column(name = "tenant_role")
     private String role;
+
+    @Column(name = "active")
+    private boolean active;
 
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/info/entities/Permission.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/entities/Permission.java
@@ -1,9 +1,6 @@
 package uk.gov.digital.ho.hocs.info.entities;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import uk.gov.digital.ho.hocs.info.dto.PermissionDto;
 import uk.gov.digital.ho.hocs.info.security.AccessLevel;
 
@@ -15,6 +12,7 @@ import java.util.UUID;
 @Table(name = "permission")
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(of = {"accessLevel", "caseType", "team"})
 @Getter
 @Setter
 public class Permission implements Serializable {
@@ -29,12 +27,6 @@ public class Permission implements Serializable {
     @Column(name = "id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    @Column(name = "team_uuid", insertable = false, updatable = false)
-    private UUID teamUUID;
-
-    @Column(name = "case_type", insertable = false, updatable = false)
-    private String caseTypeCode;
 
     @Column(name = "access_level")
     @Enumerated(EnumType.STRING)

--- a/src/main/java/uk/gov/digital/ho/hocs/info/entities/Team.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/entities/Team.java
@@ -1,9 +1,6 @@
 package uk.gov.digital.ho.hocs.info.entities;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import uk.gov.digital.ho.hocs.info.dto.TeamDto;
 
 import javax.persistence.*;
@@ -19,18 +16,23 @@ import java.util.UUID;
 @AllArgsConstructor
 @Getter
 @Setter
+@EqualsAndHashCode(of = {"uuid"})
 public class Team implements Serializable {
 
-    public Team(String displayName, UUID uuid) {
+    public Team(String displayName, UUID uuid, boolean active) {
         this.displayName = displayName;
         this.uuid = uuid;
+        this.active = active;
         this.permissions = new HashSet<>();
     }
 
     public Team(String displayName, UUID uuid, Set<Permission> permissions) {
         this.displayName = displayName;
         this.uuid = uuid;
-        this.permissions = Optional.ofNullable(permissions).orElse(new HashSet<>());
+        this.permissions = new HashSet<>();
+        if(permissions !=null) {
+            addPermissions(permissions);
+        }
     }
 
     @Id
@@ -44,8 +46,8 @@ public class Team implements Serializable {
     @Column(name = "uuid")
     private UUID uuid;
 
-    @Column(name = "unit_uuid", insertable = false, updatable = false)
-    private UUID unitUUID;
+    @Column(name = "active")
+    private boolean active;
 
     @ManyToOne
     @JoinColumn(name = "unit_uuid", referencedColumnName = "uuid")
@@ -55,8 +57,10 @@ public class Team implements Serializable {
     private Set<Permission> permissions;
 
     public void addPermission(Permission permission) {
-        permission.setTeam(this);
-        permissions.add(permission);
+        if(!permissions.contains(permission)) {
+            permission.setTeam(this);
+            permissions.add(permission);
+        }
     }
 
     public void addPermissions(Set<Permission> newPermissions) {

--- a/src/main/java/uk/gov/digital/ho/hocs/info/logging/LogEvent.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/logging/LogEvent.java
@@ -3,12 +3,10 @@ package uk.gov.digital.ho.hocs.info.logging;
 public enum LogEvent {
 
     UNIT_CREATED,
-    UNIT_RENAMED,
     TEAM_CREATED,
     TEAM_ADDED_TO_UNIT,
     TEAM_RENAMED,
     TEAM_PERMISSIONS_UPDATED,
-    USER_CREATED,
     USER_ADDED_TO_TEAM;
 
     public static final String EVENT = "event_id";

--- a/src/main/java/uk/gov/digital/ho/hocs/info/repositories/TeamRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/repositories/TeamRepository.java
@@ -20,5 +20,5 @@ public interface TeamRepository extends CrudRepository<Team, Long> {
 
     Team findByUuid(UUID uuid);
 
-    Set<Team> findTeamsByUnitUUID(UUID unitUUID);
+    Set<Team> findTeamsByUnitUuid(UUID unitUUID);
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/info/security/KeyCloakConfiguration.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/security/KeyCloakConfiguration.java
@@ -1,4 +1,4 @@
-package uk.gov.digital.ho.hocs.info.keycloak;
+package uk.gov.digital.ho.hocs.info.security;
 
 import org.keycloak.admin.client.Keycloak;
 import org.springframework.beans.factory.BeanCreationException;

--- a/src/main/java/uk/gov/digital/ho/hocs/info/security/KeycloakException.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/security/KeycloakException.java
@@ -1,0 +1,8 @@
+package uk.gov.digital.ho.hocs.info.security;
+
+public class KeycloakException extends RuntimeException {
+
+    public KeycloakException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/info/security/KeycloakService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/security/KeycloakService.java
@@ -1,9 +1,11 @@
 package uk.gov.digital.ho.hocs.info.security;
 
+import lombok.extern.slf4j.Slf4j;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.representations.idm.GroupRepresentation;
+import org.keycloak.representations.idm.PartialImportRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -12,7 +14,12 @@ import javax.ws.rs.core.Response;
 import java.util.List;
 import java.util.UUID;
 
+import static net.logstash.logback.argument.StructuredArguments.value;
+import static uk.gov.digital.ho.hocs.info.logging.LogEvent.EVENT;
+import static uk.gov.digital.ho.hocs.info.logging.LogEvent.TEAM_CREATED;
+
 @Service
+@Slf4j
 public class KeycloakService {
 
     private Keycloak keycloakClient;
@@ -26,27 +33,46 @@ public class KeycloakService {
     }
 
    public  void addUserToGroup(UUID userUUID, String groupPath) {
+       try {
         RealmResource hocsRealm = keycloakClient.realm(hocsRealmName);
         UserResource user = hocsRealm.users().get(userUUID.toString());
         GroupRepresentation group = hocsRealm.getGroupByPath(groupPath);
-        user.joinGroup(group.getId());
+
+            user.joinGroup(group.getId());
+        }
+        catch(Exception e) {
+            log.error("Failed to add user {} to group {} for reason: {}", userUUID, groupPath, e.getMessage() , value(EVENT, TEAM_CREATED));
+            throw new KeycloakException(e.getMessage(), e);
+        }
     }
 
     public void createUnitGroupIfNotExists(String unit) {
-        RealmResource hocsRealm = keycloakClient.realm(hocsRealmName);
-        GroupRepresentation unitGroup = new GroupRepresentation();
-        unitGroup.setName(unit);
-        Response response = hocsRealm.groups().add(unitGroup);
-        response.close();
+        try {
+            RealmResource hocsRealm = keycloakClient.realm(hocsRealmName);
+            GroupRepresentation unitGroup = new GroupRepresentation();
+            unitGroup.setName(unit);
+            Response response = hocsRealm.groups().add(unitGroup);
+            response.close();
+        }
+        catch(Exception e) {
+            log.error("Failed to create group for unit {} for reason: {}", unit, e.getMessage() , value(EVENT, TEAM_CREATED));
+            throw new KeycloakException(e.getMessage(), e);
+        }
     }
 
     public void createGroupPathIfNotExists(String parentPath, String groupName) {
+      try {
         RealmResource hocsRealm = keycloakClient.realm(hocsRealmName);
         GroupRepresentation parentGroup =  hocsRealm.getGroupByPath(parentPath);
         GroupRepresentation newGroup = new GroupRepresentation();
         newGroup.setName(groupName);
         Response response = hocsRealm.groups().group(parentGroup.getId()).subGroup(newGroup);
         response.close();
+      }
+      catch(Exception e) {
+          log.error("Failed to create group  {} with parent {} for reason: {}", groupName ,parentPath, e.getMessage() , value(EVENT, TEAM_CREATED));
+          throw new KeycloakException(e.getMessage(), e);
+      }
     }
 
     public List<UserRepresentation> getAllUsers() {
@@ -55,23 +81,37 @@ public class KeycloakService {
     }
 
     public void updateUserGroupsForGroup(String groupPath) {
-        RealmResource hocsRealm = keycloakClient.realm(hocsRealmName);
-        GroupRepresentation group = hocsRealm.getGroupByPath(groupPath);
-        List<UserRepresentation> users = hocsRealm.groups().group(group.getId()).members();
-        for (GroupRepresentation subGroup : group.getSubGroups()) {
-            for (UserRepresentation user : users) {
-                addUserToGroup(UUID.fromString(user.getId()), subGroup.getPath());
+        try {
+            RealmResource hocsRealm = keycloakClient.realm(hocsRealmName);
+            GroupRepresentation group = hocsRealm.getGroupByPath(groupPath);
+            List<UserRepresentation> users = hocsRealm.groups().group(group.getId()).members();
+            for (GroupRepresentation subGroup : group.getSubGroups()) {
+                for (GroupRepresentation permissionGroup : subGroup.getSubGroups()) {
+                    for (UserRepresentation user : users) {
+                        addUserToGroup(UUID.fromString(user.getId()), permissionGroup.getPath());
+                    }
+                }
             }
+        }
+        catch(Exception e) {
+            log.error("Failed to update Keycloak user groups for group {} for reason: {}. WARNING: User groups may now be out of sync." ,groupPath, e.getMessage() , value(EVENT, TEAM_CREATED));
+            throw new KeycloakException(e.getMessage(), e);
         }
     }
 
 
     public void moveGroup(String currentGroupPath, String newParent) {
-        RealmResource hocsRealm = keycloakClient.realm(hocsRealmName);
-        GroupRepresentation group = hocsRealm.getGroupByPath(currentGroupPath);
-        createUnitGroupIfNotExists(newParent);
-        GroupRepresentation newParentGroup = hocsRealm.getGroupByPath(newParent);
-        hocsRealm.groups().group(newParentGroup.getId()).subGroup(group);
+        try {
+            RealmResource hocsRealm = keycloakClient.realm(hocsRealmName);
+            GroupRepresentation group = hocsRealm.getGroupByPath(currentGroupPath);
+            createUnitGroupIfNotExists(newParent);
+            GroupRepresentation newParentGroup = hocsRealm.getGroupByPath(newParent);
+            hocsRealm.groups().group(newParentGroup.getId()).subGroup(group);
+        }
+        catch(Exception e) {
+            log.error("Failed to move Keycloak group {} to new parent {} for reason: {}." ,currentGroupPath, newParent, e.getMessage() , value(EVENT, TEAM_CREATED));
+            throw new KeycloakException(e.getMessage(), e);
+    }
     }
 
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/info/security/KeycloakService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/security/KeycloakService.java
@@ -25,7 +25,6 @@ public class KeycloakService {
         this.hocsRealmName = hocsRealmName;
     }
 
-
    public  void addUserToGroup(UUID userUUID, String groupPath) {
         RealmResource hocsRealm = keycloakClient.realm(hocsRealmName);
         UserResource user = hocsRealm.users().get(userUUID.toString());
@@ -46,7 +45,6 @@ public class KeycloakService {
         GroupRepresentation parentGroup =  hocsRealm.getGroupByPath(parentPath);
         GroupRepresentation newGroup = new GroupRepresentation();
         newGroup.setName(groupName);
-        System.out.println(parentGroup.getId());
         Response response = hocsRealm.groups().group(parentGroup.getId()).subGroup(newGroup);
         response.close();
     }
@@ -56,12 +54,24 @@ public class KeycloakService {
         return users;
     }
 
+    public void updateUserGroupsForGroup(String groupPath) {
+        RealmResource hocsRealm = keycloakClient.realm(hocsRealmName);
+        GroupRepresentation group = hocsRealm.getGroupByPath(groupPath);
+        List<UserRepresentation> users = hocsRealm.groups().group(group.getId()).members();
+        for (GroupRepresentation subGroup : group.getSubGroups()) {
+            for (UserRepresentation user : users) {
+                addUserToGroup(UUID.fromString(user.getId()), subGroup.getPath());
+            }
+        }
+    }
+
+
     public void moveGroup(String currentGroupPath, String newParent) {
         RealmResource hocsRealm = keycloakClient.realm(hocsRealmName);
         GroupRepresentation group = hocsRealm.getGroupByPath(currentGroupPath);
+        createUnitGroupIfNotExists(newParent);
         GroupRepresentation newParentGroup = hocsRealm.getGroupByPath(newParent);
         hocsRealm.groups().group(newParentGroup.getId()).subGroup(group);
-
     }
 
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/info/team/TeamResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/team/TeamResource.java
@@ -3,6 +3,8 @@ package uk.gov.digital.ho.hocs.info.team;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import uk.gov.digital.ho.hocs.info.dto.TeamDto;
+import uk.gov.digital.ho.hocs.info.dto.UpdateTeamNameRequest;
+import uk.gov.digital.ho.hocs.info.dto.UpdateTeamPermissionsRequest;
 
 
 import java.util.Set;
@@ -16,21 +18,39 @@ public class TeamResource {
         this.teamService = teamService;
     }
 
-    @PostMapping(value = "/users/{userUUID}/teams/{teamUUID}")
+    @PostMapping(value = "/users/{userUUID}/team/{teamUUID}")
     public ResponseEntity addUserToGroup(@PathVariable String userUUID, @PathVariable String teamUUID) {
         teamService.addUserToTeam(UUID.fromString(userUUID), UUID.fromString(teamUUID));
         return ResponseEntity.ok().build();
     }
 
     @PostMapping(value = "/unit/{unitUUID}/teams" )
-    public ResponseEntity createTeam(@PathVariable String unitUUID, @RequestBody TeamDto team) {
-        teamService.createTeam(team, UUID.fromString(unitUUID));
+    public ResponseEntity<TeamDto> createUpdateTeam(@PathVariable String unitUUID, @RequestBody TeamDto team) {
+        TeamDto createdTeam = teamService.createTeam(team, UUID.fromString(unitUUID));
+        return ResponseEntity.ok(createdTeam);
+    }
+
+    @PostMapping(value = "/unit/{unitUUID}/teams/{teamUUID}")
+    public ResponseEntity addTeamToUnit(@PathVariable String unitUUID, @PathVariable String teamUUID) {
+        teamService.moveToNewUnit(UUID.fromString(unitUUID), UUID.fromString(teamUUID));
         return ResponseEntity.ok().build();
     }
 
-    @PutMapping(value = "/unit/{unitUUID}/teams/{teamUUID}")
-    public ResponseEntity addTeamToUnit(@PathVariable String unitUUID, @PathVariable String teamUUID) {
-        teamService.moveToNewUnit(UUID.fromString(unitUUID), UUID.fromString(teamUUID));
+    @PutMapping(value = "/team/{teamUUID}")
+    public ResponseEntity updateTeamName(@PathVariable String teamUUID, @RequestBody UpdateTeamNameRequest team) {
+        teamService.updateTeamName(UUID.fromString(teamUUID), team.getDisplayName());
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping(value = "/team/{teamUUID}")
+    public ResponseEntity deleteTeam(@PathVariable String teamUUID) {
+        teamService.deleteTeam(UUID.fromString(teamUUID));
+        return ResponseEntity.ok().build();
+    }
+
+    @PutMapping(value = "/team/{teamUUID}/permissions")
+    public ResponseEntity updateTeamPermissions(@PathVariable String teamUUID, @RequestBody UpdateTeamPermissionsRequest team) {
+        teamService.updateTeamPermissions(UUID.fromString(teamUUID),team.getPermissions());
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,2 +1,2 @@
-#docs.queue=aws-sqs://${docs.queue.name}?amazonSQSClient=#docsSqsClient
-#case.queue=aws-sqs://${case.queue.name}?amazonSQSClient=#caseSqsClient
+docs.queue=aws-sqs://${docs.queue.name}?amazonSQSClient=#docsSqsClient
+case.queue=aws-sqs://${case.queue.name}?amazonSQSClient=#caseSqsClient

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,2 +1,2 @@
-docs.queue=aws-sqs://${docs.queue.name}?amazonSQSClient=#docsSqsClient
-case.queue=aws-sqs://${case.queue.name}?amazonSQSClient=#caseSqsClient
+#docs.queue=aws-sqs://${docs.queue.name}?amazonSQSClient=#docsSqsClient
+#case.queue=aws-sqs://${case.queue.name}?amazonSQSClient=#caseSqsClient

--- a/src/main/resources/db/postgresql/V1_12__SEED_DATA.sql
+++ b/src/main/resources/db/postgresql/V1_12__SEED_DATA.sql
@@ -51,10 +51,10 @@ VALUES ('2018-08-27', 'MIN'),
 INSERT INTO unit (display_name, uuid,short_code, active)
 VALUES ('UNIT 1', 'd9a93c21-a1a8-4a5d-aa7b-597bb95a782c', 'UNIT1', TRUE);
 
-INSERT INTO team (display_name, uuid, unit_uuid)
-VALUES ('TEAM 1', '44444444-2222-2222-2222-222222222222', 'd9a93c21-a1a8-4a5d-aa7b-597bb95a782c'),
-       ('TEAM 2', '11111111-1111-1111-1111-111111111111', 'd9a93c21-a1a8-4a5d-aa7b-597bb95a782c'),
-       ('TEAM 3', '33333333-3333-3333-3333-333333333333', 'd9a93c21-a1a8-4a5d-aa7b-597bb95a782c');
+INSERT INTO team (display_name, uuid, unit_uuid, active)
+VALUES ('TEAM 1', '44444444-2222-2222-2222-222222222222', 'd9a93c21-a1a8-4a5d-aa7b-597bb95a782c', true),
+       ('TEAM 2', '11111111-1111-1111-1111-111111111111', 'd9a93c21-a1a8-4a5d-aa7b-597bb95a782c', true),
+       ('TEAM 3', '33333333-3333-3333-3333-333333333333', 'd9a93c21-a1a8-4a5d-aa7b-597bb95a782c', true);
 
 INSERT INTO unit_case_type (unit_uuid, case_type)
 VALUES ('d9a93c21-a1a8-4a5d-aa7b-597bb95a782c', 'MIN');

--- a/src/main/resources/db/postgresql/V1_2__CREATE_TABLE_CASE_TYPE.sql
+++ b/src/main/resources/db/postgresql/V1_2__CREATE_TABLE_CASE_TYPE.sql
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS case_type
   bulk         boolean NULL,
 
     CONSTRAINT case_type_type_idempotent UNIQUE ( type ),
-  CONSTRAINT case_type_name_idempotent UNIQUE (display_name),
+  CONSTRAINT case_type_name_idempotent UNIQUE (display_name)
 );
 
 CREATE INDEX idx_case_type_tenant_role

--- a/src/main/resources/db/postgresql/V1_2__CREATE_TABLE_CASE_TYPE.sql
+++ b/src/main/resources/db/postgresql/V1_2__CREATE_TABLE_CASE_TYPE.sql
@@ -7,11 +7,10 @@ CREATE TABLE IF NOT EXISTS case_type
   type         TEXT    NOT NULL,
   tenant_role  TEXT    NOT NULL,
   active       boolean NOT NULL,
-  bulk         boolean NOT NULL,
+  bulk         boolean NULL,
 
     CONSTRAINT case_type_type_idempotent UNIQUE ( type ),
   CONSTRAINT case_type_name_idempotent UNIQUE (display_name),
-  CONSTRAINT fk_case_type_uuid FOREIGN KEY (tenant_role) REFERENCES tenant (role)
 );
 
 CREATE INDEX idx_case_type_tenant_role

--- a/src/main/resources/db/postgresql/V1_3__CREATE_TABLE_UNIT_TEAM.sql
+++ b/src/main/resources/db/postgresql/V1_3__CREATE_TABLE_UNIT_TEAM.sql
@@ -28,6 +28,8 @@ CREATE TABLE IF NOT EXISTS team
   display_name TEXT NOT NULL,
   uuid         UUID NOT NULL,
   unit_uuid    UUID NOT NULL,
+  active       boolean NOT NULL,
+
 
   CONSTRAINT team_uuid_idempotent UNIQUE (uuid),
   CONSTRAINT team_name_idempotent UNIQUE (display_name),

--- a/src/test/java/uk/gov/digital/ho/hocs/info/casetype/CaseTypeEntityResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/casetype/CaseTypeEntityResourceTest.java
@@ -155,37 +155,37 @@ public class CaseTypeEntityResourceTest {
 
     private static Set<CaseTypeEntity> getMockCaseTypesSingleTenant() {
         Set<CaseTypeEntity> caseTypesSet = new HashSet<>();
-        caseTypesSet.add(new CaseTypeEntity(1L,"DCU Ministerial", "MIN","DCU"));
-        caseTypesSet.add(new CaseTypeEntity(2L,"DCU Treat Official", "TRO","DCU"));
-        caseTypesSet.add(new CaseTypeEntity(3L,"DCU Number 10", "DTEN","DCU"));
+        caseTypesSet.add(new CaseTypeEntity(1L,"DCU Ministerial", "MIN","DCU", true));
+        caseTypesSet.add(new CaseTypeEntity(2L,"DCU Treat Official", "TRO","DCU", true));
+        caseTypesSet.add(new CaseTypeEntity(3L,"DCU Number 10", "DTEN","DCU", true));
         return caseTypesSet;
     }
 
     private static Set<CaseTypeEntity> getMockCaseTypesSingleTenantBulk() {
         Set<CaseTypeEntity> caseTypesSet = new HashSet<>();
-        caseTypesSet.add(new CaseTypeEntity(1L,"DCU Ministerial", "MIN","DCU"));
-        caseTypesSet.add(new CaseTypeEntity(2L,"DCU Treat Official", "TRO","DCU"));
+        caseTypesSet.add(new CaseTypeEntity(1L,"DCU Ministerial", "MIN","DCU", true));
+        caseTypesSet.add(new CaseTypeEntity(2L,"DCU Treat Official", "TRO","DCU", true));
         return caseTypesSet;
     }
 
     private Set<CaseTypeEntity> getMockCaseTypesMultipleTenant() {
         Set<CaseTypeEntity> caseTypesSet = new HashSet<>();
-        caseTypesSet.add(new CaseTypeEntity(1L,"DCU Ministerial", "MIN","DCU"));
-        caseTypesSet.add(new CaseTypeEntity(2L,"DCU Treat Official", "TRO","DCU"));
-        caseTypesSet.add(new CaseTypeEntity(3L,"DCU Number 10", "DTEN","UKVI"));
-        caseTypesSet.add(new CaseTypeEntity(4L, "UKVI B REF", "IMCB","UKVI"));
-        caseTypesSet.add(new CaseTypeEntity(5L, "UKVI Ministerial REF", "IMCM","UKVI"));
-        caseTypesSet.add(new CaseTypeEntity(6L, "UKVI Number 10", "UTEN","UKVI"));
+        caseTypesSet.add(new CaseTypeEntity(1L,"DCU Ministerial", "MIN","DCU", true));
+        caseTypesSet.add(new CaseTypeEntity(2L,"DCU Treat Official", "TRO","DCU", true));
+        caseTypesSet.add(new CaseTypeEntity(3L,"DCU Number 10", "DTEN","UKVI", true));
+        caseTypesSet.add(new CaseTypeEntity(4L, "UKVI B REF", "IMCB","UKVI", true));
+        caseTypesSet.add(new CaseTypeEntity(5L, "UKVI Ministerial REF", "IMCM","UKVI", true));
+        caseTypesSet.add(new CaseTypeEntity(6L, "UKVI Number 10", "UTEN","UKVI", true));
         return caseTypesSet;
     }
 
     private Set<CaseTypeEntity> getMockCaseTypesMultipleTenantBulk() {
         Set<CaseTypeEntity> caseTypesSet = new HashSet<>();
-        caseTypesSet.add(new CaseTypeEntity(1L,"DCU Ministerial", "MIN","DCU"));
-        caseTypesSet.add(new CaseTypeEntity(2L,"DCU Treat Official", "TRO","DCU"));
-        caseTypesSet.add(new CaseTypeEntity(4L, "UKVI B REF", "IMCB","UKVI"));
-        caseTypesSet.add(new CaseTypeEntity(5L, "UKVI Ministerial REF", "IMCM","UKVI"));
-        caseTypesSet.add(new CaseTypeEntity(6L, "UKVI Number 10", "UTEN","UKVI"));
+        caseTypesSet.add(new CaseTypeEntity(1L,"DCU Ministerial", "MIN","DCU", true));
+        caseTypesSet.add(new CaseTypeEntity(2L,"DCU Treat Official", "TRO","DCU", true));
+        caseTypesSet.add(new CaseTypeEntity(4L, "UKVI B REF", "IMCB","UKVI", true));
+        caseTypesSet.add(new CaseTypeEntity(5L, "UKVI Ministerial REF", "IMCM","UKVI", true));
+        caseTypesSet.add(new CaseTypeEntity(6L, "UKVI Number 10", "UTEN","UKVI", true));
         return caseTypesSet;
     }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/info/casetype/CaseTypeEntityServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/casetype/CaseTypeEntityServiceTest.java
@@ -132,33 +132,33 @@ public class CaseTypeEntityServiceTest {
     }
 
     private Set<CaseTypeEntity> getDCUCaseType() {
-        return new HashSet<>(Arrays.asList(new CaseTypeEntity(1L, "DCU Ministerial", "MIN", "DCU"),
-                new CaseTypeEntity(2L, "DCU Treat Official", "TRO", "DCU"),
-                new CaseTypeEntity(3L, "DCU Number 10", "DTEN", "DCU")));
+        return new HashSet<>(Arrays.asList(new CaseTypeEntity(1L, "DCU Ministerial", "MIN", "DCU", true),
+                new CaseTypeEntity(2L, "DCU Treat Official", "TRO", "DCU", true),
+                new CaseTypeEntity(3L, "DCU Number 10", "DTEN", "DCU", true)));
     }
 
     private Set<CaseTypeEntity> getDCUCaseTypeBulk() {
-        return new HashSet<>(Arrays.asList(new CaseTypeEntity(1L, "DCU Ministerial", "MIN", "DCU"),
-                new CaseTypeEntity(2L, "DCU Treat Official", "TRO", "DCU")));
+        return new HashSet<>(Arrays.asList(new CaseTypeEntity(1L, "DCU Ministerial", "MIN", "DCU", true),
+                new CaseTypeEntity(2L, "DCU Treat Official", "TRO", "DCU", true)));
     }
 
     private HashSet<CaseTypeEntity> getDCUAndUKVICaseType() {
         return new HashSet<>(Arrays.asList(
-                new CaseTypeEntity(1L, "DCU Ministerial", "MIN", "DCU"),
-                new CaseTypeEntity(2L, "DCU Treat Official", "TRO", "DCU"),
-                new CaseTypeEntity(3L, "DCU Number 10", "DTEN", "DCU"),
-                new CaseTypeEntity(1L, "UKVI B REF", "IMCB", "UKVI"),
-                new CaseTypeEntity(2L, "UKVI Ministerial REF", "IMCM", "UKVI"),
-                new CaseTypeEntity(3L, "UKVI Number 10", "UTEN", "UKVI")));
+                new CaseTypeEntity(1L, "DCU Ministerial", "MIN", "DCU", true),
+                new CaseTypeEntity(2L, "DCU Treat Official", "TRO", "DCU", true),
+                new CaseTypeEntity(3L, "DCU Number 10", "DTEN", "DCU", true),
+                new CaseTypeEntity(1L, "UKVI B REF", "IMCB", "UKVI", true),
+                new CaseTypeEntity(2L, "UKVI Ministerial REF", "IMCM", "UKVI", true),
+                new CaseTypeEntity(3L, "UKVI Number 10", "UTEN", "UKVI", true)));
     }
 
     private HashSet<CaseTypeEntity> getDCUAndUKVICaseTypeBulk() {
         return new HashSet<>(Arrays.asList(
-                new CaseTypeEntity(1L, "DCU Ministerial", "MIN", "DCU"),
-                new CaseTypeEntity(2L, "DCU Treat Official", "TRO", "DCU"),
-                new CaseTypeEntity(1L, "UKVI B REF", "IMCB", "UKVI"),
-                new CaseTypeEntity(2L, "UKVI Ministerial REF", "IMCM", "UKVI"),
-                new CaseTypeEntity(3L, "UKVI Number 10", "UTEN", "UKVI")));
+                new CaseTypeEntity(1L, "DCU Ministerial", "MIN", "DCU", true),
+                new CaseTypeEntity(2L, "DCU Treat Official", "TRO", "DCU", true),
+                new CaseTypeEntity(1L, "UKVI B REF", "IMCB", "UKVI", true),
+                new CaseTypeEntity(2L, "UKVI Ministerial REF", "IMCM", "UKVI", true),
+                new CaseTypeEntity(3L, "UKVI Number 10", "UTEN", "UKVI", true)));
     }
 
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/info/dto/CaseTypeDtoTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/dto/CaseTypeDtoTest.java
@@ -11,7 +11,7 @@ public class CaseTypeDtoTest {
 
     @Test
     public void shouldBuildCaseTypeDtoFromCaseTypeObject() {
-        CaseTypeEntity caseTypeEntity = new CaseTypeEntity(1L,"Name","MIN","DCU");
+        CaseTypeEntity caseTypeEntity = new CaseTypeEntity(1L,"Name","MIN","DCU", true);
 
         CaseTypeDto caseTypeDto = CaseTypeDto.from(caseTypeEntity);
 

--- a/src/test/java/uk/gov/digital/ho/hocs/info/dto/GetCaseTypesResponseTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/dto/GetCaseTypesResponseTest.java
@@ -13,9 +13,9 @@ public class GetCaseTypesResponseTest {
     @Test
     public void shouldCreateGetCaseTypesResponseDTOFromCaseTypesEntity() {
         Set<CaseTypeEntity> caseTypeSet = new HashSet<>();
-        caseTypeSet.add(new CaseTypeEntity(1L,"DCU Ministerial","MIN","DCU"));
-        caseTypeSet.add(new CaseTypeEntity(2L,"DCU Treat Official","TRO","DCU"));
-        caseTypeSet.add(new CaseTypeEntity(3L,"DCU Number 10","DTEN","DCU"));
+        caseTypeSet.add(new CaseTypeEntity(1L,"DCU Ministerial","MIN","DCU", true));
+        caseTypeSet.add(new CaseTypeEntity(2L,"DCU Treat Official","TRO","DCU", true));
+        caseTypeSet.add(new CaseTypeEntity(3L,"DCU Number 10","DTEN","DCU", true));
 
         GetCaseTypesResponse getCaseTypesResponse = GetCaseTypesResponse.from(caseTypeSet);
 

--- a/src/test/java/uk/gov/digital/ho/hocs/info/dto/TeamDtoTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/dto/TeamDtoTest.java
@@ -12,12 +12,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TeamDtoTest {
 
     UUID uuid = UUID.randomUUID();
-    UUID unitUUID = UUID.randomUUID();
 
     @Test
     public void from() {
 
-        Team team = new Team(1L,"displayName", uuid, unitUUID, null,new HashSet<Permission>());
+        Team team = new Team(1L,"displayName", uuid, true, null,new HashSet<Permission>());
 
         TeamDto teamDto = TeamDto.from(team);
 

--- a/src/test/java/uk/gov/digital/ho/hocs/info/dto/UnitDtoTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/dto/UnitDtoTest.java
@@ -22,9 +22,9 @@ public class UnitDtoTest {
 
         Set<Permission> permissions = new HashSet<Permission>(){{
             add(new Permission(AccessLevel.OWNER, null,
-                    new CaseTypeEntity(1L, "MIN", "type", "role")));
+                    new CaseTypeEntity(1L, "MIN", "type", "role", true)));
             add(new Permission(AccessLevel.OWNER, null,
-                    new CaseTypeEntity(1L, "MIN", "type", "role")));
+                    new CaseTypeEntity(1L, "MIN", "type", "role", true)));
         }};
         Team team = new Team("Team 1", UUID.randomUUID(), permissions);
         Unit unit = new Unit("Unit 1", "TEST", UUID.randomUUID(), true);
@@ -42,9 +42,9 @@ public class UnitDtoTest {
 
         Set<Permission> permissions = new HashSet<Permission>(){{
             add(new Permission(AccessLevel.OWNER, null,
-                    new CaseTypeEntity(1L, "MIN", "type", "role")));
+                    new CaseTypeEntity(1L, "MIN", "type", "role", true)));
             add(new Permission(AccessLevel.OWNER, null,
-                    new CaseTypeEntity(1L, "MIN", "type", "role")));
+                    new CaseTypeEntity(1L, "MIN", "type", "role", true)));
         }};
         Team team = new Team("Team 1", UUID.randomUUID(), permissions);
         Unit unit = new Unit("Unit 1", "TEST", UUID.randomUUID(), true);

--- a/src/test/java/uk/gov/digital/ho/hocs/info/entities/TeamTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/entities/TeamTest.java
@@ -11,12 +11,12 @@ public class TeamTest {
 
     @Test
     public void shouldAddPermissionsToTeam() {
-        Team team = new Team("Team 1", UUID.randomUUID());
+        Team team = new Team("Team 1", UUID.randomUUID(), true);
 
         Permission permission1 = new Permission(AccessLevel.OWNER, team,
-                new CaseTypeEntity(1L, "MIN", "type", "role"));
+                new CaseTypeEntity(1L, "MIN", "type", "role", true));
         Permission permission2 = new Permission(AccessLevel.OWNER, team,
-                new CaseTypeEntity(1L, "MIN", "type", "role"));
+                new CaseTypeEntity(1L, "MIN", "type", "role", true));
 
         assertThat(team.getPermissions().size()).isEqualTo(0);
         team.addPermission(permission1);

--- a/src/test/java/uk/gov/digital/ho/hocs/info/entities/UnitTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/entities/UnitTest.java
@@ -15,8 +15,8 @@ public class UnitTest {
         UUID team2UUID = UUID.randomUUID();
         Unit unit = new Unit("Unit 1", "TEST", UUID.randomUUID(), true);
 
-        Team team1 = new Team("Team 2", team1UUID);
-        Team team2 = new Team("Team 2", team2UUID);
+        Team team1 = new Team("Team 2", team1UUID, true);
+        Team team2 = new Team("Team 2", team2UUID, true);
 
         assertThat(unit.getTeams().size()).isEqualTo(0);
         unit.addTeam(team1);
@@ -32,8 +32,8 @@ public class UnitTest {
         UUID team2UUID = UUID.randomUUID();
         Unit unit = new Unit("Unit 1", "TEST", UUID.randomUUID(), true);
 
-        Team team1 = new Team("Team 2", team1UUID);
-        Team team2 = new Team("Team 2", team2UUID);
+        Team team1 = new Team("Team 2", team1UUID, true);
+        Team team2 = new Team("Team 2", team2UUID, true);
         unit.addTeam(team1);
         unit.addTeam(team2);
 

--- a/src/test/java/uk/gov/digital/ho/hocs/info/integration/TeamIntegrationTests.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/integration/TeamIntegrationTests.java
@@ -1,0 +1,207 @@
+package uk.gov.digital.ho.hocs.info.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.entity.ContentType;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.representations.idm.GroupRepresentation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlConfig;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.digital.ho.hocs.info.dto.PermissionDto;
+import uk.gov.digital.ho.hocs.info.dto.TeamDto;
+import uk.gov.digital.ho.hocs.info.dto.UpdateTeamNameRequest;
+
+import uk.gov.digital.ho.hocs.info.dto.UpdateTeamPermissionsRequest;
+import uk.gov.digital.ho.hocs.info.repositories.TeamRepository;
+import uk.gov.digital.ho.hocs.info.security.AccessLevel;
+import uk.gov.digital.ho.hocs.info.security.KeycloakService;
+
+import javax.ws.rs.NotFoundException;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+import static org.springframework.test.context.jdbc.SqlConfig.TransactionMode.ISOLATED;
+
+
+    @RunWith(SpringRunner.class)
+    @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+    @Sql(
+            scripts = "classpath:beforeTest.sql",
+            config = @SqlConfig(transactionMode = ISOLATED)
+    )
+    @Sql(
+            scripts = "classpath:afterTest.sql",
+            config = @SqlConfig(transactionMode = ISOLATED),
+            executionPhase = AFTER_TEST_METHOD
+    )
+    public class TeamIntegrationTests {
+
+    TestRestTemplate restTemplate = new TestRestTemplate();
+
+    @Autowired
+    TeamRepository teamRepository;
+
+    @Autowired
+    KeycloakService keycloakService;
+
+    @Autowired
+    private Keycloak keycloakClient;
+
+    private final UUID unitUUID = UUID.fromString("09221c48-b916-47df-9aa0-a0194f86f6dd");
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    ObjectMapper mapper;
+
+
+    HttpHeaders headers;
+
+    @Before
+    public void setup() {
+        headers = new HttpHeaders();
+        headers.add(HttpHeaders.ACCEPT, ContentType.APPLICATION_JSON.toString());
+    }
+
+    @Test
+    public void shouldGetAllTeams() {
+        HttpEntity httpEntity = new HttpEntity(headers);
+        ResponseEntity<Set<TeamDto>> result = restTemplate.exchange(
+                getBasePath()  + "/unit/" + unitUUID.toString() + "/teams"
+                ,HttpMethod.GET,httpEntity, new ParameterizedTypeReference<Set<TeamDto>>() {});
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody().size()).isEqualTo(3);
+    }
+
+    @Test
+    public void shouldAddTeamToDatabaseAndKeyCloak() {
+
+        Set<PermissionDto> permissions = new HashSet<PermissionDto>() {{
+           add(new PermissionDto("CT1", AccessLevel.OWNER));
+        }};
+        TeamDto team = new TeamDto("Team 3000",permissions);
+
+        HttpEntity<TeamDto> httpEntity = new HttpEntity<>(team, headers);
+
+        ResponseEntity<TeamDto> result = restTemplate.exchange(
+                getBasePath()  + "/unit/" + unitUUID.toString() + "/teams"
+                ,HttpMethod.POST,httpEntity, TeamDto.class);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(teamRepository.findByUuid(result.getBody().getUuid())).isNotNull();
+        GroupRepresentation unitGroup =  keycloakClient.realm("hocs")
+                .getGroupByPath("/UNIT2/" + team.getUuid() + "/CT1/OWNER");
+        assertThat(unitGroup).isNotNull();
+    }
+
+
+        @Test
+        public void shouldAddTeamToUnitAndREmoveFromOldUnit() {
+
+            String teamUUID = "434a4e33-437f-4e6d-8f04-14ea40fdbfa2";
+            UUID newUnitUUID = UUID.fromString("65996106-91a5-44bf-bc92-a6c2f691f062");
+            HttpEntity httpEntity = new HttpEntity(headers);
+
+            keycloakClient.realm("hocs")
+                    .getGroupByPath("/UNIT2/" + teamUUID + "/CT2/WRITE");
+
+             assertThatThrownBy(() -> keycloakClient.realm("hocs")
+                    .getGroupByPath("/UNIT3/" + teamUUID + "/CT2/WRITE")).isInstanceOf(NotFoundException.class);
+
+            ResponseEntity<String> result = restTemplate.exchange(
+                    getBasePath()  + "/unit/" + newUnitUUID + "/teams/" + teamUUID
+                    ,HttpMethod.POST,httpEntity, String.class);
+
+            assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+            assertThat(teamRepository.findByUuid(UUID.fromString(teamUUID)).getUnit().getUuid()).isEqualTo(newUnitUUID);
+
+
+            keycloakClient.realm("hocs")
+                    .getGroupByPath("/UNIT3/" + teamUUID + "/CT2/WRITE");
+
+            assertThatThrownBy(() -> keycloakClient.realm("hocs")
+                    .getGroupByPath("/UNIT2/" + teamUUID + "/CT2/WRITE")).isInstanceOf(NotFoundException.class);
+
+        }
+
+        @Test
+        public void shouldAddUserToGroup() {
+
+            String userId = "ed00bf4a-1a74-4d0b-a3d0-379c12c5e3ff";
+            String teamId = "08612f06-bae2-4d2f-90d2-2254a68414b8";
+            HttpEntity httpEntity = new HttpEntity(headers);
+
+            ResponseEntity<String> result = restTemplate.exchange(
+                    getBasePath()  + "/users/" + userId + "/team/" + teamId
+                    ,HttpMethod.POST, httpEntity, String.class);
+
+            assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+            GroupRepresentation group = keycloakClient.realm("hocs")
+                    .getGroupByPath("/UNIT2/" + teamId + "/CT1/OWNER");
+
+            assertThat(keycloakClient.realm("hocs")
+                    .users().get(userId).groups().stream()
+                    .anyMatch(g -> g.getId().equals(group.getId()))).isTrue();
+        }
+
+        @Test
+        public void shouldUpdateTeamPermissions() {
+            String teamId = "434a4e33-437f-4e6d-8f04-14ea40fdbfa2";
+            Set<PermissionDto> permissions = new HashSet<PermissionDto>() {{
+                add(new PermissionDto("CT2", AccessLevel.READ));
+            }};
+
+            UpdateTeamPermissionsRequest request = new UpdateTeamPermissionsRequest(permissions);
+
+            HttpEntity<UpdateTeamPermissionsRequest> httpEntity = new HttpEntity<>(request, headers);
+
+            ResponseEntity<String> result = restTemplate.exchange(
+                    getBasePath()  + "/team/" + teamId + "/permissions"
+                    ,HttpMethod.PUT, httpEntity, String.class);
+
+            assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+            GroupRepresentation permissionGroup =  keycloakClient.realm("hocs")
+                    .getGroupByPath("/UNIT2/" + teamId + "/CT2/READ");
+            assertThat(permissionGroup).isNotNull();
+
+        }
+
+        @Test
+        public void shouldChangeTeamName() {
+            String teamId = "08612f06-bae2-4d2f-90d2-2254a68414b8";
+
+            UpdateTeamNameRequest request = new UpdateTeamNameRequest("New Team Name");
+            HttpEntity<UpdateTeamNameRequest> httpEntity = new HttpEntity(request);
+
+           ResponseEntity<String> result = restTemplate.exchange(
+                    getBasePath()  + "/team/" + teamId
+                    ,HttpMethod.PUT, httpEntity, String.class);
+
+            assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(teamRepository.findByUuid(UUID.fromString(teamId)).getDisplayName()).isEqualTo("New Team Name");
+
+        }
+
+    private String getBasePath() {
+        return "http://localhost:"+ port;
+    }
+}
+
+

--- a/src/test/java/uk/gov/digital/ho/hocs/info/integration/TeamIntegrationTests.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/integration/TeamIntegrationTests.java
@@ -2,52 +2,58 @@ package uk.gov.digital.ho.hocs.info.integration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.entity.ContentType;
+import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.representations.idm.GroupRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.*;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlConfig;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.digital.ho.hocs.info.dto.PermissionDto;
 import uk.gov.digital.ho.hocs.info.dto.TeamDto;
 import uk.gov.digital.ho.hocs.info.dto.UpdateTeamNameRequest;
-
 import uk.gov.digital.ho.hocs.info.dto.UpdateTeamPermissionsRequest;
 import uk.gov.digital.ho.hocs.info.repositories.TeamRepository;
 import uk.gov.digital.ho.hocs.info.security.AccessLevel;
 import uk.gov.digital.ho.hocs.info.security.KeycloakService;
-
 import javax.ws.rs.NotFoundException;
+import java.io.File;
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 import static org.springframework.test.context.jdbc.SqlConfig.TransactionMode.ISOLATED;
 
 
-    @RunWith(SpringRunner.class)
-    @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-    @Sql(
-            scripts = "classpath:beforeTest.sql",
-            config = @SqlConfig(transactionMode = ISOLATED)
-    )
-    @Sql(
-            scripts = "classpath:afterTest.sql",
-            config = @SqlConfig(transactionMode = ISOLATED),
-            executionPhase = AFTER_TEST_METHOD
-    )
-    public class TeamIntegrationTests {
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Sql(
+        scripts = "classpath:beforeTest.sql",
+        config = @SqlConfig(transactionMode = ISOLATED)
+)
+@Sql(
+        scripts = "classpath:afterTest.sql",
+        config = @SqlConfig(transactionMode = ISOLATED),
+        executionPhase = AFTER_TEST_METHOD
+)
+@DirtiesContext(classMode = AFTER_EACH_TEST_METHOD)
+public class TeamIntegrationTests {
 
     TestRestTemplate restTemplate = new TestRestTemplate();
 
@@ -57,10 +63,11 @@ import static org.springframework.test.context.jdbc.SqlConfig.TransactionMode.IS
     @Autowired
     KeycloakService keycloakService;
 
-    @Autowired
-    private Keycloak keycloakClient;
+
+    Keycloak keycloakClient;
 
     private final UUID unitUUID = UUID.fromString("09221c48-b916-47df-9aa0-a0194f86f6dd");
+    private HttpHeaders headers;
 
     @LocalServerPort
     int port;
@@ -68,21 +75,68 @@ import static org.springframework.test.context.jdbc.SqlConfig.TransactionMode.IS
     @Autowired
     ObjectMapper mapper;
 
+    @Value("${keycloak.server.url}")
+    String serverUrl;
+    @Value("${keycloak.username}")
+    String username;
+    @Value("${keycloak.password}")
+    String password;
+    @Value("${keycloak.client.id}")
+    String clientId;
+    @Value("${keycloak.realm}")
+    String HOCS_REALM;
 
-    HttpHeaders headers;
 
     @Before
-    public void setup() {
+    public void setup() throws IOException {
         headers = new HttpHeaders();
         headers.add(HttpHeaders.ACCEPT, ContentType.APPLICATION_JSON.toString());
+        setupKeycloakRealm();
+
+        keycloakClient = Keycloak.getInstance(
+                serverUrl, HOCS_REALM, username, password, clientId, clientId);
+
+    }
+
+
+    @Test
+    public void shouldAddTeamToUnitAndRemoveFromOldUnit() {
+
+        String teamUUID = "434a4e33-437f-4e6d-8f04-14ea40fdbfa2";
+        UUID newUnitUUID = UUID.fromString("65996106-91a5-44bf-bc92-a6c2f691f062");
+        HttpEntity httpEntity = new HttpEntity(headers);
+
+
+        keycloakClient.realm(HOCS_REALM)
+                .getGroupByPath("/UNIT2/" + teamUUID + "/CT2/WRITE");
+
+        assertThatThrownBy(() -> keycloakClient.realm(HOCS_REALM)
+                .getGroupByPath("/UNIT3/" + teamUUID + "/CT2/WRITE")).isInstanceOf(NotFoundException.class);
+
+        ResponseEntity<String> result = restTemplate.exchange(
+                getBasePath() + "/unit/" + newUnitUUID + "/teams/" + teamUUID
+                , HttpMethod.POST, httpEntity, String.class);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        assertThat(teamRepository.findByUuid(UUID.fromString(teamUUID)).getUnit().getUuid()).isEqualTo(newUnitUUID);
+
+
+        keycloakClient.realm(HOCS_REALM)
+                .getGroupByPath("/UNIT3/" + teamUUID + "/CT2/WRITE");
+
+        assertThatThrownBy(() -> keycloakClient.realm(HOCS_REALM)
+                .getGroupByPath("/UNIT2/" + teamUUID + "/CT2/WRITE")).isInstanceOf(NotFoundException.class);
+
     }
 
     @Test
     public void shouldGetAllTeams() {
         HttpEntity httpEntity = new HttpEntity(headers);
         ResponseEntity<Set<TeamDto>> result = restTemplate.exchange(
-                getBasePath()  + "/unit/" + unitUUID.toString() + "/teams"
-                ,HttpMethod.GET,httpEntity, new ParameterizedTypeReference<Set<TeamDto>>() {});
+                getBasePath() + "/unit/" + unitUUID.toString() + "/teams"
+                , HttpMethod.GET, httpEntity, new ParameterizedTypeReference<Set<TeamDto>>() {
+                });
         assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(result.getBody().size()).isEqualTo(3);
     }
@@ -91,117 +145,102 @@ import static org.springframework.test.context.jdbc.SqlConfig.TransactionMode.IS
     public void shouldAddTeamToDatabaseAndKeyCloak() {
 
         Set<PermissionDto> permissions = new HashSet<PermissionDto>() {{
-           add(new PermissionDto("CT1", AccessLevel.OWNER));
+            add(new PermissionDto("CT1", AccessLevel.OWNER));
         }};
-        TeamDto team = new TeamDto("Team 3000",permissions);
+        TeamDto team = new TeamDto("Team 3000", permissions);
 
         HttpEntity<TeamDto> httpEntity = new HttpEntity<>(team, headers);
 
         ResponseEntity<TeamDto> result = restTemplate.exchange(
-                getBasePath()  + "/unit/" + unitUUID.toString() + "/teams"
-                ,HttpMethod.POST,httpEntity, TeamDto.class);
+                getBasePath() + "/unit/" + unitUUID.toString() + "/teams"
+                , HttpMethod.POST, httpEntity, TeamDto.class);
 
         assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(teamRepository.findByUuid(result.getBody().getUuid())).isNotNull();
-        GroupRepresentation unitGroup =  keycloakClient.realm("hocs")
+        GroupRepresentation unitGroup = keycloakClient.realm("hocs")
                 .getGroupByPath("/UNIT2/" + team.getUuid() + "/CT1/OWNER");
         assertThat(unitGroup).isNotNull();
     }
 
 
-        @Test
-        public void shouldAddTeamToUnitAndREmoveFromOldUnit() {
-
-            String teamUUID = "434a4e33-437f-4e6d-8f04-14ea40fdbfa2";
-            UUID newUnitUUID = UUID.fromString("65996106-91a5-44bf-bc92-a6c2f691f062");
-            HttpEntity httpEntity = new HttpEntity(headers);
-
-            keycloakClient.realm("hocs")
-                    .getGroupByPath("/UNIT2/" + teamUUID + "/CT2/WRITE");
-
-             assertThatThrownBy(() -> keycloakClient.realm("hocs")
-                    .getGroupByPath("/UNIT3/" + teamUUID + "/CT2/WRITE")).isInstanceOf(NotFoundException.class);
-
-            ResponseEntity<String> result = restTemplate.exchange(
-                    getBasePath()  + "/unit/" + newUnitUUID + "/teams/" + teamUUID
-                    ,HttpMethod.POST,httpEntity, String.class);
-
-            assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
-
-            assertThat(teamRepository.findByUuid(UUID.fromString(teamUUID)).getUnit().getUuid()).isEqualTo(newUnitUUID);
 
 
-            keycloakClient.realm("hocs")
-                    .getGroupByPath("/UNIT3/" + teamUUID + "/CT2/WRITE");
+    @Test
+    public void shouldAddUserToGroup() {
 
-            assertThatThrownBy(() -> keycloakClient.realm("hocs")
-                    .getGroupByPath("/UNIT2/" + teamUUID + "/CT2/WRITE")).isInstanceOf(NotFoundException.class);
+        String userId = "ed00bf4a-1a74-4d0b-a3d0-379c12c5e3ff";
+        String teamId = "08612f06-bae2-4d2f-90d2-2254a68414b8";
+        HttpEntity httpEntity = new HttpEntity(headers);
 
-        }
+        ResponseEntity<String> result = restTemplate.exchange(
+                getBasePath() + "/users/" + userId + "/team/" + teamId
+                , HttpMethod.POST, httpEntity, String.class);
 
-        @Test
-        public void shouldAddUserToGroup() {
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
 
-            String userId = "ed00bf4a-1a74-4d0b-a3d0-379c12c5e3ff";
-            String teamId = "08612f06-bae2-4d2f-90d2-2254a68414b8";
-            HttpEntity httpEntity = new HttpEntity(headers);
+        GroupRepresentation group = keycloakClient.realm(HOCS_REALM)
+                .getGroupByPath("/UNIT2/" + teamId + "/CT1/OWNER");
 
-            ResponseEntity<String> result = restTemplate.exchange(
-                    getBasePath()  + "/users/" + userId + "/team/" + teamId
-                    ,HttpMethod.POST, httpEntity, String.class);
+        assertThat(keycloakClient.realm(HOCS_REALM)
+                .users().get(userId).groups().stream()
+                .anyMatch(g -> g.getId().equals(group.getId()))).isTrue();
+    }
 
-            assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    @Test
+    public void shouldUpdateTeamPermissions() {
+        String teamId = "434a4e33-437f-4e6d-8f04-14ea40fdbfa2";
+        Set<PermissionDto> permissions = new HashSet<PermissionDto>() {{
+            add(new PermissionDto("CT2", AccessLevel.READ));
+        }};
 
-            GroupRepresentation group = keycloakClient.realm("hocs")
-                    .getGroupByPath("/UNIT2/" + teamId + "/CT1/OWNER");
+        UpdateTeamPermissionsRequest request = new UpdateTeamPermissionsRequest(permissions);
 
-            assertThat(keycloakClient.realm("hocs")
-                    .users().get(userId).groups().stream()
-                    .anyMatch(g -> g.getId().equals(group.getId()))).isTrue();
-        }
+        HttpEntity<UpdateTeamPermissionsRequest> httpEntity = new HttpEntity<>(request, headers);
 
-        @Test
-        public void shouldUpdateTeamPermissions() {
-            String teamId = "434a4e33-437f-4e6d-8f04-14ea40fdbfa2";
-            Set<PermissionDto> permissions = new HashSet<PermissionDto>() {{
-                add(new PermissionDto("CT2", AccessLevel.READ));
-            }};
+        ResponseEntity<String> result = restTemplate.exchange(
+                getBasePath() + "/team/" + teamId + "/permissions"
+                , HttpMethod.PUT, httpEntity, String.class);
 
-            UpdateTeamPermissionsRequest request = new UpdateTeamPermissionsRequest(permissions);
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
 
-            HttpEntity<UpdateTeamPermissionsRequest> httpEntity = new HttpEntity<>(request, headers);
+        GroupRepresentation permissionGroup = keycloakClient.realm(HOCS_REALM)
+                .getGroupByPath("/UNIT2/" + teamId + "/CT2/READ");
+        assertThat(permissionGroup).isNotNull();
 
-            ResponseEntity<String> result = restTemplate.exchange(
-                    getBasePath()  + "/team/" + teamId + "/permissions"
-                    ,HttpMethod.PUT, httpEntity, String.class);
+    }
 
-            assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    @Test
+    public void shouldChangeTeamName() {
+        String teamId = "08612f06-bae2-4d2f-90d2-2254a68414b8";
 
-            GroupRepresentation permissionGroup =  keycloakClient.realm("hocs")
-                    .getGroupByPath("/UNIT2/" + teamId + "/CT2/READ");
-            assertThat(permissionGroup).isNotNull();
+        UpdateTeamNameRequest request = new UpdateTeamNameRequest("New Team Name");
+        HttpEntity<UpdateTeamNameRequest> httpEntity = new HttpEntity(request);
 
-        }
+        ResponseEntity<String> result = restTemplate.exchange(
+                getBasePath() + "/team/" + teamId
+                , HttpMethod.PUT, httpEntity, String.class);
 
-        @Test
-        public void shouldChangeTeamName() {
-            String teamId = "08612f06-bae2-4d2f-90d2-2254a68414b8";
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(teamRepository.findByUuid(UUID.fromString(teamId)).getDisplayName()).isEqualTo("New Team Name");
 
-            UpdateTeamNameRequest request = new UpdateTeamNameRequest("New Team Name");
-            HttpEntity<UpdateTeamNameRequest> httpEntity = new HttpEntity(request);
-
-           ResponseEntity<String> result = restTemplate.exchange(
-                    getBasePath()  + "/team/" + teamId
-                    ,HttpMethod.PUT, httpEntity, String.class);
-
-            assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
-            assertThat(teamRepository.findByUuid(UUID.fromString(teamId)).getDisplayName()).isEqualTo("New Team Name");
-
-        }
+    }
 
     private String getBasePath() {
-        return "http://localhost:"+ port;
+        return "http://localhost:" + port;
     }
+
+    private void setupKeycloakRealm() throws IOException {
+        Keycloak adminClient = Keycloak.getInstance(
+                serverUrl, "master", username, password, clientId, clientId);
+
+        try {
+            adminClient.realms().realm(HOCS_REALM).remove();
+        } catch (Exception e) {
+            //Realm does not exist
+        }
+        RealmRepresentation hocsRealm = mapper.readValue(new File("./keycloak/local-realm.json"), RealmRepresentation.class);
+        adminClient.realms().create(hocsRealm);
+         }
 }
 
 

--- a/src/test/java/uk/gov/digital/ho/hocs/info/repositories/TeamRepositoryTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/repositories/TeamRepositoryTest.java
@@ -4,6 +4,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -12,16 +13,14 @@ import uk.gov.digital.ho.hocs.info.entities.Permission;
 import uk.gov.digital.ho.hocs.info.entities.Team;
 import uk.gov.digital.ho.hocs.info.entities.Unit;
 import uk.gov.digital.ho.hocs.info.security.AccessLevel;
-
-import javax.persistence.AccessType;
 import javax.persistence.PersistenceException;
 import java.util.*;
-import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
 @DataJpaTest
+@AutoConfigureTestDatabase(replace= AutoConfigureTestDatabase.Replace.NONE)
 public class TeamRepositoryTest {
 
 

--- a/src/test/java/uk/gov/digital/ho/hocs/info/repositories/TeamRepositoryTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/repositories/TeamRepositoryTest.java
@@ -1,0 +1,100 @@
+package uk.gov.digital.ho.hocs.info.repositories;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.digital.ho.hocs.info.entities.CaseTypeEntity;
+import uk.gov.digital.ho.hocs.info.entities.Permission;
+import uk.gov.digital.ho.hocs.info.entities.Team;
+import uk.gov.digital.ho.hocs.info.entities.Unit;
+import uk.gov.digital.ho.hocs.info.security.AccessLevel;
+
+import javax.persistence.AccessType;
+import javax.persistence.PersistenceException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+public class TeamRepositoryTest {
+
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private TeamRepository repository;
+
+    private final UUID unitUUID = UUID.randomUUID();
+    private final UUID teamUUID = UUID.randomUUID();
+    @Before
+    public void setup() {
+        Unit unit = new Unit("Unit 1", "UNIT_1", unitUUID,true);
+        CaseTypeEntity caseType = new CaseTypeEntity(null,"TEST","TEST", "", true);
+        entityManager.persistAndFlush(caseType);
+        Set<Permission> permissions = new HashSet<Permission>(){{
+            add(new Permission(AccessLevel.OWNER,null, caseType));
+        }};
+        Team team = new Team("a team", teamUUID, permissions);
+        unit.addTeam(team);
+        this.entityManager.persist(unit);
+    }
+
+    @Test()
+    public void shouldGetAllTeamsForAUnit() {
+        List<Team> teams = new ArrayList<>(repository.findTeamsByUnitUuid(unitUUID));
+        assertThat(teams.get(0).getUnit().getUuid()).isEqualTo(unitUUID);
+        assertThat(teams.get(0).getUuid()).isEqualTo(teamUUID);
+        assertThat(teams.size()).isEqualTo(1);
+    }
+
+    @Test()
+    public void shouldFindTeamByUUID() {
+        Team team = repository.findByUuid(teamUUID);
+        assertThat(team.getUnit().getUuid()).isEqualTo(unitUUID);
+        assertThat(team.getUuid()).isEqualTo(teamUUID);
+        assertThat(team.getId()).isNotNull();
+    }
+
+    @Test()
+    public void shouldGetPermissions() {
+        Team team = repository.findByUuid(teamUUID);
+        assertThat(team.getPermissions().size()).isEqualTo(1);
+        List<Permission> permissions = new ArrayList<>(team.getPermissions());
+        assertThat(permissions.get(0).getCaseType().getType()).isEqualTo("TEST");
+        assertThat(permissions.get(0).getAccessLevel()).isEqualTo(AccessLevel.OWNER);
+        assertThat(permissions.get(0).getTeam().getUuid()).isEqualTo(teamUUID);
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void shouldThrowExceptionWhenuplicateUUID() {
+       UUID teamUUID = UUID.randomUUID();
+        entityManager.persist(new Team("test 1", teamUUID, true));
+        entityManager.persist(new Team("test 2", teamUUID, true));
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void shouldThrowExceptionWhenuplicateDisplayName() {
+        UUID teamUUID = UUID.randomUUID();
+        entityManager.persist(new Team("test 1", teamUUID, true));
+        entityManager.persist(new Team("test 1", UUID.randomUUID(), true));
+    }
+
+    @Test
+    public void addPermissionsShouldBeIdempotent() {
+        Team team = repository.findByUuid(teamUUID);
+        assertThat(team.getPermissions().size()).isEqualTo(1);
+        CaseTypeEntity caseType = new CaseTypeEntity(null,"TEST","TEST", "", true);
+        team.addPermission(new Permission(AccessLevel.OWNER,null, caseType));
+        assertThat(team.getPermissions().size()).isEqualTo(1);
+
+    }
+
+
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/info/repositories/UnitRepositoryTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/repositories/UnitRepositoryTest.java
@@ -5,6 +5,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -19,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
 @DataJpaTest
+@AutoConfigureTestDatabase(replace= AutoConfigureTestDatabase.Replace.NONE)
 public class UnitRepositoryTest {
 
 

--- a/src/test/java/uk/gov/digital/ho/hocs/info/repositories/UnitRepositoryTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/repositories/UnitRepositoryTest.java
@@ -1,5 +1,6 @@
 package uk.gov.digital.ho.hocs.info.repositories;
 
+import java.util.*;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -7,9 +8,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.digital.ho.hocs.info.entities.CaseTypeEntity;
+import uk.gov.digital.ho.hocs.info.entities.Permission;
+import uk.gov.digital.ho.hocs.info.entities.Team;
 import uk.gov.digital.ho.hocs.info.entities.Unit;
+import uk.gov.digital.ho.hocs.info.security.AccessLevel;
 import javax.persistence.PersistenceException;
-import java.util.UUID;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
@@ -37,10 +42,62 @@ public class UnitRepositoryTest {
         assertThat(unit.getDisplayName()).isEqualTo("Unit 1");
     }
 
+    @Test()
+    public void shouldAddTeamToUnit() {
+        Unit unit = repository.findByUuid(unitUUID);
+        UUID teamUUID = UUID.randomUUID();
+
+        Team team = new Team("a team", teamUUID, true);
+        unit.addTeam(team);
+        entityManager.persistAndFlush(unit);
+        Unit newUnit = repository.findByUuid(unitUUID);
+        List<Team> teams = new ArrayList<>(newUnit.getTeams());
+
+        assertThat(teams.get(0).getUnit()).isEqualTo(unit);
+        assertThat(teams.get(0).getUuid()).isEqualTo(teamUUID);
+        assertThat(teams.get(0).getId()).isNotNull();
+    }
+
+    @Test()
+    public void shouldAddTeamWithPermissionsToUnit() {
+        UUID teamUUID = UUID.randomUUID();
+        Unit unit = repository.findByUuid(unitUUID);
+        CaseTypeEntity caseType = new CaseTypeEntity(null,"TEST","TEST", "", true);
+        entityManager.persistAndFlush(caseType);
+
+
+        Set<Permission> permissions = new HashSet<Permission>(){{
+            add(new Permission(AccessLevel.OWNER,null, caseType));
+        }};
+        Team team = new Team("a team", teamUUID, permissions);
+        unit.addTeam(team);
+        entityManager.persistAndFlush(unit);
+
+        Unit savedUnit = repository.findByUuid(unitUUID);
+        List<Team> teams = new ArrayList<>(savedUnit.getTeams());
+
+        List<Permission> savedPermissions = new ArrayList<>(teams.get(0).getPermissions());
+        assertThat(savedPermissions.get(0).getTeam()).isEqualTo(team);
+        assertThat(savedPermissions.get(0).getAccessLevel()).isEqualTo(AccessLevel.OWNER);
+        assertThat(savedPermissions.get(0).getId()).isNotNull();
+        assertThat(savedPermissions.get(0).getCaseType()).isEqualTo(caseType);
+    }
+
     @Test(expected = PersistenceException.class)
     public void shouldThrowExceptionWhenuplicateUUID() {
         this.entityManager.persist(new Unit("Unit 1", "UNIT_1", unitUUID,true));
+    }
 
+    @Test(expected = PersistenceException.class)
+    public void shouldThrowExceptionWhenuplicateShortCode() {
+        this.entityManager.persist(new Unit("Unit 1", "UNIT_1", unitUUID,true));
+        this.entityManager.persist(new Unit("Unit 2", "UNIT_1", UUID.randomUUID(),true));
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void shouldThrowExceptionWhenuplicateDisplayName() {
+        this.entityManager.persist(new Unit("Unit 1", "UNIT_1", unitUUID,true));
+        this.entityManager.persist(new Unit("Unit 1", "UNIT_2", UUID.randomUUID(),true));
     }
 
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/info/team/TeamIntegrationTests.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/team/TeamIntegrationTests.java
@@ -1,10 +1,8 @@
-package uk.gov.digital.ho.hocs.info.integration;
+package uk.gov.digital.ho.hocs.info.team;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.entity.ContentType;
-import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.keycloak.admin.client.Keycloak;
@@ -43,15 +41,8 @@ import static org.springframework.test.context.jdbc.SqlConfig.TransactionMode.IS
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@Sql(
-        scripts = "classpath:beforeTest.sql",
-        config = @SqlConfig(transactionMode = ISOLATED)
-)
-@Sql(
-        scripts = "classpath:afterTest.sql",
-        config = @SqlConfig(transactionMode = ISOLATED),
-        executionPhase = AFTER_TEST_METHOD
-)
+@Sql(scripts = "classpath:beforeTest.sql", config = @SqlConfig(transactionMode = ISOLATED))
+@Sql(scripts = "classpath:afterTest.sql", config = @SqlConfig(transactionMode = ISOLATED), executionPhase = AFTER_TEST_METHOD)
 @DirtiesContext(classMode = AFTER_EACH_TEST_METHOD)
 public class TeamIntegrationTests {
 
@@ -97,7 +88,6 @@ public class TeamIntegrationTests {
                 serverUrl, HOCS_REALM, username, password, clientId, clientId);
 
     }
-
 
     @Test
     public void shouldAddTeamToUnitAndRemoveFromOldUnit() {
@@ -162,9 +152,6 @@ public class TeamIntegrationTests {
         assertThat(unitGroup).isNotNull();
     }
 
-
-
-
     @Test
     public void shouldAddUserToGroup() {
 
@@ -222,7 +209,6 @@ public class TeamIntegrationTests {
 
         assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(teamRepository.findByUuid(UUID.fromString(teamId)).getDisplayName()).isEqualTo("New Team Name");
-
     }
 
     private String getBasePath() {
@@ -232,7 +218,6 @@ public class TeamIntegrationTests {
     private void setupKeycloakRealm() throws IOException {
         Keycloak adminClient = Keycloak.getInstance(
                 serverUrl, "master", username, password, clientId, clientId);
-
         try {
             adminClient.realms().realm(HOCS_REALM).remove();
         } catch (Exception e) {
@@ -240,7 +225,7 @@ public class TeamIntegrationTests {
         }
         RealmRepresentation hocsRealm = mapper.readValue(new File("./keycloak/local-realm.json"), RealmRepresentation.class);
         adminClient.realms().create(hocsRealm);
-         }
+    }
 }
 
 

--- a/src/test/java/uk/gov/digital/ho/hocs/info/team/TeamIntegrationTests.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/team/TeamIntegrationTests.java
@@ -1,4 +1,0 @@
-package uk.gov.digital.ho.hocs.info.team;
-
-public class TeamIntegrationTests {
-}

--- a/src/test/java/uk/gov/digital/ho/hocs/info/team/TeamResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/team/TeamResourceTest.java
@@ -92,7 +92,7 @@ public class TeamResourceTest {
         UUID teamUUID = UUID.randomUUID();
         UUID unitUUID = UUID.randomUUID();
         TeamDto team = new TeamDto( "Team1", teamUUID, true, new HashSet<>());
-        doNothing().when(teamService).createTeam(team, unitUUID);
+        when(teamService.createTeam(team, unitUUID)).thenReturn(team);
 
         ResponseEntity result = teamResource.createUpdateTeam(unitUUID.toString(), team);
         assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);

--- a/src/test/resources/afterTest.sql
+++ b/src/test/resources/afterTest.sql
@@ -1,0 +1,8 @@
+DELETE FROM permission WHERE case_type = 'CT1' OR case_type = 'CT2';
+DELETE FROM unit_case_type WHERE unit_uuid = '09221c48-b916-47df-9aa0-a0194f86f6dd';
+
+DELETE FROM team WHERE unit_uuid = '09221c48-b916-47df-9aa0-a0194f86f6dd' OR unit_uuid = '65996106-91a5-44bf-bc92-a6c2f691f062';
+DELETE FROM unit WHERE uuid = '09221c48-b916-47df-9aa0-a0194f86f6dd' OR uuid = '65996106-91a5-44bf-bc92-a6c2f691f062';
+DELETE FROM case_type WHERE type = 'CT1' OR type = 'CT2';
+DELETE FROM tenant WHERE role = 'TEST_TENANT' OR role = 'TEST2_TENANT';
+

--- a/src/test/resources/application-local.properties
+++ b/src/test/resources/application-local.properties
@@ -1,6 +1,6 @@
 db.host = postgres
-spring.flyway.locations=classpath:/db/postgres
-spring.datasource.url=jdbc:hsqldb:mem:testdb;sql.syntax_pgs=true
+spring.flyway.locations=classpath:/db/postgresql
+spring.datasource.url=jdbc:postgresql://${db.host:localhost}:${db.port:5432}/${db.name:postgres}?currentSchema=${db.schema.name:info}&user=${db.username:root}&password=${db.password:dev}&stringtype=unspecified
 
 
 keycloak.server.root=http://keycloak:8080

--- a/src/test/resources/application-local.properties
+++ b/src/test/resources/application-local.properties
@@ -1,12 +1,12 @@
-
-
+db.host = postgres
 spring.datasource.url=jdbc:postgresql://${db.host:localhost}:${db.port:5432}/${db.name:postgres}?currentSchema=${db.schema.name:info}&user=${db.username:root}&password=${db.password:dev}&stringtype=unspecified
 
 
-keycloak.server.root=http://localhost:9081
+keycloak.server.root=http://keycloak:8080
 keycloak.server.url=${keycloak.server.root}/auth
 keycloak.realm=hocs
 keycloak.username=admin
 keycloak.password=password1
 keycloak.client.id=admin-cli
+hocs.basicauth=UNSET
 

--- a/src/test/resources/application-local.properties
+++ b/src/test/resources/application-local.properties
@@ -1,5 +1,6 @@
 db.host = postgres
-spring.datasource.url=jdbc:postgresql://${db.host:localhost}:${db.port:5432}/${db.name:postgres}?currentSchema=${db.schema.name:info}&user=${db.username:root}&password=${db.password:dev}&stringtype=unspecified
+spring.flyway.locations=classpath:/db/postgres
+spring.datasource.url=jdbc:hsqldb:mem:testdb;sql.syntax_pgs=true
 
 
 keycloak.server.root=http://keycloak:8080

--- a/src/test/resources/application-local.properties
+++ b/src/test/resources/application-local.properties
@@ -9,5 +9,16 @@ keycloak.realm=hocs
 keycloak.username=admin
 keycloak.password=password1
 keycloak.client.id=admin-cli
+
+hocs.url=http://localhost:8080
+hocs.case-service=http://localhost:8082
+hocs.document-service=http://localhost:8087
 hocs.basicauth=UNSET
 
+docs.queue.name=cs-dev-document-sqs
+docs.queue=seda://${docs.queue.name}
+api.uk.parliament=https://data.parliament.uk/membersdataplatform/services/mnisv1.0/members/query/House=%s
+api.scottish.parliament=https://data.parliament.scot/api/members
+api.ni.assembly=http://data.niassembly.gov.uk/members.asmx/GetAllCurrentMembers
+api.european.parliament=http://www.europarl.europa.eu/meps/en/download/advanced/xml?countryCode=GB
+api.welsh.assembly=https://senedd.assembly.wales/mgwebservice.asmx/GetCouncillorsByWard

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,4 +1,23 @@
 
+keycloak.server.root=http://localhost:9081
+keycloak.server.url=${keycloak.server.root}/auth
+keycloak.realm=hocs
+keycloak.username=admin
+keycloak.password=password1
+keycloak.client.id=admin-cli
 
 spring.flyway.locations=classpath:/db
 spring.datasource.url=jdbc:hsqldb:mem:testdb;sql.syntax_pgs=true
+
+hocs.url=http://localhost:8080
+hocs.case-service=http://localhost:8082
+hocs.document-service=http://localhost:8087
+hocs.basicauth=UNSET
+
+docs.queue.name=cs-dev-document-sqs
+docs.queue=seda://${docs.queue.name}
+api.uk.parliament=https://data.parliament.uk/membersdataplatform/services/mnisv1.0/members/query/House=%s
+api.scottish.parliament=https://data.parliament.scot/api/members
+api.ni.assembly=http://data.niassembly.gov.uk/members.asmx/GetAllCurrentMembers
+api.european.parliament=http://www.europarl.europa.eu/meps/en/download/advanced/xml?countryCode=GB
+api.welsh.assembly=https://senedd.assembly.wales/mgwebservice.asmx/GetCouncillorsByWard

--- a/src/test/resources/beforeTest.sql
+++ b/src/test/resources/beforeTest.sql
@@ -1,0 +1,27 @@
+Insert INTO tenant (display_name, role)
+VALUES ('TEST_TENANT', 'TEST_TENANT'),
+       ('TEST2_TENANT', 'TEST2_TENANT');
+
+Insert INTO case_type (display_name, type, tenant_role, active, bulk)
+VALUES ('Test Case Type 1', 'CT1', 'CT1', true, true),
+       ('Test Case Type 2', 'CT2', 'CT2', true, true);
+
+INSERT INTO unit (display_name, uuid,short_code, active)
+VALUES ('UNIT 2', '09221c48-b916-47df-9aa0-a0194f86f6dd', 'UNIT2', TRUE),
+       ('UNIT 3', '65996106-91a5-44bf-bc92-a6c2f691f062', 'UNIT3', TRUE);
+
+INSERT INTO team (display_name, uuid, unit_uuid, active)
+VALUES ('TEAM 4', '08612f06-bae2-4d2f-90d2-2254a68414b8', '09221c48-b916-47df-9aa0-a0194f86f6dd', TRUE),
+       ('TEAM 5', '911adabe-5ab7-4470-8395-6b584a61462d', '09221c48-b916-47df-9aa0-a0194f86f6dd', TRUE),
+       ('TEAM 6', '434a4e33-437f-4e6d-8f04-14ea40fdbfa2', '09221c48-b916-47df-9aa0-a0194f86f6dd', TRUE);
+
+INSERT INTO unit_case_type (unit_uuid, case_type)
+VALUES ('09221c48-b916-47df-9aa0-a0194f86f6dd', 'CT1'),
+       ('09221c48-b916-47df-9aa0-a0194f86f6dd', 'CT2');
+
+INSERT INTO permission (team_uuid, case_type, access_level)
+VALUES ('08612f06-bae2-4d2f-90d2-2254a68414b8','CT1', 'OWNER'),
+       ('08612f06-bae2-4d2f-90d2-2254a68414b8','CT2', 'READ'),
+       ('911adabe-5ab7-4470-8395-6b584a61462d','CT1', 'WRITE'),
+       ('434a4e33-437f-4e6d-8f04-14ea40fdbfa2','CT2', 'WRITE');
+


### PR DESCRIPTION
Added functions to:
- Add/Remove Units and Teams
- Set Team permissions
- Move teams between units
- Change team name
- Add users to Teams
- Get all users
- integration with keycloak to put AD users into correct user group for their team

Added integration tests to against instance of Keycloak in drone and locally (docker compose)

