### PR TITLE
Sort fields on schema by primary key id (to match insertion sequence).

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/Schema.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/Schema.java
@@ -50,6 +50,7 @@ public class Schema implements Serializable {
             joinColumns = @JoinColumn(name="schema_uuid", referencedColumnName="uuid"),
             inverseJoinColumns = @JoinColumn( name="field_uuid", referencedColumnName="uuid")
     )
+    @OrderBy("id")
     private List<Field> fields;
 
     public Schema(String type, String title, String actionLabel) {


### PR DESCRIPTION
Fix: sort fields on schema by primary key id (to match insertion sequence).