### PR TITLE
Add unique constraint to field_screen table.

### DIFF
--- a/src/main/resources/db/postgresql/V1_15__ADD_CONSTRAINT_TO_FIELD_SCREEN.sql
+++ b/src/main/resources/db/postgresql/V1_15__ADD_CONSTRAINT_TO_FIELD_SCREEN.sql
@@ -1,3 +1,9 @@
 ALTER TABLE field_screen
     ADD CONSTRAINT field_screen_unique_schema_field
-    UNIQUE (schema_uuid, field_uuid);
+    UNIQUE (schema_uuid,field_uuid);
+
+
+ALTER TABLE case_type_schema
+    ADD CONSTRAINT case_type_schema_unique_schema_case_stage
+    UNIQUE (schema_uuid,case_type,stage_type);
+

--- a/src/main/resources/db/postgresql/V1_15__ADD_CONSTRAINT_TO_FIELD_SCREEN.sql
+++ b/src/main/resources/db/postgresql/V1_15__ADD_CONSTRAINT_TO_FIELD_SCREEN.sql
@@ -1,0 +1,3 @@
+ALTER TABLE field_screen
+    ADD CONSTRAINT field_screen_unique_schema_field
+    UNIQUE (schema_uuid, field_uuid);


### PR DESCRIPTION
Add unique constraint to field_screen table to prevent duplicates, e.g. when repeatedly running the insertion scripts.