### PR TITLE
HOCS-1836: fix for issue when loading completed DCU cases.

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/UserService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/UserService.java
@@ -21,11 +21,13 @@ public class UserService {
 
     private KeycloakService keycloakService;
     private CaseworkClient caseworkClient;
+    private StageTypeService stageTypeService;
 
     @Autowired
-    public UserService(KeycloakService keycloakService, CaseworkClient caseworkClient) {
+    public UserService(KeycloakService keycloakService, CaseworkClient caseworkClient, StageTypeService stageTypeService) {
         this.keycloakService = keycloakService;
         this.caseworkClient = caseworkClient;
+        this.stageTypeService = stageTypeService;
     }
 
     @Cacheable("users")
@@ -56,7 +58,8 @@ public class UserService {
     }
 
     public List<UserDto> getUsersForTeamByStage(UUID caseUUID, UUID stageUUID) {
-        UUID teamUUID = caseworkClient.getStageTeam(caseUUID, stageUUID);
+        String stageType = caseworkClient.getStageTypeFromStage(caseUUID, stageUUID);
+        UUID teamUUID = stageTypeService.getTeamForStageType(stageType).getUuid();
         return getUsersForTeam(teamUUID);
     }
 

--- a/src/main/java/uk/gov/digital/ho/hocs/info/client/caseworkclient/CaseworkClient.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/client/caseworkclient/CaseworkClient.java
@@ -41,14 +41,14 @@ public class CaseworkClient {
         }
     }
 
-    public UUID getStageTeam(UUID caseUUID, UUID stageUUID) {
-        ResponseEntity<UUID> response = restHelper.get(serviceBaseURL, String.format("/case/%s/stage/%s/team", caseUUID, stageUUID), UUID.class);
+    public String getStageTypeFromStage(UUID caseUUID, UUID stageUUID) {
+        ResponseEntity<String> response = restHelper.get(serviceBaseURL, String.format("/case/%s/stage/%s/type", caseUUID, stageUUID), String.class);
 
         if (response.getStatusCodeValue() == 200) {
-            log.info("Got Team for stage: {}", stageUUID);
+            log.info("Got Type for stage: {}", stageUUID);
             return response.getBody();
         } else {
-            throw new ApplicationExceptions.EntityNotFoundException("Could not get Team for stage %s; response: %s", stageUUID, response.getStatusCodeValue());
+            throw new ApplicationExceptions.EntityNotFoundException("Could not get Type for stage %s; response: %s", stageUUID, response.getStatusCodeValue());
         }
     }
 


### PR DESCRIPTION
Use stage_type.acting_team_uuid to get team UUID instead of stage_data.team_uuid. This is because stage_data.team_uuid is often empty, whereas stage_type.acting_team_uuid is not. 