### PR TITLE
HOCS-1848 : prevent stage_type.display_stage_order column null values

### DIFF
--- a/src/main/resources/db/postgresql/V1_42__ALTER_TABLE_STAGE_TYPE.sql
+++ b/src/main/resources/db/postgresql/V1_42__ALTER_TABLE_STAGE_TYPE.sql
@@ -1,0 +1,2 @@
+--HOCS-1848
+ALTER TABLE stage_type ALTER COLUMN display_stage_order SET NOT NULL;


### PR DESCRIPTION
Null values in stage_type.display_stage_order column are making the service error.