### PR TITLE
null MEP were causing the member refresh to crash.

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/client/ingest/ListConsumerService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/client/ingest/ListConsumerService.java
@@ -58,8 +58,12 @@ public class ListConsumerService {
         log.info("Updating European Parliament");
         HouseAddress houseAddress = houseAddressRepository.findByHouseCode("EU");
         EuropeMembers europeMembers = getDataFromAPI(apiEuropeanParliament, MediaType.APPLICATION_XML, EuropeMembers.class);
-        return europeMembers.getMembers().stream().map(m -> new Member(House.HOUSE_EUROPEAN_PARLIAMENT.getDisplayValue(), m.getName()+" MEP", houseAddress.getUuid(),"EU"+m.getId())).collect(Collectors.toSet());
-    }
+        if(europeMembers != null && europeMembers.getMembers() != null){
+            return europeMembers.getMembers().stream().map(m -> new Member(House.HOUSE_EUROPEAN_PARLIAMENT.getDisplayValue(), m.getName()+" MEP", houseAddress.getUuid(),"EU"+m.getId())).collect(Collectors.toSet());
+
+        }
+        return Set.of();
+     }
 
     public Set<Member> createFromIrishAssemblyAPI() {
         log.info("Updating Irish Assembly");


### PR DESCRIPTION
We do not notice the crash as MEP's were the last group to be fetched anyway.