### PR TITLE
HOCS-1758 - UKVI Campaign - Add New

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/entity/EntityRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/entity/EntityRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 @Repository
@@ -27,5 +28,10 @@ public interface EntityRepository extends CrudRepository<Entity, Long> {
             " and e.active = TRUE" +
             " order by e.id", nativeQuery = true)
     List<Entity> findByEntityListSimpleName(String listSimpleName);
+
+    @Query(value = "select Cast(el.uuid as varchar) id from entity_list el where el.simple_name = ?1", nativeQuery = true)
+    String findEntityListUUIDBySimpleName(String listSimpleName);
+
+    Optional<Entity> findBySimpleName(String simpleName);
 
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/entity/EntityResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/entity/EntityResource.java
@@ -4,9 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import uk.gov.digital.ho.hocs.info.domain.entity.dto.EntityDto;
 import uk.gov.digital.ho.hocs.info.domain.entity.dto.GetCaseSummaryFieldsResponse;
 
@@ -34,10 +32,16 @@ class EntityResource {
     }
 
     @GetMapping(value = "/entity/list/{name}", produces = APPLICATION_JSON_UTF8_VALUE)
-    @Cacheable(value = "getEntitiesForListName", unless = "#result == null", key = "#name")
+    @Cacheable(value = "getEntitiesForListName", unless = "#result == null || #name == 'MPAM_CAMPAIGNS'", key = "#name")
     public ResponseEntity<List<EntityDto>> getEntitiesForListName(@PathVariable String name) {
         List<Entity> entities = entityService.getByEntityListName(name);
         return ResponseEntity.ok(entities.stream().map(EntityDto::from).collect(Collectors.toList()));
+    }
+
+    @PostMapping(value = "/entity/list/{listName}", produces = APPLICATION_JSON_UTF8_VALUE)
+    public ResponseEntity createEntity(@PathVariable String listName, @RequestBody EntityDto entityDto) {
+        entityService.createEntity(listName, entityDto);
+        return ResponseEntity.ok().build();
     }
 
 

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/entity/EntityService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/entity/EntityService.java
@@ -3,10 +3,13 @@ package uk.gov.digital.ho.hocs.info.domain.entity;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import uk.gov.digital.ho.hocs.info.domain.entity.dto.EntityDto;
 import uk.gov.digital.ho.hocs.info.domain.exception.ApplicationExceptions;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 
 @Service
 @Slf4j
@@ -33,5 +36,25 @@ public class EntityService {
         } else {
             throw new ApplicationExceptions.EntityNotFoundException("listName was null!");
         }
+    }
+
+    public void createEntity(String listName, EntityDto entityDto) {
+
+        Optional<Entity> existingEntity = entityRepository.findBySimpleName(entityDto.getSimpleName());
+
+        if (existingEntity.isPresent()) {
+            throw new ApplicationExceptions.EntityAlreadyExistsException("entity with this simple name already exists!");
+        }
+
+        String entityListUUID = entityRepository.findEntityListUUIDBySimpleName(listName);
+
+        if (entityListUUID == null) {
+            throw new ApplicationExceptions.EntityNotFoundException("EntityList not found for: %s ", listName);
+        }
+
+        Entity newEntity = new Entity(null, UUID.randomUUID(), entityDto.getSimpleName(), entityDto.getData(), UUID.fromString(entityListUUID), true);
+
+        entityRepository.save(newEntity);
+
     }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/entity/dto/EntityDto.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/entity/dto/EntityDto.java
@@ -13,11 +13,12 @@ import uk.gov.digital.ho.hocs.info.domain.entity.Entity;
 public class EntityDto {
 
     private String simpleName;
+    private String uuid;
     @JsonRawValue
     private String data;
 
     public static EntityDto from(Entity entity) {
-        return new EntityDto(entity.getSimpleName(), entity.getData());
+        return new EntityDto(entity.getSimpleName(), entity.getUuid() != null ? entity.getUuid().toString() : null, entity.getData());
     }
 
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/info/domain/entity/EntityResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/domain/entity/EntityResourceTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.digital.ho.hocs.info.domain.entity.dto.EntityDto;
 import uk.gov.digital.ho.hocs.info.domain.entity.dto.GetCaseSummaryFieldsResponse;
@@ -75,6 +76,22 @@ public class EntityResourceTest {
         assertThat(result.getBody().get(1).getData()).isEqualTo(data2);
 
         verify(entityService).getByEntityListName(listName);
+        verifyNoMoreInteractions(entityService);
+    }
+
+    @Test
+    public void createEntity() {
+        String listName = "L1";
+        String simpleName = "name";
+        String uuid = UUID.randomUUID().toString();
+        String data = "data";
+        EntityDto entityDto = new EntityDto(simpleName, uuid, data);
+
+        ResponseEntity<String> response = entityResource.createEntity(listName, entityDto);
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        verify(entityService).createEntity(listName, entityDto);
         verifyNoMoreInteractions(entityService);
     }
 

--- a/src/test/java/uk/gov/digital/ho/hocs/info/domain/entity/EntityServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/domain/entity/EntityServiceTest.java
@@ -3,11 +3,14 @@ package uk.gov.digital.ho.hocs.info.domain.entity;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.digital.ho.hocs.info.domain.entity.dto.EntityDto;
 import uk.gov.digital.ho.hocs.info.domain.exception.ApplicationExceptions;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -105,6 +108,65 @@ public class EntityServiceTest {
     public void getByEntityListName_nullList() {
         entityService.getByEntityListName(null);
         verifyNoMoreInteractions(entityRepository);
+    }
+
+
+    @Test
+    public void createEntity() {
+        String listName = "L1";
+        String simpleName = "name";
+        String uuid = UUID.randomUUID().toString();
+        String listUUID = UUID.randomUUID().toString();
+        String data = "data";
+        EntityDto entityDto = new EntityDto(simpleName, uuid, data);
+        ArgumentCaptor<Entity> argumentCaptor = ArgumentCaptor.forClass(Entity.class);
+
+        when(entityRepository.findBySimpleName(simpleName)).thenReturn(Optional.empty());
+        when(entityRepository.findEntityListUUIDBySimpleName(listName)).thenReturn(listUUID);
+
+        entityService.createEntity(listName, entityDto);
+
+        verify(entityRepository).save(argumentCaptor.capture());
+        verify(entityRepository).findBySimpleName(simpleName);
+        verify(entityRepository).findEntityListUUIDBySimpleName(listName);
+        verifyNoMoreInteractions(entityRepository);
+
+        Entity capturedEntity = argumentCaptor.getValue();
+        assertThat(capturedEntity).isNotNull();
+        assertThat(capturedEntity.getSimpleName()).isEqualTo(simpleName);
+        assertThat(capturedEntity.getData()).isEqualTo(data);
+        assertThat(capturedEntity.isActive()).isTrue();
+
+
+    }
+
+    @Test(expected = ApplicationExceptions.EntityAlreadyExistsException.class)
+    public void createEntity_duplicate() {
+        String listName = "L1";
+        String simpleName = "name";
+        String uuid = UUID.randomUUID().toString();
+        String data = "data";
+        EntityDto entityDto = new EntityDto(simpleName, uuid, data);
+
+        when(entityRepository.findBySimpleName(simpleName)).thenReturn(Optional.of(new Entity()));
+
+        entityService.createEntity(listName, entityDto);
+
+    }
+
+    @Test(expected = ApplicationExceptions.EntityNotFoundException.class)
+    public void createEntity_listNotFound() {
+        String listName = "L1";
+        String simpleName = "name";
+        String uuid = UUID.randomUUID().toString();
+        String data = "data";
+        EntityDto entityDto = new EntityDto(simpleName, uuid, data);
+
+        when(entityRepository.findBySimpleName(simpleName)).thenReturn(Optional.empty());
+        when(entityRepository.findEntityListUUIDBySimpleName(listName)).thenReturn(null);
+
+        entityService.createEntity(listName, entityDto);
+
     }
 
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/info/domain/entity/dto/EntityDtoTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/domain/entity/dto/EntityDtoTest.java
@@ -13,13 +13,15 @@ public class EntityDtoTest {
     public void from() {
 
         String simpleName = "name123";
+        UUID uuid = UUID.randomUUID();
         String data = "{ title: 'Title 321' }";
-        Entity entity = new Entity(1L, UUID.randomUUID(), simpleName, data, UUID.randomUUID(), true);
+        Entity entity = new Entity(1L, uuid, simpleName, data, UUID.randomUUID(), true);
 
         EntityDto entityDto = EntityDto.from(entity);
 
         assertThat(entityDto.getSimpleName()).isEqualTo(simpleName);
         assertThat(entityDto.getData()).isEqualTo(data);
+        assertThat(entityDto.getUuid()).isEqualTo(uuid.toString());
 
     }
 }


### PR DESCRIPTION
- excluded 'MPAM_CAMPAIGNS' entity list from cache
- added ability to add new items to entity lists (new endpoint and
service implementation)
- EntityDto now also includes UUID, it will be required for editing.