### PR TITLE
HOCS-1855 - Standard Lines - Management

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/StandardLineResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/StandardLineResource.java
@@ -5,8 +5,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import uk.gov.digital.ho.hocs.info.api.dto.CreateStandardLineDocumentDto;
 import uk.gov.digital.ho.hocs.info.api.dto.GetStandardLineResponse;
+import uk.gov.digital.ho.hocs.info.api.dto.UpdateStandardLineDto;
 import uk.gov.digital.ho.hocs.info.domain.model.StandardLine;
 
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -29,15 +31,49 @@ public class StandardLineResource {
         return ResponseEntity.ok(standardLines.stream().map(GetStandardLineResponse::from).collect(Collectors.toSet()));
     }
 
+    @GetMapping(value = "/standardLine/{standardLineUuid}", produces = APPLICATION_JSON_UTF8_VALUE)
+    public ResponseEntity<GetStandardLineResponse> getStandardLine(@PathVariable UUID standardLineUuid) {
+        StandardLine standardLine = standardLineService.getStandardLine(standardLineUuid);
+
+        if (standardLine != null) {
+            return ResponseEntity.ok(GetStandardLineResponse.from(standardLine));
+        }
+        return ResponseEntity.notFound().build();
+    }
+
     @GetMapping(value = "/topic/{topicUUID}/standardLine", produces = APPLICATION_JSON_UTF8_VALUE)
     public ResponseEntity<GetStandardLineResponse> getStandardLinesForPrimaryTopic(@PathVariable UUID topicUUID) {
         StandardLine standardLine = standardLineService.getStandardLineForTopic(topicUUID);
         return ResponseEntity.ok(GetStandardLineResponse.from(standardLine));
     }
 
+    @GetMapping(value = "/standardLine/all", produces = APPLICATION_JSON_UTF8_VALUE)
+    public ResponseEntity<List<GetStandardLineResponse>> getAllStandardLines() {
+        List<StandardLine> standardLines = standardLineService.getAllStandardLines();
+        return ResponseEntity.ok(standardLines.stream().map(GetStandardLineResponse::from).collect(Collectors.toList()));
+    }
+
     @PostMapping(value = "/standardLine", produces = APPLICATION_JSON_UTF8_VALUE)
-    public ResponseEntity createDocument(@RequestBody CreateStandardLineDocumentDto request) {
+    public ResponseEntity createStandardLine(@RequestBody CreateStandardLineDocumentDto request) {
         standardLineService.createStandardLine(request.getDisplayName(), request.getTopicUUID(), request.getExpires(), request.getS3UntrustedUrl());
+        return ResponseEntity.ok().build();
+    }
+
+    @PutMapping(value = "/standardLine/{standardLineUuid}", produces = APPLICATION_JSON_UTF8_VALUE)
+    public ResponseEntity updateStandardLine(@PathVariable UUID standardLineUuid, @RequestBody UpdateStandardLineDto request) {
+        standardLineService.updateStandardLine(standardLineUuid, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PutMapping(value = "/standardLine/expire/{standardLineUuid}", produces = APPLICATION_JSON_UTF8_VALUE)
+    public ResponseEntity expireStandardLine(@PathVariable UUID standardLineUuid) {
+        standardLineService.expireStandardLine(standardLineUuid);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping(value = "/standardLine/delete/{standardLineUuid}", produces = APPLICATION_JSON_UTF8_VALUE)
+    public ResponseEntity deleteStandardLine(@PathVariable UUID standardLineUuid) {
+        standardLineService.deleteStandardLine(standardLineUuid);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/UpdateStandardLineDto.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/UpdateStandardLineDto.java
@@ -1,0 +1,20 @@
+package uk.gov.digital.ho.hocs.info.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class UpdateStandardLineDto {
+
+    @JsonProperty("displayName")
+    private String displayName;
+
+    @JsonProperty("expires")
+    private LocalDate expires;
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/StandardLine.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/StandardLine.java
@@ -3,10 +3,13 @@ package uk.gov.digital.ho.hocs.info.domain.model;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.util.StringUtils;
+import uk.gov.digital.ho.hocs.info.api.dto.UpdateStandardLineDto;
 
 import javax.persistence.*;
 import java.io.Serializable;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.UUID;
 
 @Entity
@@ -40,7 +43,7 @@ public class StandardLine implements Serializable {
     @Column(name = "expires")
     private LocalDateTime expires;
 
-    public StandardLine(String displayName, UUID topicUUID, LocalDateTime expires){
+    public StandardLine(String displayName, UUID topicUUID, LocalDateTime expires) {
         this.uuid = UUID.randomUUID();
         this.displayName = displayName;
         this.topicUUID = topicUUID;
@@ -49,5 +52,15 @@ public class StandardLine implements Serializable {
 
     public void expire() {
         this.expires = LocalDateTime.now();
+    }
+
+    public void update(UpdateStandardLineDto request) {
+        if (StringUtils.hasText(request.getDisplayName())) {
+            this.displayName = request.getDisplayName();
+        }
+
+        if (request.getExpires() != null) {
+            this.expires = LocalDateTime.of(request.getExpires(), LocalTime.MAX.minusHours(1));
+        }
     }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/StandardLineRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/StandardLineRepository.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Repository;
 import uk.gov.digital.ho.hocs.info.domain.model.StandardLine;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -17,4 +18,9 @@ public interface StandardLineRepository extends CrudRepository<StandardLine, Str
 
     @Query(value = "SELECT sl.* FROM standard_line sl WHERE sl.expires > ?1", nativeQuery = true)
     Set<StandardLine> findStandardLinesByExpires(LocalDateTime currentDate);
+
+    @Query(value = "SELECT sl.* FROM standard_line sl, topic t where sl.topic_uuid = t.uuid order by t.display_name, sl.display_name ", nativeQuery = true)
+    List<StandardLine> findAllStandardLines();
+
+    StandardLine findByUuid(UUID uuid);
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/StandardLineResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/StandardLineResourceTest.java
@@ -11,8 +11,12 @@ import uk.gov.digital.ho.hocs.info.api.StandardLineResource;
 import uk.gov.digital.ho.hocs.info.api.StandardLineService;
 import uk.gov.digital.ho.hocs.info.api.dto.CreateStandardLineDocumentDto;
 import uk.gov.digital.ho.hocs.info.api.dto.GetStandardLineResponse;
+import uk.gov.digital.ho.hocs.info.api.dto.UpdateStandardLineDto;
 import uk.gov.digital.ho.hocs.info.domain.model.StandardLine;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -27,7 +31,8 @@ public class StandardLineResourceTest {
 
     private StandardLineResource standardLineResource;
 
-    UUID uuid = UUID.randomUUID();
+    private UUID uuid = UUID.randomUUID();
+    private UUID standardLineUUID = UUID.randomUUID();
 
     @Before
     public void setUp() {
@@ -41,7 +46,7 @@ public class StandardLineResourceTest {
 
         ResponseEntity<Set<GetStandardLineResponse>> response = standardLineResource.getStandardLines();
 
-        verify(standardLineService, times(1)).getActiveStandardLines();
+        verify(standardLineService).getActiveStandardLines();
         verifyNoMoreInteractions(standardLineService);
         assertThat(response).isNotNull();
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -55,7 +60,7 @@ public class StandardLineResourceTest {
         ResponseEntity<GetStandardLineResponse> response =
                 standardLineResource.getStandardLinesForPrimaryTopic(uuid);
 
-        verify(standardLineService, times(1)).getStandardLineForTopic(uuid);
+        verify(standardLineService).getStandardLineForTopic(uuid);
         verifyNoMoreInteractions(standardLineService);
         assertThat(response).isNotNull();
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -66,9 +71,82 @@ public class StandardLineResourceTest {
         CreateStandardLineDocumentDto standardLineDocumentDto = new CreateStandardLineDocumentDto();
 
         ResponseEntity response =
-                standardLineResource.createDocument(standardLineDocumentDto);
+                standardLineResource.createStandardLine(standardLineDocumentDto);
 
-        verify(standardLineService, times(1)).createStandardLine(standardLineDocumentDto.getDisplayName(), standardLineDocumentDto.getTopicUUID(), standardLineDocumentDto.getExpires(), standardLineDocumentDto.getS3UntrustedUrl());
+        verify(standardLineService).createStandardLine(standardLineDocumentDto.getDisplayName(), standardLineDocumentDto.getTopicUUID(), standardLineDocumentDto.getExpires(), standardLineDocumentDto.getS3UntrustedUrl());
+        verifyNoMoreInteractions(standardLineService);
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    public void getStandardLine(){
+        when(standardLineService.getStandardLine(standardLineUUID)).thenReturn(new StandardLine("DisplayName", uuid, LocalDateTime.now()));
+
+        ResponseEntity<GetStandardLineResponse> response = standardLineResource.getStandardLine(standardLineUUID);
+        verify(standardLineService).getStandardLine(standardLineUUID);
+        verifyNoMoreInteractions(standardLineService);
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getDisplayName()).isEqualTo("DisplayName");
+        assertThat(response.getBody().getTopicUUID()).isEqualTo(uuid);
+    }
+
+    @Test
+    public void getStandardLine_lineNotFound(){
+
+        ResponseEntity<GetStandardLineResponse> response = standardLineResource.getStandardLine(standardLineUUID);
+        verify(standardLineService).getStandardLine(standardLineUUID);
+        verifyNoMoreInteractions(standardLineService);
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getBody()).isNull();
+    }
+
+    @Test
+    public void getAllStandardLines(){
+        List<StandardLine> standardLines = List.of(new StandardLine("DisplayName", uuid, LocalDateTime.now()));
+
+        when(standardLineService.getAllStandardLines()).thenReturn(standardLines);
+
+        ResponseEntity<List<GetStandardLineResponse>> response = standardLineResource.getAllStandardLines();
+        verify(standardLineService).getAllStandardLines();
+        verifyNoMoreInteractions(standardLineService);
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().size()).isEqualTo(1);
+        assertThat(response.getBody().get(0).getDisplayName()).isEqualTo("DisplayName");
+        assertThat(response.getBody().get(0).getTopicUUID()).isEqualTo(uuid);
+    }
+
+    @Test
+    public void updateStandardLine(){
+        UpdateStandardLineDto updateStandardLineDto = new UpdateStandardLineDto("NewDisplayName", LocalDate.now().plusDays(10));
+        ResponseEntity response = standardLineResource.updateStandardLine(standardLineUUID, updateStandardLineDto);
+
+        verify(standardLineService).updateStandardLine(standardLineUUID, updateStandardLineDto);
+        verifyNoMoreInteractions(standardLineService);
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    public void expireStandardLine(){
+        ResponseEntity response = standardLineResource.expireStandardLine(standardLineUUID);
+
+        verify(standardLineService).expireStandardLine(standardLineUUID);
+        verifyNoMoreInteractions(standardLineService);
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    public void deleteStandardLine(){
+        ResponseEntity response = standardLineResource.deleteStandardLine(standardLineUUID);
+
+        verify(standardLineService).deleteStandardLine(standardLineUUID);
         verifyNoMoreInteractions(standardLineService);
         assertThat(response).isNotNull();
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);


### PR DESCRIPTION
-added endpoint for fetching single standard line info
-added endpoint for fetching all standard lines
-renamed incorrectly named method (createDocument)
-added endpoint to update standard line (covers expiryDate and
displayName)
-added endpoint to expire standard line
-added endpoint to delete standard line
-added workaround to fix localdatetime bug (end of day - 1 hour) -
this needs more looking into as the solution is less than perfect.