### PR TITLE
New permissions

### DIFF
--- a/keycloak/local-realm.json
+++ b/keycloak/local-realm.json
@@ -253,246 +253,7 @@
           "attributes": {},
           "realmRoles": [],
           "clientRoles": {},
-          "subGroups": [
-            {
-              "id": "d8b8061d-33f0-440f-adfa-2ca2b8be788e",
-              "name": "MIN",
-              "path": "/RERERCIiIiIiIiIiIiIiIg/MIN",
-              "attributes": {},
-              "realmRoles": [],
-              "clientRoles": {},
-              "subGroups": [
-                {
-                  "id": "ad6e35ed-6765-4925-8b3f-827a540c69c0",
-                  "name": "5",
-                  "path": "/RERERCIiIiIiIiIiIiIiIg/MIN/5",
-                  "attributes": {},
-                  "realmRoles": [],
-                  "clientRoles": {},
-                  "subGroups": []
-                }
-              ]
-            },
-            {
-              "id": "0a9c6824-1889-4a14-91e4-ef10c9622f7d",
-              "name": "IMCB",
-              "path": "/RERERCIiIiIiIiIiIiIiIg/IMCB",
-              "attributes": {},
-              "realmRoles": [],
-              "clientRoles": {},
-              "subGroups": [
-                {
-                  "id": "8126723d-399d-4a25-9df5-4c215ebdff97",
-                  "name": "5",
-                  "path": "/RERERCIiIiIiIiIiIiIiIg/IMCB/5",
-                  "attributes": {},
-                  "realmRoles": [],
-                  "clientRoles": {},
-                  "subGroups": []
-                }
-              ]
-            },
-            {
-              "id": "ebadfd8b-83d9-4433-a8ed-e0d0890be414",
-              "name": "UTEN",
-              "path": "/RERERCIiIiIiIiIiIiIiIg/UTEN",
-              "attributes": {},
-              "realmRoles": [],
-              "clientRoles": {},
-              "subGroups": [
-                {
-                  "id": "f91517a2-4082-4697-80dd-a15e40964805",
-                  "name": "5",
-                  "path": "/RERERCIiIiIiIiIiIiIiIg/UTEN/5",
-                  "attributes": {},
-                  "realmRoles": [],
-                  "clientRoles": {},
-                  "subGroups": []
-                }
-              ]
-            },
-            {
-              "id": "a1acfee0-9572-4e2a-9269-2b204b0bfeab",
-              "name": "TRO",
-              "path": "/RERERCIiIiIiIiIiIiIiIg/TRO",
-              "attributes": {},
-              "realmRoles": [],
-              "clientRoles": {},
-              "subGroups": [
-                {
-                  "id": "71f1613b-f3fd-4226-a28a-a818ef8b9b0b",
-                  "name": "5",
-                  "path": "/RERERCIiIiIiIiIiIiIiIg/TRO/5",
-                  "attributes": {},
-                  "realmRoles": [],
-                  "clientRoles": {},
-                  "subGroups": []
-                }
-              ]
-            },
-            {
-              "id": "34d8e262-90e0-4be3-bbc0-d9ff3798dcd9",
-              "name": "IMCM",
-              "path": "/RERERCIiIiIiIiIiIiIiIg/IMCM",
-              "attributes": {},
-              "realmRoles": [],
-              "clientRoles": {},
-              "subGroups": [
-                {
-                  "id": "aa6825dc-9e2c-442a-afdc-89c6afbfbf3f",
-                  "name": "5",
-                  "path": "/RERERCIiIiIiIiIiIiIiIg/IMCM/5",
-                  "attributes": {},
-                  "realmRoles": [],
-                  "clientRoles": {},
-                  "subGroups": []
-                }
-              ]
-            },
-            {
-              "id": "13a92e63-ec8d-48f7-9dd2-f868d5d92210",
-              "name": "DTEN",
-              "path": "/RERERCIiIiIiIiIiIiIiIg/DTEN",
-              "attributes": {},
-              "realmRoles": [],
-              "clientRoles": {},
-              "subGroups": [
-                {
-                  "id": "bf5343c1-973f-44cb-bcee-3c515d09a6b6",
-                  "name": "5",
-                  "path": "/RERERCIiIiIiIiIiIiIiIg/DTEN/5",
-                  "attributes": {},
-                  "realmRoles": [],
-                  "clientRoles": {},
-                  "subGroups": []
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "id": "62e93615-fb28-474e-b64e-b96fd9153ace",
-          "name": "EREREREREREREREREREREQ",
-          "path": "/EREREREREREREREREREREQ",
-          "attributes": {},
-          "realmRoles": [],
-          "clientRoles": {},
-          "subGroups": [
-            {
-              "id": "c951a1a6-266b-4172-84ef-73e8ef59a8ad",
-              "name": "MIN",
-              "path": "/EREREREREREREREREREREQ/MIN",
-              "attributes": {},
-              "realmRoles": [],
-              "clientRoles": {},
-              "subGroups": [
-                {
-                  "id": "c5871618-40bb-43d8-a4af-b08b2877e70f",
-                  "name": "2",
-                  "path": "/EREREREREREREREREREREQ/MIN/2",
-                  "attributes": {},
-                  "realmRoles": [],
-                  "clientRoles": {},
-                  "subGroups": []
-                }
-              ]
-            },
-            {
-              "id": "c5d54b97-40d7-4b03-8436-90d1ec6180b4",
-              "name": "IMCB",
-              "path": "/EREREREREREREREREREREQ/IMCB",
-              "attributes": {},
-              "realmRoles": [],
-              "clientRoles": {},
-              "subGroups": [
-                {
-                  "id": "d84c28e4-97ca-4281-83e4-578d1142c971",
-                  "name": "2",
-                  "path": "/EREREREREREREREREREREQ/IMCB/2",
-                  "attributes": {},
-                  "realmRoles": [],
-                  "clientRoles": {},
-                  "subGroups": []
-                }
-              ]
-            },
-            {
-              "id": "417ffffe-8c62-45ff-a9c5-fec20a5cccd2",
-              "name": "IMCM",
-              "path": "/EREREREREREREREREREREQ/IMCM",
-              "attributes": {},
-              "realmRoles": [],
-              "clientRoles": {},
-              "subGroups": [
-                {
-                  "id": "91444167-9f82-4d94-a62d-3ce1f88a6c94",
-                  "name": "2",
-                  "path": "/EREREREREREREREREREREQ/IMCM/2",
-                  "attributes": {},
-                  "realmRoles": [],
-                  "clientRoles": {},
-                  "subGroups": []
-                }
-              ]
-            },
-            {
-              "id": "20411fbb-ec44-4375-ae4c-ac94b65f6fcf",
-              "name": "UTEN",
-              "path": "/EREREREREREREREREREREQ/UTEN",
-              "attributes": {},
-              "realmRoles": [],
-              "clientRoles": {},
-              "subGroups": [
-                {
-                  "id": "5954952e-db9f-4b4d-8920-12bfd165010c",
-                  "name": "2",
-                  "path": "/EREREREREREREREREREREQ/UTEN/2",
-                  "attributes": {},
-                  "realmRoles": [],
-                  "clientRoles": {},
-                  "subGroups": []
-                }
-              ]
-            },
-            {
-              "id": "103c960f-cf7d-493c-a317-08ef13812e8c",
-              "name": "TRO",
-              "path": "/EREREREREREREREREREREQ/TRO",
-              "attributes": {},
-              "realmRoles": [],
-              "clientRoles": {},
-              "subGroups": [
-                {
-                  "id": "311d5430-b71b-40b1-966a-ff81e0484578",
-                  "name": "2",
-                  "path": "/EREREREREREREREREREREQ/TRO/2",
-                  "attributes": {},
-                  "realmRoles": [],
-                  "clientRoles": {},
-                  "subGroups": []
-                }
-              ]
-            },
-            {
-              "id": "278e3062-d216-4f15-ab81-6d3f01c5c528",
-              "name": "DTEN",
-              "path": "/EREREREREREREREREREREQ/DTEN",
-              "attributes": {},
-              "realmRoles": [],
-              "clientRoles": {},
-              "subGroups": [
-                {
-                  "id": "a029f126-f67d-4ada-b526-80b1c38bae2f",
-                  "name": "2",
-                  "path": "/EREREREREREREREREREREQ/DTEN/2",
-                  "attributes": {},
-                  "realmRoles": [],
-                  "clientRoles": {},
-                  "subGroups": []
-                }
-              ]
-            }
-          ]
+          "subGroups": []
         },
         {
           "id": "3a195c4d-6be8-420b-9f60-06003e3b575a",
@@ -501,151 +262,16 @@
           "attributes": {},
           "realmRoles": [],
           "clientRoles": {},
-          "subGroups": [
-            {
-              "id": "ebe21ecf-157b-4824-b570-badcb836bb9d",
-              "name": "TRO",
-              "path": "/MzMzMzMzMzMzMzMzMzMzMw/TRO",
-              "attributes": {},
-              "realmRoles": [],
-              "clientRoles": {},
-              "subGroups": [
-                {
-                  "id": "45711c82-5c09-4a9b-9a5c-881ef290f0db",
-                  "name": "3",
-                  "path": "/MzMzMzMzMzMzMzMzMzMzMw/TRO/3",
-                  "attributes": {},
-                  "realmRoles": [],
-                  "clientRoles": {},
-                  "subGroups": []
-                }
-              ]
-            },
-            {
-              "id": "fe4d73f9-7b55-4684-a779-1add3814bfd0",
-              "name": "MIN",
-              "path": "/MzMzMzMzMzMzMzMzMzMzMw/MIN",
-              "attributes": {},
-              "realmRoles": [],
-              "clientRoles": {},
-              "subGroups": [
-                {
-                  "id": "d05e0b96-b285-46aa-b5b1-88d72277a27b",
-                  "name": "3",
-                  "path": "/MzMzMzMzMzMzMzMzMzMzMw/MIN/3",
-                  "attributes": {},
-                  "realmRoles": [],
-                  "clientRoles": {},
-                  "subGroups": []
-                }
-              ]
-            },
-            {
-              "id": "518d5703-da58-4d1d-bb6d-a07496dacde4",
-              "name": "IMCB",
-              "path": "/MzMzMzMzMzMzMzMzMzMzMw/IMCB",
-              "attributes": {},
-              "realmRoles": [],
-              "clientRoles": {},
-              "subGroups": [
-                {
-                  "id": "cf9bcd94-5ff3-4f6e-b88c-d293c9ca65dc",
-                  "name": "3",
-                  "path": "/MzMzMzMzMzMzMzMzMzMzMw/IMCB/3",
-                  "attributes": {},
-                  "realmRoles": [],
-                  "clientRoles": {},
-                  "subGroups": []
-                }
-              ]
-            },
-            {
-              "id": "55eefff4-a957-4726-856e-43f0922d371f",
-              "name": "IMCM",
-              "path": "/MzMzMzMzMzMzMzMzMzMzMw/IMCM",
-              "attributes": {},
-              "realmRoles": [],
-              "clientRoles": {},
-              "subGroups": [
-                {
-                  "id": "b63e8389-dc1c-4058-bf56-297f9869039b",
-                  "name": "3",
-                  "path": "/MzMzMzMzMzMzMzMzMzMzMw/IMCM/3",
-                  "attributes": {},
-                  "realmRoles": [],
-                  "clientRoles": {},
-                  "subGroups": []
-                }
-              ]
-            },
-            {
-              "id": "79b23677-a9f5-4b54-a879-0f795073d1e0",
-              "name": "UTEN",
-              "path": "/MzMzMzMzMzMzMzMzMzMzMw/UTEN",
-              "attributes": {},
-              "realmRoles": [],
-              "clientRoles": {},
-              "subGroups": [
-                {
-                  "id": "9ee4fef2-b660-4e94-b5fb-8f95caaab398",
-                  "name": "3",
-                  "path": "/MzMzMzMzMzMzMzMzMzMzMw/UTEN/3",
-                  "attributes": {},
-                  "realmRoles": [],
-                  "clientRoles": {},
-                  "subGroups": []
-                }
-              ]
-            },
-            {
-              "id": "b78d8984-93ec-4fca-9ce9-eb9213dde7cf",
-              "name": "DTEN",
-              "path": "/MzMzMzMzMzMzMzMzMzMzMw/DTEN",
-              "attributes": {},
-              "realmRoles": [],
-              "clientRoles": {},
-              "subGroups": [
-                {
-                  "id": "4e393380-3cb7-40db-8153-ca34e70c1482",
-                  "name": "3",
-                  "path": "/MzMzMzMzMzMzMzMzMzMzMw/DTEN/3",
-                  "attributes": {},
-                  "realmRoles": [],
-                  "clientRoles": {},
-                  "subGroups": []
-                }
-              ]
-            }
-          ]
+          "subGroups": []
         },
-    {
+        {
           "id": "abf7617c-058c-4287-9f41-b95384fdbc7d",
           "name": "Q0pOM0N_Tm2PBBTqQP2_og",
           "path": "/Q0pOM0N_Tm2PBBTqQP2_og",
           "attributes": {},
           "realmRoles": [],
           "clientRoles": {},
-          "subGroups": [
-            {
-              "id": "a6f5c195-b625-4a95-9789-6609ef87cb38",
-              "name": "CT2",
-              "path": "/Q0pOM0N_Tm2PBBTqQP2_og/CT2",
-              "attributes": {},
-              "realmRoles": [],
-              "clientRoles": {},
-              "subGroups": [
-                {
-                  "id": "a9faabdd-4e39-47c0-94ee-6548bf5b3547",
-                  "name": "3",
-                  "path": "/Q0pOM0N_Tm2PBBTqQP2_og/CT2/3",
-                  "attributes": {},
-                  "realmRoles": [],
-                  "clientRoles": {},
-                  "subGroups": []
-                }
-              ]
-            }
-          ]
+          "subGroups": []
         },
         {
           "id": "abf7617c-058c-4287-9f41-b95384fdbc7e",
@@ -654,36 +280,7 @@
           "attributes": {},
           "realmRoles": [],
           "clientRoles": {},
-          "subGroups": [
-            {
-              "id": "a6f5c195-b625-4a95-9789-6609ef87cb39",
-              "name": "CT3",
-              "path": "/iztDZqN8SLaydExQ-Ag4Qw/CT3",
-              "attributes": {},
-              "realmRoles": [],
-              "clientRoles": {},
-              "subGroups": [
-                {
-                  "id": "a9faabdd-4e39-47c0-94ee-6548bf5b354a",
-                  "name": "3",
-                  "path": "/iztDZqN8SLaydExQ-Ag4Qw/CT3/3",
-                  "attributes": {},
-                  "realmRoles": [],
-                  "clientRoles": {},
-                  "subGroups": []
-                },
-                {
-                  "id": "a9faabdd-4e39-47c0-94ee-6548bf5b354b",
-                  "name": "2",
-                  "path": "/iztDZqN8SLaydExQ-Ag4Qw/CT3/2",
-                  "attributes": {},
-                  "realmRoles": [],
-                  "clientRoles": {},
-                  "subGroups": []
-                }
-              ]
-            }
-          ]
+          "subGroups": []
         }
   ],
   "defaultRoles" : [ "uma_authorization", "offline_access" ],
@@ -722,7 +319,7 @@
       "account" : [ "view-profile", "manage-account" ]
     },
     "notBefore" : 0,
-    "groups" : [ "/Q0pOM0N_Tm2PBBTqQP2_og/CT2/3", "/iztDZqN8SLaydExQ-Ag4Qw/CT3/3", "/iztDZqN8SLaydExQ-Ag4Qw/CT3/2"]
+    "groups" : [ "/Q0pOM0N_Tm2PBBTqQP2_og", "/iztDZqN8SLaydExQ-Ag4Qw"]
   },
 
     {
@@ -741,24 +338,9 @@
       },
       "notBefore" : 0,
       "groups" : [
-                  "/EREREREREREREREREREREQ/MIN/2",
-                  "/EREREREREREREREREREREQ/IMCB/2",
-                  "/EREREREREREREREREREREQ/DTEN/2",
-                  "/EREREREREREREREREREREQ/IMCM/2",
-                  "/EREREREREREREREREREREQ/TRO/2",
-                  "/EREREREREREREREREREREQ/UTEN/2",
-                  "/MzMzMzMzMzMzMzMzMzMzMw/UTEN/3",
-                  "/MzMzMzMzMzMzMzMzMzMzMw/IMCB/3",
-                  "/MzMzMzMzMzMzMzMzMzMzMw/TRO/3",
-                  "/MzMzMzMzMzMzMzMzMzMzMw/IMCM/3",
-                  "/MzMzMzMzMzMzMzMzMzMzMw/DTEN/3",
-                  "/MzMzMzMzMzMzMzMzMzMzMw/MIN/3",
-                  "/RERERCIiIiIiIiIiIiIiIg/UTEN/5",
-                  "/RERERCIiIiIiIiIiIiIiIg/MIN/5",
-                  "/RERERCIiIiIiIiIiIiIiIg/TRO/5",
-                  "/RERERCIiIiIiIiIiIiIiIg/DTEN/5",
-                  "/RERERCIiIiIiIiIiIiIiIg/IMCM/5",
-                  "/RERERCIiIiIiIiIiIiIiIg/IMCB/5"]
+                  "/EREREREREREREREREREREQ",
+                  "/MzMzMzMzMzMzMzMzMzMzMw",
+                  "/RERERCIiIiIiIiIiIiIiIg"]
     },
     {
       "id" : "968672ca-9fc1-491c-b2b9-d13c58b12d7a",
@@ -786,7 +368,7 @@
         "account" : [ "view-profile", "manage-account" ]
       },
       "notBefore" : 0,
-      "groups" : [ "/EREREREREREREREREREREQ/MIN/2", "/EREREREREREREREREREREQ/TRO/2", "/EREREREREREREREREREREQ/IMCB/2", "/MzMzMzMzMzMzMzMzMzMzMw/MIN/3", "/EREREREREREREREREREREQ/DTEN/2", "/EREREREREREREREREREREQ/UTEN/2", "/EREREREREREREREREREREQ/IMCM/2" ]
+      "groups" : [ "/EREREREREREREREREREREQ", "/MzMzMzMzMzMzMzMzMzMzMw" ]
     }, {
       "id" : "fc72ee08-7972-40df-a801-501d3a271fa3",
       "createdTimestamp" : 1544174692718,
@@ -813,7 +395,7 @@
         "account" : [ "view-profile", "manage-account" ]
       },
       "notBefore" : 0,
-      "groups" : [ "/EREREREREREREREREREREQ/MIN/2" ]
+      "groups" : [ "/EREREREREREREREREREREQ" ]
     }
   ],
   "scopeMappings" : [ {

--- a/keycloak/local-realm.json
+++ b/keycloak/local-realm.json
@@ -246,42 +246,52 @@
     }
   },
   "groups": [
-        {
-          "id": "59d92ab1-82f4-44b4-9c44-3f4e904bef8b",
-          "name": "RERERCIiIiIiIiIiIiIiIg",
-          "path": "/RERERCIiIiIiIiIiIiIiIg",
-          "attributes": {},
-          "realmRoles": [],
-          "clientRoles": {},
-          "subGroups": []
-        },
-        {
-          "id": "3a195c4d-6be8-420b-9f60-06003e3b575a",
-          "name": "MzMzMzMzMzMzMzMzMzMzMw",
-          "path": "/MzMzMzMzMzMzMzMzMzMzMw",
-          "attributes": {},
-          "realmRoles": [],
-          "clientRoles": {},
-          "subGroups": []
-        },
-        {
-          "id": "abf7617c-058c-4287-9f41-b95384fdbc7d",
-          "name": "Q0pOM0N_Tm2PBBTqQP2_og",
-          "path": "/Q0pOM0N_Tm2PBBTqQP2_og",
-          "attributes": {},
-          "realmRoles": [],
-          "clientRoles": {},
-          "subGroups": []
-        },
-        {
-          "id": "abf7617c-058c-4287-9f41-b95384fdbc7e",
-          "name": "iztDZqN8SLaydExQ-Ag4Qw",
-          "path": "/iztDZqN8SLaydExQ-Ag4Qw",
-          "attributes": {},
-          "realmRoles": [],
-          "clientRoles": {},
-          "subGroups": []
-        }
+    {
+      "id": "59d92ab1-82f4-44b4-9c44-3f4e904bef8b",
+      "name": "RERERCIiIiIiIiIiIiIiIg",
+      "path": "/RERERCIiIiIiIiIiIiIiIg",
+      "attributes": {},
+      "realmRoles": [],
+      "clientRoles": {},
+      "subGroups": []
+    },
+    {
+      "id": "3a195c4d-6be8-420b-9f60-06003e3b575a",
+      "name": "MzMzMzMzMzMzMzMzMzMzMw",
+      "path": "/MzMzMzMzMzMzMzMzMzMzMw",
+      "attributes": {},
+      "realmRoles": [],
+      "clientRoles": {},
+      "subGroups": []
+    },
+    {
+      "id": "abf7617c-058c-4287-9f41-b95384fdbc7d",
+      "name": "Q0pOM0N_Tm2PBBTqQP2_og",
+      "path": "/Q0pOM0N_Tm2PBBTqQP2_og",
+      "attributes": {},
+      "realmRoles": [],
+      "clientRoles": {},
+      "subGroups": []
+    },
+    {
+      "id": "abf7617c-058c-4287-9f41-b95384fdbc7e",
+      "name": "iztDZqN8SLaydExQ-Ag4Qw",
+      "path": "/iztDZqN8SLaydExQ-Ag4Qw",
+      "attributes": {},
+      "realmRoles": [],
+      "clientRoles": {},
+      "subGroups": []
+    },
+    {
+      "id": "abf7617c-058c-4287-9f41-b95384fdbc7f",
+      "name": "EREREREREREREREREREREQ",
+      "path": "/EREREREREREREREREREREQ",
+      "attributes": {},
+      "realmRoles": [],
+      "clientRoles": {},
+      "subGroups": []
+    }
+
   ],
   "defaultRoles" : [ "uma_authorization", "offline_access" ],
   "requiredCredentials" : [ "password" ],
@@ -338,9 +348,9 @@
       },
       "notBefore" : 0,
       "groups" : [
-                  "/EREREREREREREREREREREQ",
-                  "/MzMzMzMzMzMzMzMzMzMzMw",
-                  "/RERERCIiIiIiIiIiIiIiIg"]
+        "/EREREREREREREREREREREQ",
+        "/MzMzMzMzMzMzMzMzMzMzMw",
+        "/RERERCIiIiIiIiIiIiIiIg"]
     },
     {
       "id" : "968672ca-9fc1-491c-b2b9-d13c58b12d7a",

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/CaseTypeService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/CaseTypeService.java
@@ -41,18 +41,19 @@ public class CaseTypeService {
     Set<CaseType> getAllCaseTypesForUser(boolean bulkOnly) {
         log.debug("Getting case types by User, bulkOnly = {}", bulkOnly);
         Set<UUID> userTeams = userPermissionsService.getUserTeams();
-        log.debug("Found {} teams", userTeams.size());
+        Set<String> teams = userTeams.stream().map(uuid -> uuid.toString()).collect(Collectors.toSet());
+        log.debug("Finding case types for {} teams", teams);
         if(userTeams.isEmpty()) {
             log.warn("No Teams - Returning 0 CaseTypes");
             return new HashSet<>(0);
         } else {
             Set<CaseType> caseTypes;
             if (bulkOnly) {
-                caseTypes = caseTypeRepository.findAllBulkCaseTypesByTeam(userTeams);
+                caseTypes = caseTypeRepository.findAllBulkCaseTypesByTeam(teams);
             } else {
-                caseTypes = caseTypeRepository.findAllCaseTypesByTeam(userTeams);
+                caseTypes = caseTypeRepository.findAllCaseTypesByTeam(teams);
             }
-            log.info("Got {} CaseTypes (bulkOnly = {}", caseTypes.size(), bulkOnly);
+            log.info("Got {} CaseTypes (bulkOnly = {})", caseTypes.size(), bulkOnly);
             return caseTypes;
         }
     }

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/CaseTypeService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/CaseTypeService.java
@@ -40,7 +40,7 @@ public class CaseTypeService {
 
     Set<CaseType> getAllCaseTypesForUser(boolean bulkOnly) {
         log.debug("Getting case types by User, bulkOnly = {}", bulkOnly);
-        Set<String> userTeams = userPermissionsService.getUserTeams();
+        Set<UUID> userTeams = userPermissionsService.getUserTeams();
         log.debug("Found {} teams", userTeams.size());
         if(userTeams.isEmpty()) {
             log.warn("No Teams - Returning 0 CaseTypes");

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/TeamResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/TeamResource.java
@@ -85,7 +85,7 @@ public class TeamResource {
     @GetMapping(value = "/team")
     public ResponseEntity<Set<TeamDto>> getActiveTeams() {
         Set<Team> teams = teamService.getAllActiveTeams();
-        return ResponseEntity.ok(teams.stream().map(TeamDto::fromWithoutPermissions).collect(Collectors.toSet()));
+        return ResponseEntity.ok(teams.stream().map(TeamDto::from).collect(Collectors.toSet()));
     }
 
     @GetMapping(value = "/teams", params = {"unit"}, produces = APPLICATION_JSON_UTF8_VALUE)

--- a/src/main/java/uk/gov/digital/ho/hocs/info/application/CacheScheduler.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/application/CacheScheduler.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
+import uk.gov.digital.ho.hocs.info.api.TeamService;
 import uk.gov.digital.ho.hocs.info.api.UserService;
 
 @Configuration
@@ -14,9 +15,15 @@ import uk.gov.digital.ho.hocs.info.api.UserService;
 public class CacheScheduler {
 
     private UserService userService;
+    private TeamService teamService;
 
     @Scheduled(fixedDelayString = "${cache.user.refresh}000")
     public void refreshUserCache(){
         userService.refreshUserCache();
+    }
+
+    @Scheduled(fixedDelayString = "${cache.team.refresh}000")
+    public void refreshTeamCache(){
+        teamService.refreshTeamCache();
     }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/Permission.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/Permission.java
@@ -9,8 +9,7 @@ import java.io.Serializable;
 @NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
 @Entity
 @Table(name = "permission")
-@EqualsAndHashCode(of = {"accessLevel", "caseType", "team"})
-
+@EqualsAndHashCode(of = {"accessLevel", "caseType"})
 public class Permission implements Serializable {
 
     public Permission(AccessLevel accessLevel, Team team, CaseType caseType) {

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/CaseTypeRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/CaseTypeRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 import java.util.Set;
+import java.util.UUID;
 
 import uk.gov.digital.ho.hocs.info.domain.model.CaseType;
 
@@ -11,10 +12,10 @@ import uk.gov.digital.ho.hocs.info.domain.model.CaseType;
 public interface CaseTypeRepository extends CrudRepository<CaseType, String> {
 
     @Query(value = "SELECT ct.* FROM case_type ct JOIN permission ON ct.type = permission.case_type WHERE permission.team_uuid IN ?1 AND ct.active = TRUE", nativeQuery = true)
-    Set<CaseType> findAllCaseTypesByTeam(Set<String> team);
+    Set<CaseType> findAllCaseTypesByTeam(Set<UUID> team);
 
     @Query(value = "SELECT ct.* FROM case_type ct JOIN permission ON ct.type = permission.case_type WHERE permission.team_uuid IN ?1 AND ct.active = TRUE AND ct.bulk = TRUE", nativeQuery = true)
-    Set<CaseType> findAllBulkCaseTypesByTeam(Set<String> team);
+    Set<CaseType> findAllBulkCaseTypesByTeam(Set<UUID> team);
 
     Set<CaseType> findAll();
 

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/CaseTypeRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/CaseTypeRepository.java
@@ -12,10 +12,10 @@ import uk.gov.digital.ho.hocs.info.domain.model.CaseType;
 public interface CaseTypeRepository extends CrudRepository<CaseType, String> {
 
     @Query(value = "SELECT ct.* FROM case_type ct JOIN permission ON ct.type = permission.case_type WHERE permission.team_uuid IN ?1 AND ct.active = TRUE", nativeQuery = true)
-    Set<CaseType> findAllCaseTypesByTeam(Set<UUID> team);
+    Set<CaseType> findAllCaseTypesByTeam(Set<String> team);
 
     @Query(value = "SELECT ct.* FROM case_type ct JOIN permission ON ct.type = permission.case_type WHERE permission.team_uuid IN ?1 AND ct.active = TRUE AND ct.bulk = TRUE", nativeQuery = true)
-    Set<CaseType> findAllBulkCaseTypesByTeam(Set<UUID> team);
+    Set<CaseType> findAllBulkCaseTypesByTeam(Set<String> team);
 
     Set<CaseType> findAll();
 

--- a/src/main/java/uk/gov/digital/ho/hocs/info/security/UserPermissionsService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/security/UserPermissionsService.java
@@ -4,14 +4,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.digital.ho.hocs.info.application.RequestData;
-import uk.gov.digital.ho.hocs.info.domain.model.CaseType;
-
 import java.nio.BufferUnderflowException;
 import java.util.*;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import static net.logstash.logback.argument.StructuredArguments.value;
-import static uk.gov.digital.ho.hocs.info.application.LogEvent.*;
 
 @Service
 @Slf4j
@@ -24,73 +19,19 @@ public class UserPermissionsService {
         this.requestData = requestData;
     }
 
-    public UUID getUserId() {
-        return UUID.fromString(requestData.userId());
-    }
-
-    public AccessLevel getMaxAccessLevel(String caseType) {
-        return getUserPermission()
-                .flatMap(type -> type.getValue().getOrDefault(caseType, new HashSet<>()).stream())
-                .max(Comparator.comparing(AccessLevel::getLevel))
-                .orElseThrow(() ->
-                        new SecurityExceptions.PermissionCheckException("User does not have any permissions for this case type", SECURITY_UNAUTHORISED));
-    }
-
-    public Set<AccessLevel> getUserAccessLevels(CaseType caseType) {
-
-        return getUserPermission()
-                .flatMap(type -> type.getValue().getOrDefault(caseType.getShortCode(), new HashSet<>()).stream())
+    public Set<UUID> getUserTeams() {
+        return Arrays.stream(requestData.groupsArray())
+                .map(group -> getUUIDFromBase64(group))
+                .filter(Objects::nonNull)
                 .collect(Collectors.toSet());
     }
 
-
-    public Set<String> getUserTeams() {
-        return getUserPermission()
-                .map(Map.Entry::getKey)
-                .collect(Collectors.toSet());
-    }
-
-    public Set<String> getUserCaseTypes() {
-        return getUserPermission()
-                .flatMap(team -> team.getValue().entrySet().stream())
-                .map(caseType -> caseType.getKey())
-                .collect(Collectors.toSet());
-    }
-
-    Stream<Map.Entry<String, Map<String, Set<AccessLevel>>>> getUserPermission() {
-        Map<String, Map<String, Set<AccessLevel>>> permissions = new HashMap<>();
-
-        Arrays.stream(requestData.groupsArray())
-                .map(group -> group.split("/"))
-                .filter(group -> group.length >= 4)
-                .forEach(group -> getAccessLevel(permissions, group));
-
-        return permissions.entrySet().stream();
-    }
-
-    private static void getAccessLevel(Map<String, Map<String, Set<AccessLevel>>> permissions, String[] permission) {
+    private UUID getUUIDFromBase64(String uuid) {
         try {
-            String team = Optional.ofNullable(permission[1]).orElseThrow(() -> new SecurityExceptions.PermissionCheckException("Null team Found", SECURITY_PARSE_ERROR));
-            String caseType = Optional.ofNullable(permission[2]).orElseThrow(() -> new SecurityExceptions.PermissionCheckException("Invalid case type Found",SECURITY_PARSE_ERROR));
-            String accessLevel = Optional.ofNullable(permission[3]).orElseThrow(() -> new SecurityExceptions.PermissionCheckException("Invalid access type Found",SECURITY_PARSE_ERROR));
-
-            UUID decodedTeam = Base64UUID.Base64StringToUUID(team);
-
-            buildPermissions(permissions, decodedTeam.toString(), caseType, accessLevel);
-
-        } catch (SecurityExceptions.PermissionCheckException | BufferUnderflowException e) {
-            log.error(e.getMessage(),value(EVENT, SECURITY_PARSE_ERROR));
+            return Base64UUID.Base64StringToUUID(uuid);
+        }
+        catch (BufferUnderflowException e) {
+            return null;
         }
     }
-
-    private static void buildPermissions(Map<String, Map<String, Set<AccessLevel>>> permissions, String team, String caseType, String accessLevel) {
-        try{
-            permissions.computeIfAbsent(team, map -> new HashMap<>())
-                    .computeIfAbsent(caseType, map -> new HashSet<>())
-                    .add(AccessLevel.from((Integer.valueOf(accessLevel))));
-        } catch (IllegalArgumentException e){
-            log.error("invalid access level found - {}", accessLevel, value(EVENT, INVALID_ACCESS_LEVEL_FOUND));
-        }
-    }
-
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/info/security/UserPermissionsService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/security/UserPermissionsService.java
@@ -27,10 +27,12 @@ public class UserPermissionsService {
     }
 
     private UUID getUUIDFromBase64(String uuid) {
+        if (uuid.startsWith("/")) {
+            uuid = uuid.substring(1);
+        }
         try {
             return Base64UUID.Base64StringToUUID(uuid);
-        }
-        catch (BufferUnderflowException e) {
+        } catch (BufferUnderflowException e) {
             return null;
         }
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,6 +29,7 @@ aws.region=eu-west-2
 aws.account.id=12345
 
 cache.user.refresh=3600
+cache.team.refresh=3600
 
 camel.springboot.main-run-controller=true
 

--- a/src/test/java/uk/gov/digital/ho/hocs/info/CacheSchedulerTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/CacheSchedulerTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.digital.ho.hocs.info.api.TeamService;
 import uk.gov.digital.ho.hocs.info.application.CacheScheduler;
 import uk.gov.digital.ho.hocs.info.api.UserService;
 import static org.mockito.Mockito.*;
@@ -16,12 +17,20 @@ public class CacheSchedulerTest {
     @Mock
     UserService userService;
 
+    @Mock
+    TeamService teamService;
+
     @Test
     public void shouldCallUserServiceRefresh() {
-        service = new CacheScheduler(userService);
+        service = new CacheScheduler(userService, teamService);
         service.refreshUserCache();
         verify(userService, times(1)).refreshUserCache();
     }
 
-
+    @Test
+    public void shouldCallTeamServiceRefresh() {
+        service = new CacheScheduler(userService, teamService);
+        service.refreshTeamCache();
+        verify(teamService, times(1)).refreshTeamCache();
+    }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/CaseTypeServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/CaseTypeServiceTest.java
@@ -11,6 +11,7 @@ import uk.gov.digital.ho.hocs.info.domain.repository.HolidayDateRepository;
 import uk.gov.digital.ho.hocs.info.security.UserPermissionsService;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -32,8 +33,11 @@ public class CaseTypeServiceTest {
     private UserPermissionsService userPermissionsService;
 
     private CaseTypeService caseTypeService;
-    private Set team = new HashSet<String>() {{ add("74c79583-1375-494c-9883-f574e7e36541");}};
-    private Set teams = new HashSet<String>() {{ add("74c79583-1375-494c-9883-f574e7e36541, 8b532de4-4915-4783-a19a-c79fd6754d5c"); }};
+    private Set<UUID> team = new HashSet<UUID>() {{  add(UUID.fromString("74c79583-1375-494c-9883-f574e7e36541"));}};
+    Set<String> teamString = team.stream().map(uuid -> uuid.toString()).collect(Collectors.toSet());
+    private Set<UUID> teams = new HashSet<UUID>() {{ add(UUID.fromString("74c79583-1375-494c-9883-f574e7e36541"));
+                                                add(UUID.fromString("8b532de4-4915-4783-a19a-c79fd6754d5c"));}};
+    Set<String> teamsString = teams.stream().map(uuid -> uuid.toString()).collect(Collectors.toSet());
     private UUID unitUUID = UUID.randomUUID();
 
     @Before
@@ -54,7 +58,7 @@ public class CaseTypeServiceTest {
     public void shouldGetCaseTypesSingleTenantRequested() {
 
         when(userPermissionsService.getUserTeams()).thenReturn(team);
-        when(caseTypeRepository.findAllCaseTypesByTeam(team)).thenReturn(getDCUCaseType());
+        when(caseTypeRepository.findAllCaseTypesByTeam(teamString)).thenReturn(getDCUCaseType());
 
         Set<CaseType> caseTypeDtos = caseTypeService.getAllCaseTypesForUser(false);
 
@@ -71,7 +75,7 @@ public class CaseTypeServiceTest {
     @Test
     public void shouldGetCaseTypesMultipleTeamsRequested() {
         when(userPermissionsService.getUserTeams()).thenReturn(teams);
-        when(caseTypeRepository.findAllCaseTypesByTeam(teams)).thenReturn(getDCUAndUKVICaseType());
+        when(caseTypeRepository.findAllCaseTypesByTeam(teamsString)).thenReturn(getDCUAndUKVICaseType());
 
         Set<CaseType> caseTypeDtos = caseTypeService.getAllCaseTypesForUser(false);
 
@@ -89,11 +93,11 @@ public class CaseTypeServiceTest {
     public void shouldGetBulkCaseTypesSingleTeamRequested() {
 
         when(userPermissionsService.getUserTeams()).thenReturn(team);
-        when(caseTypeRepository.findAllBulkCaseTypesByTeam(team)).thenReturn(getDCUCaseTypeBulk());
+        when(caseTypeRepository.findAllBulkCaseTypesByTeam(teamString)).thenReturn(getDCUCaseTypeBulk());
 
         Set<CaseType> caseTypeDtos = caseTypeService.getAllCaseTypesForUser(true);
 
-        verify(caseTypeRepository, times(1)).findAllBulkCaseTypesByTeam(team);
+        verify(caseTypeRepository, times(1)).findAllBulkCaseTypesByTeam(teamString);
 
         assertThat(caseTypeDtos.size()).isEqualTo(2);
 
@@ -106,11 +110,11 @@ public class CaseTypeServiceTest {
     @Test
     public void shouldGetBulkCaseTypesMultipleTeamRequested() {
         when(userPermissionsService.getUserTeams()).thenReturn(teams);
-        when(caseTypeRepository.findAllBulkCaseTypesByTeam(teams)).thenReturn(getDCUAndUKVICaseTypeBulk());
+        when(caseTypeRepository.findAllBulkCaseTypesByTeam(teamsString)).thenReturn(getDCUAndUKVICaseTypeBulk());
 
         Set<CaseType> caseTypeDtos = caseTypeService.getAllCaseTypesForUser(true);
 
-        verify(caseTypeRepository, times(1)).findAllBulkCaseTypesByTeam(teams);
+        verify(caseTypeRepository, times(1)).findAllBulkCaseTypesByTeam(teamsString);
 
         assertThat(caseTypeDtos.size()).isEqualTo(5);
 

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/TeamServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/TeamServiceTest.java
@@ -138,7 +138,7 @@ public class TeamServiceTest {
         assertThat(result.getUuid()).isEqualTo(team1UUID);
         verify(teamRepository, times(1)).findByUuid(team1UUID);
         verify(unitRepository, times(1)).findByUuid(unitUUID);
-        verify(keycloakService, times(1)).createTeamGroupIfNotExists(base64Team1UUID);
+        verify(keycloakService, times(1)).createTeamGroupIfNotExists(team1UUID);
         verifyNoMoreInteractions(teamRepository);
         verifyNoMoreInteractions(keycloakService);
     }
@@ -158,7 +158,7 @@ public class TeamServiceTest {
         teamService.createTeam(teamDto, unitUUID);
         verify(unitRepository, times(1)).findByUuid(unitUUID);
         verify(unitRepository, never()).save(unit);
-        verify(keycloakService, times(1)).createTeamGroupIfNotExists(base64Team1UUID);
+        verify(keycloakService, times(1)).createTeamGroupIfNotExists(team1UUID);
         verifyNoMoreInteractions(keycloakService);
     }
 
@@ -218,20 +218,14 @@ public class TeamServiceTest {
         team.setUnit(unit);
         team.addPermissions(permissions);
 
-        String teamGroupPath =  "/" + base64Team1UUID;
-        String caseGroupPath =  teamGroupPath + "/MIN";
-        String accessLevelGroupPath = teamGroupPath + "/MIN/5";
-
         when(teamRepository.findByUuid(team1UUID)).thenReturn(team);
         teamService.addUserToTeam(userUUID, team1UUID);
-        verify(keycloakService, times(1)).createTeamGroupIfNotExists(base64Team1UUID);
-        verify(keycloakService, times(1)).createGroupPathIfNotExists(teamGroupPath, "MIN");
-        verify(keycloakService, times(1)).createGroupPathIfNotExists(caseGroupPath, "5");
-        verify(keycloakService, times(1)).addUserToGroup(userUUID, accessLevelGroupPath);
+        verify(keycloakService, times(1)).createTeamGroupIfNotExists(team1UUID);
+        verify(keycloakService, times(1)).addUserToTeam(userUUID, team1UUID);
     }
 
     @Test
-    public void shouldUpdatePermissionsInDatabaseAndKeycloak() {
+    public void shouldUpdatePermissionsInDatabase() {
 
         UUID unitUUID = UUID.randomUUID();
         Unit unit = new Unit("a unit", "UNIT", unitUUID, true);
@@ -248,23 +242,16 @@ public class TeamServiceTest {
             add(new PermissionDto("MIN", AccessLevel.OWNER));
         }};
 
-        Set<String> permissionPaths = new HashSet<String>() {{
-            add("/" + base64Team1UUID + "/MIN/2");
-            add("/" + base64Team1UUID + "/MIN/5");
-        }};
-
         assertThat(team.getPermissions().size()).isEqualTo(0);
         teamService.updateTeamPermissions(team1UUID, permissions);
         assertThat(team.getPermissions().size()).isEqualTo(2);
 
-
         verify(teamRepository, times(1)).findByUuid(team1UUID);
-        verify(keycloakService, times(1)).updateUserTeamGroups(team1UUID,permissionPaths);
         verifyNoMoreInteractions(teamRepository);
     }
 
     @Test
-    public void shouldDeleteSinglePermissionInDatabaseAndKeycloak() {
+    public void shouldDeleteSinglePermissionInDatabase() {
 
         UUID unitUUID = UUID.randomUUID();
         Set<Permission> permissions = new HashSet<>();
@@ -278,7 +265,6 @@ public class TeamServiceTest {
 
         when(teamRepository.findByUuid(team1UUID)).thenReturn(team);
         when(caseTypeService.getCaseType(any())).thenReturn(caseType);
-        doNothing().when(keycloakService).deleteTeamPermisisons(any());
 
         Set<PermissionDto> permissionDtoSet = new HashSet<PermissionDto>() {{
             add(new PermissionDto("MIN", AccessLevel.READ));
@@ -290,7 +276,6 @@ public class TeamServiceTest {
 
 
         verify(teamRepository, times(1)).findByUuid(team1UUID);
-        verify(keycloakService, times(1)).deleteTeamPermisisons("/"+ base64Team1UUID+"/MIN/2");
         verifyNoMoreInteractions(teamRepository);
     }
 
@@ -309,7 +294,6 @@ public class TeamServiceTest {
 
         when(teamRepository.findByUuid(team1UUID)).thenReturn(team);
         when(caseTypeService.getCaseType(any())).thenReturn(caseType);
-        doNothing().when(keycloakService).deleteTeamPermisisons(any());
 
         Set<PermissionDto> permissionDtoSet = new HashSet<PermissionDto>() {{
             add(new PermissionDto("MIN", AccessLevel.READ));
@@ -322,8 +306,6 @@ public class TeamServiceTest {
 
 
         verify(teamRepository, times(1)).findByUuid(team1UUID);
-        verify(keycloakService, times(1)).deleteTeamPermisisons("/" + base64Team1UUID+"/MIN/2");
-        verify(keycloakService, times(1)).deleteTeamPermisisons("/" + base64Team1UUID+"/MIN/5");
         verifyNoMoreInteractions(teamRepository);
     }
 
@@ -459,7 +441,6 @@ public class TeamServiceTest {
 
         when(teamRepository.findByUuid(team1UUID)).thenReturn(team);
         when(caseTypeService.getCaseType(any())).thenReturn(caseType);
-        doNothing().when(keycloakService).deleteTeamPermisisons(any());
 
         Set<PermissionDto> permissionDtoSet = new HashSet<PermissionDto>() {{
             add(new PermissionDto("MIN", AccessLevel.READ));

--- a/src/test/java/uk/gov/digital/ho/hocs/info/security/UserPermissionsServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/security/UserPermissionsServiceTest.java
@@ -8,8 +8,13 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
+import uk.gov.digital.ho.hocs.info.api.TeamService;
 import uk.gov.digital.ho.hocs.info.application.RequestData;
 import uk.gov.digital.ho.hocs.info.domain.model.CaseType;
+import uk.gov.digital.ho.hocs.info.domain.model.Permission;
+import uk.gov.digital.ho.hocs.info.domain.model.Team;
+
+import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
@@ -23,11 +28,9 @@ public class UserPermissionsServiceTest {
     private RequestData requestData;
 
     private UserPermissionsService service;
-
     private String uuid1 = Base64UUID.UUIDToBase64String(UUID.fromString("1325fe16-b864-42c7-85c2-7cab2863fe01"));
     private String uuid2 = Base64UUID.UUIDToBase64String(UUID.fromString("f1825c7d-baff-4c09-8056-2166760ccbd2"));
     private String uuid3 = Base64UUID.UUIDToBase64String(UUID.fromString("1c1e2f17-d5d9-4ff6-a023-6c40d76e1e9d"));
-
 
     @Before
     public void setup() {
@@ -36,90 +39,33 @@ public class UserPermissionsServiceTest {
         RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
     }
 
-
-    @Test
-    public void shouldParseValidUserGroups() {
-
-        String[] groups =
-                        ("/" + uuid1 + "/TRO/2," +
-                         "/" + uuid1 + "/TRO/3," +
-                         "/" + uuid2 + "/MIN/3," +
-                         "/" + uuid3 + "/MIN/3," +
-                         "/" + uuid1 + "/MIN/5").split(",");
-
-        when(requestData.groupsArray()).thenReturn(groups);
-        service = new UserPermissionsService(requestData);
-        assertThat(service.getUserPermission().count()).isEqualTo(3);
-    }
-
-
     @Test
     public void shouldIgnoreInvalidUserGroups() {
 
         String[] groups =
-                ("/" + uuid1 + "/TRO/2," +
-                        "/" + uuid1 + "/TRO/3," +
-                        "/" + uuid2 + "/MIN/3," +
-                        "/B@d***UU!D/MIN/3," +
-                        "/" + uuid1 + "/MIN/5").split(",");
+                (uuid2 + "," +
+                        uuid3 + "," +
+                        "INVALID_UUID").split(",");
 
         when(requestData.groupsArray()).thenReturn(groups);
         service = new UserPermissionsService(requestData);
-        assertThat(service.getUserPermission().count()).isEqualTo(2);
-    }
-
-
-
-    @Test
-    public void shouldGetPermissionsForCaseType() {
-
-        String[] groups =
-                ("/" + uuid1 + "/TRO/2," +
-                        "/" + uuid1 + "/TRO/3," +
-                        "/" + uuid2 + "/MIN/3," +
-                        "/" + uuid3 + "/MIN/3," +
-                        "/" + uuid1 + "/MIN/5").split(",");
-
-        when(requestData.groupsArray()).thenReturn(groups);
-        service = new UserPermissionsService(requestData);
-        Set<AccessLevel> userAccessLevels = service.getUserAccessLevels(new CaseType(1L, UUID.randomUUID(),"","MIN",  "",UUID.randomUUID(), "",true,true));
-        assertThat(userAccessLevels.size()).isEqualTo(2);
-        assertThat(userAccessLevels).contains(AccessLevel.WRITE);
-        assertThat(userAccessLevels).contains(AccessLevel.OWNER);
-
+        assertThat(service.getUserTeams()).size().isEqualTo(2);
     }
 
 
     @Test
     public void shouldGetTeamsForUser() {
         String[] groups =
-                ("/" + uuid1 + "/TRO/2," +
-                        "/" + uuid1 + "/TRO/3," +
-                        "/" + uuid2 + "/MIN/3," +
-                        "/" + uuid3 + "/MIN/3," +
-                        "/" + uuid1 + "/MIN/5").split(",");
+                (uuid2 + "," +
+                        uuid3 + "," +
+                        uuid1).split(",");
 
         when(requestData.groupsArray()).thenReturn(groups);
         service = new UserPermissionsService(requestData);
-        Set<String> teams = service.getUserTeams();
-        assertThat(teams).contains("1c1e2f17-d5d9-4ff6-a023-6c40d76e1e9d");
-        assertThat(teams).contains("f1825c7d-baff-4c09-8056-2166760ccbd2");
-        assertThat(teams).contains("1325fe16-b864-42c7-85c2-7cab2863fe01");
-    }
-
-    @Test
-    public void shouldGetCaseTypesForUser() {
-        String[] groups =
-                ("/" + uuid1 + "/TRO/2," +
-                        "/" + uuid1 + "/TRO/3," +
-                        "/" + uuid2 + "/MIN/3," +
-                        "/" + uuid3 + "/MIN/3," +
-                        "/" + uuid1 + "/MIN/5").split(",");
-
-        when(requestData.groupsArray()).thenReturn(groups);
-        service = new UserPermissionsService(requestData);
-        Set<String> caseTypes = service.getUserCaseTypes();
-        assertThat(caseTypes.stream().anyMatch(c -> c.equals("TRO"))).isTrue();
-        assertThat(caseTypes.stream().anyMatch(c -> c.equals("MIN"))).isTrue();
+        Set<UUID> teams = service.getUserTeams();
+        assertThat(teams).size().isEqualTo(3);
+        assertThat(teams).contains(UUID.fromString("1c1e2f17-d5d9-4ff6-a023-6c40d76e1e9d"));
+        assertThat(teams).contains(UUID.fromString("f1825c7d-baff-4c09-8056-2166760ccbd2"));
+        assertThat(teams).contains(UUID.fromString("1325fe16-b864-42c7-85c2-7cab2863fe01"));
     }
 }


### PR DESCRIPTION
This changes the permissions model to only put the team UUID (case64 encoded) into Keycloak. The Permissions are now looked up on Info Service (cached locally).