### PR TITLE
HOCS-2008 - Standard Lines Management - Improvements

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/TeamResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/TeamResource.java
@@ -2,11 +2,9 @@ package uk.gov.digital.ho.hocs.info.api;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import uk.gov.digital.ho.hocs.info.api.data.SimpleMapItem;
 import uk.gov.digital.ho.hocs.info.api.dto.*;
 import uk.gov.digital.ho.hocs.info.domain.model.Team;
 
-import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -121,11 +119,6 @@ public class TeamResource {
     public ResponseEntity<TeamDto> getActiveTeams(@PathVariable UUID caseUUID, @PathVariable UUID topicUUID, @PathVariable String stageType) {
         Team team = teamService.getTeamByTopicAndStage(caseUUID, topicUUID, stageType);
         return ResponseEntity.ok(TeamDto.from(team));
-    }
-
-    @GetMapping(value = "/team/topic/stage/{stageType}")
-    public ResponseEntity<List<SimpleMapItem>> getTopicToTeamMappingByStageType(@PathVariable String stageType) {
-        return ResponseEntity.ok(teamService.getTopicToTeamMappingByStageType(stageType));
     }
 
     @GetMapping(value = "/teams/topic/{topicUUID}")

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/TeamResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/TeamResource.java
@@ -2,9 +2,11 @@ package uk.gov.digital.ho.hocs.info.api;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import uk.gov.digital.ho.hocs.info.api.data.SimpleMapItem;
 import uk.gov.digital.ho.hocs.info.api.dto.*;
 import uk.gov.digital.ho.hocs.info.domain.model.Team;
 
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -25,7 +27,7 @@ public class TeamResource {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping(value = "/unit/{unitUUID}/teams" )
+    @PostMapping(value = "/unit/{unitUUID}/teams")
     public ResponseEntity<TeamDto> createUpdateTeam(@PathVariable String unitUUID, @RequestBody TeamDto team) {
         Team createdTeam = teamService.createTeam(team, UUID.fromString(unitUUID));
         return ResponseEntity.ok(TeamDto.from(createdTeam));
@@ -57,7 +59,7 @@ public class TeamResource {
 
     @PutMapping(value = "/team/{teamUUID}/permissions")
     public ResponseEntity updateTeamPermissions(@PathVariable String teamUUID, @RequestBody UpdateTeamPermissionsRequest team) {
-        teamService.updateTeamPermissions(UUID.fromString(teamUUID),team.getPermissions());
+        teamService.updateTeamPermissions(UUID.fromString(teamUUID), team.getPermissions());
         return ResponseEntity.ok().build();
     }
 
@@ -119,6 +121,11 @@ public class TeamResource {
     public ResponseEntity<TeamDto> getActiveTeams(@PathVariable UUID caseUUID, @PathVariable UUID topicUUID, @PathVariable String stageType) {
         Team team = teamService.getTeamByTopicAndStage(caseUUID, topicUUID, stageType);
         return ResponseEntity.ok(TeamDto.from(team));
+    }
+
+    @GetMapping(value = "/team/topic/stage/{stageType}")
+    public ResponseEntity<List<SimpleMapItem>> getTopicToTeamMappingByStageType(@PathVariable String stageType) {
+        return ResponseEntity.ok(teamService.getTopicToTeamMappingByStageType(stageType));
     }
 
     @GetMapping(value = "/teams/topic/{topicUUID}")

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/TeamService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/TeamService.java
@@ -7,7 +7,6 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.digital.ho.hocs.info.api.dto.PermissionDto;
-import uk.gov.digital.ho.hocs.info.api.data.SimpleMapItem;
 import uk.gov.digital.ho.hocs.info.api.dto.TeamDeleteActiveParentTopicsDto;
 import uk.gov.digital.ho.hocs.info.api.dto.TeamDto;
 import uk.gov.digital.ho.hocs.info.client.audit.client.AuditClient;
@@ -131,10 +130,6 @@ public class TeamService {
         } else {
             throw new ApplicationExceptions.EntityNotFoundException("Team not found for Stage %s and Text %s", stageType, text);
         }
-    }
-
-    public List<SimpleMapItem> getTopicToTeamMappingByStageType(String stageType) {
-        return teamRepository.findTopicToTeamMappingByStageType(stageType);
     }
 
     @Transactional

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/TeamService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/TeamService.java
@@ -7,6 +7,7 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.digital.ho.hocs.info.api.dto.PermissionDto;
+import uk.gov.digital.ho.hocs.info.api.data.SimpleMapItem;
 import uk.gov.digital.ho.hocs.info.api.dto.TeamDeleteActiveParentTopicsDto;
 import uk.gov.digital.ho.hocs.info.api.dto.TeamDto;
 import uk.gov.digital.ho.hocs.info.client.audit.client.AuditClient;
@@ -37,7 +38,7 @@ public class TeamService {
     private AuditClient auditClient;
     private CaseworkClient caseworkClient;
 
-    public TeamService(TeamRepository teamRepository, UnitRepository unitRepository, CaseTypeService caseTypeService,ParentTopicRepository parentTopicRepository, KeycloakService keycloakService, AuditClient auditClient, CaseworkClient caseworkClient) {
+    public TeamService(TeamRepository teamRepository, UnitRepository unitRepository, CaseTypeService caseTypeService, ParentTopicRepository parentTopicRepository, KeycloakService keycloakService, AuditClient auditClient, CaseworkClient caseworkClient) {
         this.teamRepository = teamRepository;
         this.keycloakService = keycloakService;
         this.unitRepository = unitRepository;
@@ -72,7 +73,7 @@ public class TeamService {
     }
 
     public Set<Team> getAllActiveTeamsByUnitShortCode(String unitShortCode) {
-        log.debug("Getting all active Teams by Unit ShortCode {}", unitShortCode );
+        log.debug("Getting all active Teams by Unit ShortCode {}", unitShortCode);
         Set<Team> activeTeams = teamRepository.findAllByActiveTrueAndUnitShortCodeEquals(unitShortCode);
         log.info("Got {} active Teams by Unit ShortCode {}", activeTeams.size(), unitShortCode);
         return activeTeams;
@@ -96,7 +97,7 @@ public class TeamService {
         teamUUIDs.forEach(teamUUID -> {
             try {
                 teams.add(getTeam(teamUUID));
-            } catch (ApplicationExceptions.EntityNotFoundException e){
+            } catch (ApplicationExceptions.EntityNotFoundException e) {
                 log.error("Team not found for UUID {}", teamUUID);
             }
         });
@@ -130,6 +131,10 @@ public class TeamService {
         } else {
             throw new ApplicationExceptions.EntityNotFoundException("Team not found for Stage %s and Text %s", stageType, text);
         }
+    }
+
+    public List<SimpleMapItem> getTopicToTeamMappingByStageType(String stageType) {
+        return teamRepository.findTopicToTeamMappingByStageType(stageType);
     }
 
     @Transactional
@@ -216,7 +221,7 @@ public class TeamService {
     public void deleteTeam(UUID teamUUID) {
         log.debug("Deleting Team {}", teamUUID);
         List<ParentTopic> parentTopics = parentTopicRepository.findAllActiveParentTopicsForTeam(teamUUID);
-        if(parentTopics.isEmpty()) {
+        if (parentTopics.isEmpty()) {
             log.debug("No topics assigned to Team {}, safe to delete", teamUUID);
             Team team = getTeam(teamUUID);
             team.setActive(false);
@@ -258,8 +263,8 @@ public class TeamService {
         }
     }
 
-     Set<Team> findActiveTeamsByUnitUuid(UUID unitUUID) {
-         log.debug("Getting active teams for Unit {}", unitUUID);
-         return teamRepository.findActiveTeamsByUnitUuid(unitUUID);
+    Set<Team> findActiveTeamsByUnitUuid(UUID unitUUID) {
+        log.debug("Getting active teams for Unit {}", unitUUID);
+        return teamRepository.findActiveTeamsByUnitUuid(unitUUID);
     }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/TopicTeamResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/TopicTeamResource.java
@@ -4,9 +4,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import uk.gov.digital.ho.hocs.info.api.dto.*;
+import uk.gov.digital.ho.hocs.info.api.data.SimpleMapItem;
+import uk.gov.digital.ho.hocs.info.api.dto.AddTeamToTopicDto;
+import uk.gov.digital.ho.hocs.info.api.dto.TopicTeamDto;
 import uk.gov.digital.ho.hocs.info.domain.model.TopicTeam;
 
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -28,7 +31,7 @@ public class TopicTeamResource {
     public ResponseEntity<Set<TopicTeamDto>> getTopicsByCaseTypeWithTeams(@PathVariable String caseType) {
         log.info("requesting all topics by case type {} with teams", caseType);
         Set<TopicTeam> topicTeams = topicTeamService.getTopicsByCaseTypeWithTeams(caseType);
-        return ResponseEntity.ok(topicTeams.stream().map(t->TopicTeamDto.from(t)).collect(Collectors.toSet()));
+        return ResponseEntity.ok(topicTeams.stream().map(t -> TopicTeamDto.from(t)).collect(Collectors.toSet()));
     }
 
     @PostMapping(value = "/topic/{topicUUID}/team/{teamUUID}")
@@ -36,5 +39,10 @@ public class TopicTeamResource {
         log.info("Adding team () to topic {}", teamUUID, topicUUID);
         topicTeamService.addTeamToTopic(topicUUID, teamUUID, request);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping(value = "/team/topic/stage/{stageType}")
+    public ResponseEntity<List<SimpleMapItem>> getTopicToTeamMappingByStageType(@PathVariable String stageType) {
+        return ResponseEntity.ok(topicTeamService.getTopicToTeamMappingByStageType(stageType));
     }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/TopicTeamService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/TopicTeamService.java
@@ -3,6 +3,7 @@ package uk.gov.digital.ho.hocs.info.api;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import uk.gov.digital.ho.hocs.info.api.data.SimpleMapItem;
 import uk.gov.digital.ho.hocs.info.api.dto.AddTeamToTopicDto;
 import uk.gov.digital.ho.hocs.info.client.audit.client.AuditClient;
 import uk.gov.digital.ho.hocs.info.domain.exception.ApplicationExceptions;
@@ -70,7 +71,7 @@ public class TopicTeamService {
 
         validateTeamTopicStageAndCase(teamUUID, topicUUID, stageType, caseType);
         TeamLink teamLink = Optional.ofNullable(teamLinkRepository.findByLinkValueAndLinkTypeAndCaseTypeAndStageType(topicUUID.toString(), "TOPIC", caseType, stageType))
-                 .orElse(new TeamLink(topicUUID.toString(), "TOPIC", teamUUID, caseType, stageType));
+                .orElse(new TeamLink(topicUUID.toString(), "TOPIC", teamUUID, caseType, stageType));
         teamLink.setResponsibleTeamUUID(teamUUID);
         teamLinkRepository.save(teamLink);
         log.info("Added team: {} to topic: {}", teamUUID, topicUUID);
@@ -78,18 +79,23 @@ public class TopicTeamService {
 
     }
 
-    private void validateTeamTopicStageAndCase(UUID teamUUID, UUID topicUUID, String stageType, String caseType){
+    public List<SimpleMapItem> getTopicToTeamMappingByStageType(String stageType) {
+        return teamRepository.findTopicToTeamMappingByStageType(stageType);
+    }
+
+    private void validateTeamTopicStageAndCase(UUID teamUUID, UUID topicUUID, String stageType, String caseType) {
         validateTopicUUID(topicUUID);
         validateStageType(stageType);
         validateCaseType(caseType);
         validateTeamUUID(teamUUID);
     }
 
-    private void validateTopicUUID(UUID topicUUID){
+    private void validateTopicUUID(UUID topicUUID) {
         Optional.ofNullable(topicService.getTopic(topicUUID))
                 .orElseThrow(() -> new ApplicationExceptions.TopicUpdateException
                         ("Unable to add team to topic, topic {} not found.", topicUUID));
     }
+
     private void validateStageType(String stageType) {
         Optional.ofNullable(stageTypeService.getStageType(stageType))
                 .orElseThrow(() -> new ApplicationExceptions.TopicUpdateException
@@ -102,11 +108,11 @@ public class TopicTeamService {
                         ("Unable to add team to topic, case type {} not found.", caseType));
     }
 
-    private void validateTeamUUID(UUID teamUUID){
+    private void validateTeamUUID(UUID teamUUID) {
         Team team = Optional.ofNullable(teamService.getTeam(teamUUID))
                 .orElseThrow(() -> new ApplicationExceptions.TopicUpdateException
                         ("Unable to add team to topic, topic already has team {} set for this stage and case type.", teamUUID));
-        if (!team.isActive()){
+        if (!team.isActive()) {
             throw new ApplicationExceptions.TopicUpdateException("Unable to add team to topic, team {} is inactive.", teamUUID);
         }
     }

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/data/SimpleMapItem.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/data/SimpleMapItem.java
@@ -1,0 +1,9 @@
+package uk.gov.digital.ho.hocs.info.api.data;
+
+public interface SimpleMapItem {
+
+    String getValue();
+
+    String getLabel();
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/TeamRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/TeamRepository.java
@@ -4,8 +4,10 @@ package uk.gov.digital.ho.hocs.info.domain.repository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
+import uk.gov.digital.ho.hocs.info.api.data.SimpleMapItem;
 import uk.gov.digital.ho.hocs.info.domain.model.Team;
 
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -23,6 +25,9 @@ public interface TeamRepository extends CrudRepository<Team, Long> {
 
     @Query(value = "SELECT t.* FROM team t JOIN team_link tl on tl.responsible_team_uuid = t.uuid WHERE tl.link_value = cast(?1 as text) and tl.link_type = 'TOPIC' and tl.stage_type = ?2", nativeQuery = true)
     Team findByTopicAndStage(UUID topicUUID, String stageType);
+
+    @Query(value = "SELECT DISTINCT tl.link_value as value, t.display_name as label FROM team t JOIN team_link tl on tl.responsible_team_uuid = t.uuid WHERE tl.link_type = 'TOPIC' and tl.stage_type = ?1", nativeQuery = true)
+    List<SimpleMapItem> findTopicToTeamMappingByStageType(String stageType);
 
     @Query(value = "SELECT t.* FROM team t JOIN team_link tl on tl.responsible_team_uuid = t.uuid WHERE tl.stage_type = ?1 and tl.link_type = 'TEXT' and tl.link_value = ?2", nativeQuery = true)
     Team findByStageAndText(String stageType, String text);

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/TeamResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/TeamResourceTest.java
@@ -7,7 +7,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import uk.gov.digital.ho.hocs.info.api.data.SimpleMapItem;
 import uk.gov.digital.ho.hocs.info.api.dto.*;
 import uk.gov.digital.ho.hocs.info.domain.exception.ApplicationExceptions;
 import uk.gov.digital.ho.hocs.info.domain.model.Team;
@@ -15,7 +14,6 @@ import uk.gov.digital.ho.hocs.info.domain.model.Unit;
 import uk.gov.digital.ho.hocs.info.security.AccessLevel;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -300,21 +298,4 @@ public class TeamResourceTest {
         verifyNoMoreInteractions(teamService);
     }
 
-    @Test
-    public void getTopicToTeamMappingByStageType() {
-        String testStageString = "STAGE_321";
-
-        List<SimpleMapItem> mockItems = List.of(mock(SimpleMapItem.class), mock(SimpleMapItem.class));
-        when(teamService.getTopicToTeamMappingByStageType(testStageString)).thenReturn(mockItems);
-
-        ResponseEntity<List<SimpleMapItem>> response = teamResource.getTopicToTeamMappingByStageType(testStageString);
-
-        assertThat(response).isNotNull();
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody().size()).isEqualTo(2);
-
-        verify(teamService).getTopicToTeamMappingByStageType(testStageString);
-        verifyNoMoreInteractions(teamService);
-    }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/TeamResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/TeamResourceTest.java
@@ -7,7 +7,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
+import uk.gov.digital.ho.hocs.info.api.data.SimpleMapItem;
 import uk.gov.digital.ho.hocs.info.api.dto.*;
 import uk.gov.digital.ho.hocs.info.domain.exception.ApplicationExceptions;
 import uk.gov.digital.ho.hocs.info.domain.model.Team;
@@ -15,6 +15,7 @@ import uk.gov.digital.ho.hocs.info.domain.model.Unit;
 import uk.gov.digital.ho.hocs.info.security.AccessLevel;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -44,7 +45,7 @@ public class TeamResourceTest {
 
         ResponseEntity result = teamResource.addUserToGroup(userUUID.toString(), teamUUID.toString());
         assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
-        verify(teamService, times(1)).addUserToTeam(userUUID, teamUUID);
+        verify(teamService).addUserToTeam(userUUID, teamUUID);
         verifyNoMoreInteractions(teamService);
     }
 
@@ -53,7 +54,7 @@ public class TeamResourceTest {
         doNothing().when(teamService).deleteTeam(teamUUID);
         ResponseEntity result = teamResource.deleteTeam(teamUUID.toString());
         assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
-        verify(teamService, times(1)).deleteTeam(teamUUID);
+        verify(teamService).deleteTeam(teamUUID);
         verifyNoMoreInteractions(teamService);
     }
 
@@ -75,7 +76,7 @@ public class TeamResourceTest {
         ResponseEntity<Set<TeamDto>> result = teamResource.getTeamsForUnit(unitUUID.toString());
         assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(result.getBody().size()).isEqualTo(2);
-        verify(teamService, times(1)).getTeamsForUnit(unitUUID);
+        verify(teamService).getTeamsForUnit(unitUUID);
         verifyNoMoreInteractions(teamService);
     }
 
@@ -87,7 +88,7 @@ public class TeamResourceTest {
         ResponseEntity<Set<TeamDto>> result = teamResource.getTeamsForUser(userUUID.toString());
         assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(result.getBody().size()).isEqualTo(2);
-        verify(teamService, times(1)).getTeamsForUser(userUUID);
+        verify(teamService).getTeamsForUser(userUUID);
         verifyNoMoreInteractions(teamService);
     }
 
@@ -99,7 +100,7 @@ public class TeamResourceTest {
         ResponseEntity<Set<TeamDto>> result = teamResource.getActiveTeams();
         assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(result.getBody().size()).isEqualTo(2);
-        verify(teamService, times(1)).getAllActiveTeams();
+        verify(teamService).getAllActiveTeams();
         verifyNoMoreInteractions(teamService);
     }
 
@@ -112,7 +113,7 @@ public class TeamResourceTest {
         ResponseEntity<TeamDto> result = teamResource.getTeam(unitUUID.toString(), team.getUuid().toString());
         assertThat(result.getBody().getUuid()).isEqualTo(team.getUuid());
         assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
-        verify(teamService, times(1)).getTeam(team.getUuid());
+        verify(teamService).getTeam(team.getUuid());
         verifyNoMoreInteractions(teamService);
     }
 
@@ -123,7 +124,7 @@ public class TeamResourceTest {
         when(teamService.getTeam(teamUUID)).thenThrow(new ApplicationExceptions.EntityNotFoundException(""));
 
         teamResource.getTeam(unitUUID.toString(), teamUUID.toString());
-        verify(teamService, times(1)).getTeam(teamUUID);
+        verify(teamService).getTeam(teamUUID);
         verifyNoMoreInteractions(teamService);
     }
 
@@ -187,29 +188,29 @@ public class TeamResourceTest {
         ResponseEntity result = teamResource.createUpdateTeam(unitUUID.toString(), teamDto);
         assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
 
-        verify(teamService, times(1)).createTeam(teamDto, unitUUID);
+        verify(teamService).createTeam(teamDto, unitUUID);
         verifyNoMoreInteractions(teamService);
     }
 
     @Test
-    public void shouldUpdateTeamName(){
+    public void shouldUpdateTeamName() {
         UUID teamUUID = UUID.randomUUID();
         UpdateTeamNameRequest request = new UpdateTeamNameRequest("The Team");
         ResponseEntity result = teamResource.updateTeamName(teamUUID.toString(), request);
         assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
 
-        verify(teamService, times(1)).updateTeamName(teamUUID, request.getDisplayName());
+        verify(teamService).updateTeamName(teamUUID, request.getDisplayName());
         verifyNoMoreInteractions(teamService);
     }
 
     @Test
-    public void shouldUpdateTeamLetterName(){
+    public void shouldUpdateTeamLetterName() {
         UUID teamUUID = UUID.randomUUID();
         UpdateTeamLetterNameRequest request = new UpdateTeamLetterNameRequest("Bob");
         ResponseEntity result = teamResource.updateTeamLetterName(teamUUID.toString(), request);
         assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
 
-        verify(teamService, times(1)).updateTeamLetterName(teamUUID, request.getLetterName());
+        verify(teamService).updateTeamLetterName(teamUUID, request.getLetterName());
         verifyNoMoreInteractions(teamService);
     }
 
@@ -220,7 +221,7 @@ public class TeamResourceTest {
 
         ResponseEntity result = teamResource.addTeamToUnit(unitUUID.toString(), teamUUID.toString());
         assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
-        verify(teamService, times(1)).moveToNewUnit(unitUUID, teamUUID);
+        verify(teamService).moveToNewUnit(unitUUID, teamUUID);
         verifyNoMoreInteractions(teamService);
     }
 
@@ -235,7 +236,7 @@ public class TeamResourceTest {
 
         ResponseEntity result = teamResource.updateTeamPermissions(teamUUID.toString(), request);
         assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
-        verify(teamService, times(1)).updateTeamPermissions(teamUUID, permissionDtoSet);
+        verify(teamService).updateTeamPermissions(teamUUID, permissionDtoSet);
         verifyNoMoreInteractions(teamService);
     }
 
@@ -254,7 +255,7 @@ public class TeamResourceTest {
     }
 
     @Test
-    public void shouldGetActiveTeamsByLinkValue(){
+    public void shouldGetActiveTeamsByLinkValue() {
         Team team = new Team("Team1", true);
         when(teamService.getTeamByStageAndText("stageType", "text")).thenReturn(team);
 
@@ -277,7 +278,7 @@ public class TeamResourceTest {
 
         ResponseEntity result = teamResource.deleteTeamPermissions(teamUUID.toString(), request);
         assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
-        verify(teamService, times(1)).deleteTeamPermissions(teamUUID, permissionDtoSet);
+        verify(teamService).deleteTeamPermissions(teamUUID, permissionDtoSet);
         verifyNoMoreInteractions(teamService);
     }
 
@@ -289,15 +290,31 @@ public class TeamResourceTest {
     }
 
     @Test
-    public void shouldRemoveUserFromTeam()
-    {
+    public void shouldRemoveUserFromTeam() {
         UUID teamUUID = UUID.randomUUID();
         UUID userUUID = UUID.randomUUID();
 
-        doNothing().when(teamService).removeUserFromTeam(userUUID, teamUUID);
         ResponseEntity result = teamResource.removeUserFromTeam(userUUID.toString(), teamUUID.toString());
         assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
-        verify(teamService, times(1)).removeUserFromTeam(userUUID, teamUUID);
+        verify(teamService).removeUserFromTeam(userUUID, teamUUID);
+        verifyNoMoreInteractions(teamService);
+    }
+
+    @Test
+    public void getTopicToTeamMappingByStageType() {
+        String testStageString = "STAGE_321";
+
+        List<SimpleMapItem> mockItems = List.of(mock(SimpleMapItem.class), mock(SimpleMapItem.class));
+        when(teamService.getTopicToTeamMappingByStageType(testStageString)).thenReturn(mockItems);
+
+        ResponseEntity<List<SimpleMapItem>> response = teamResource.getTopicToTeamMappingByStageType(testStageString);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().size()).isEqualTo(2);
+
+        verify(teamService).getTopicToTeamMappingByStageType(testStageString);
         verifyNoMoreInteractions(teamService);
     }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/TeamServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/TeamServiceTest.java
@@ -6,7 +6,6 @@ import org.junit.runner.RunWith;
 import org.keycloak.admin.client.Keycloak;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.digital.ho.hocs.info.api.data.SimpleMapItem;
 import uk.gov.digital.ho.hocs.info.api.dto.PermissionDto;
 import uk.gov.digital.ho.hocs.info.api.dto.TeamDto;
 import uk.gov.digital.ho.hocs.info.client.audit.client.AuditClient;
@@ -580,20 +579,5 @@ public class TeamServiceTest {
         verifyZeroInteractions(auditClient);
     }
 
-    @Test
-    public void getTopicToTeamMappingByStageType() {
-        String testStageString = "STAGE_321";
-
-        List<SimpleMapItem> mockItems = List.of(mock(SimpleMapItem.class), mock(SimpleMapItem.class));
-        when(teamRepository.findTopicToTeamMappingByStageType(testStageString)).thenReturn(mockItems);
-
-        List<SimpleMapItem> results = teamService.getTopicToTeamMappingByStageType(testStageString);
-
-        assertThat(results).isNotNull();
-        assertThat(results.size()).isEqualTo(2);
-
-        verify(teamRepository).findTopicToTeamMappingByStageType(testStageString);
-        verifyNoMoreInteractions(teamRepository);
-    }
 
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/TeamServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/TeamServiceTest.java
@@ -6,6 +6,7 @@ import org.junit.runner.RunWith;
 import org.keycloak.admin.client.Keycloak;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.digital.ho.hocs.info.api.data.SimpleMapItem;
 import uk.gov.digital.ho.hocs.info.api.dto.PermissionDto;
 import uk.gov.digital.ho.hocs.info.api.dto.TeamDto;
 import uk.gov.digital.ho.hocs.info.client.audit.client.AuditClient;
@@ -66,7 +67,7 @@ public class TeamServiceTest {
                 caseworkClient);
     }
 
-    private UUID team1UUID =UUID.randomUUID();
+    private UUID team1UUID = UUID.randomUUID();
 
     @Test
     public void shouldGetAllTeams() {
@@ -90,7 +91,7 @@ public class TeamServiceTest {
 
     @Test
     public void shouldGetTeamById() {
-        Team team = new Team( "Team1", new HashSet<>());
+        Team team = new Team("Team1", new HashSet<>());
         when(teamRepository.findByUuid(team.getUuid())).thenReturn(team);
         teamService.getTeam(team.getUuid());
         verify(teamRepository, times(1)).findByUuid(team.getUuid());
@@ -132,9 +133,9 @@ public class TeamServiceTest {
     @Test
     public void shouldAddTeamToRepositoryAndKeycloak() {
 
-        Unit unit = new Unit("UNIT1", "UNIT1",true);
+        Unit unit = new Unit("UNIT1", "UNIT1", true);
 
-        TeamDto teamDto = new TeamDto( "Team1", new HashSet<>());
+        TeamDto teamDto = new TeamDto("Team1", new HashSet<>());
 
         when(teamRepository.findByUuid(any())).thenReturn(null);
         when(unitRepository.findByUuid(unit.getUuid())).thenReturn(unit);
@@ -155,7 +156,7 @@ public class TeamServiceTest {
         Unit unit = new Unit("UNIT1", "UNIT1", true);
         unit.addTeam(team);
 
-        TeamDto teamDto = new TeamDto( "Team1", null, team1UUID, true, new HashSet<>(), null);
+        TeamDto teamDto = new TeamDto("Team1", null, team1UUID, true, new HashSet<>(), null);
         when(unitRepository.findByUuid(unit.getUuid())).thenReturn(unit);
         when(teamRepository.findByUuid(team1UUID)).thenReturn(team);
 
@@ -168,7 +169,7 @@ public class TeamServiceTest {
 
     @Test
     public void shouldMarkTeamAsInactive() {
-        Team team = new Team( "Team1", true);
+        Team team = new Team("Team1", true);
         when(teamRepository.findByUuid(team1UUID)).thenReturn(team);
         assertThat(team.isActive()).isTrue();
         teamService.deleteTeam(team1UUID);
@@ -251,7 +252,7 @@ public class TeamServiceTest {
 
         Set<Permission> permissions = new HashSet<>();
         Unit unit = new Unit("a unit", "UNIT", true);
-        CaseType caseType = new CaseType(1L, UUID.randomUUID(), "MIN","a1", "MIN", UUID.randomUUID(), "DCU_MIN_DISPATCH", true, true);
+        CaseType caseType = new CaseType(1L, UUID.randomUUID(), "MIN", "a1", "MIN", UUID.randomUUID(), "DCU_MIN_DISPATCH", true, true);
         Permission permission = new Permission(AccessLevel.OWNER, null, caseType);
         permissions.add(permission);
         Team team = new Team("a team", true);
@@ -265,20 +266,20 @@ public class TeamServiceTest {
     }
 
     @Test
-    public void shouldRemoveUserWithNoCasesFromTeam(){
+    public void shouldRemoveUserWithNoCasesFromTeam() {
         Team team = new Team("a team", true);
         UUID userUUID = UUID.randomUUID();
         UUID teamUUID = UUID.randomUUID();
 
         when(caseworkClient.getCasesForUser(userUUID, teamUUID)).thenReturn(new HashSet<>());
 
-        teamService.removeUserFromTeam(userUUID,teamUUID);
+        teamService.removeUserFromTeam(userUUID, teamUUID);
         verify(keycloakService, times(1)).removeUserFromTeam(userUUID, teamUUID);
         verifyNoMoreInteractions(keycloakService);
     }
 
     @Test(expected = ApplicationExceptions.UserRemoveException.class)
-    public void shouldNotRemoveUserWithCasesFromTeam(){
+    public void shouldNotRemoveUserWithCasesFromTeam() {
         Team team = new Team("a team", true);
         UUID userUUID = UUID.randomUUID();
         UUID teamUUID = UUID.randomUUID();
@@ -299,7 +300,7 @@ public class TeamServiceTest {
         Team team = new Team("a team", true);
         team.setUnit(unit);
 
-        CaseType caseType = new CaseType(1L, UUID.randomUUID(), "MIN","a1", "MIN", UUID.randomUUID(), "DCU_MIN_DISPATCH", true, true);
+        CaseType caseType = new CaseType(1L, UUID.randomUUID(), "MIN", "a1", "MIN", UUID.randomUUID(), "DCU_MIN_DISPATCH", true, true);
 
         when(teamRepository.findByUuid(team.getUuid())).thenReturn(team);
         when(caseTypeService.getCaseType(any())).thenReturn(caseType);
@@ -324,7 +325,7 @@ public class TeamServiceTest {
         Unit unit = new Unit("a unit", "UNIT", true);
         Team team = new Team("a team", true);
         team.setUnit(unit);
-        CaseType caseType = new CaseType(1L,UUID.randomUUID(), "MIN","a1", "MIN", UUID.randomUUID(), "DCU_MIN_DISPATCH", true,true);
+        CaseType caseType = new CaseType(1L, UUID.randomUUID(), "MIN", "a1", "MIN", UUID.randomUUID(), "DCU_MIN_DISPATCH", true, true);
         permissions.add(new Permission(AccessLevel.READ, team, caseType));
         permissions.add(new Permission(AccessLevel.OWNER, team, caseType));
         team.addPermissions(permissions);
@@ -350,10 +351,10 @@ public class TeamServiceTest {
 
         UUID unitUUID = UUID.randomUUID();
         Set<Permission> permissions = new HashSet<>();
-        Unit unit = new Unit( "a unit", "UNIT", true);
+        Unit unit = new Unit("a unit", "UNIT", true);
         Team team = new Team("a team", true);
         team.setUnit(unit);
-        CaseType caseType = new CaseType(1L, UUID.randomUUID(), "MIN","a1", "MIN", UUID.randomUUID(), "DCU_MIN_DISPATCH", true, true);
+        CaseType caseType = new CaseType(1L, UUID.randomUUID(), "MIN", "a1", "MIN", UUID.randomUUID(), "DCU_MIN_DISPATCH", true, true);
         permissions.add(new Permission(AccessLevel.READ, team, caseType));
         permissions.add(new Permission(AccessLevel.OWNER, team, caseType));
         team.addPermissions(permissions);
@@ -376,7 +377,7 @@ public class TeamServiceTest {
     }
 
     @Test
-    public void ShouldDeleteTeamWhenNoActiveParentTopicsAreLinkedToIt(){
+    public void ShouldDeleteTeamWhenNoActiveParentTopicsAreLinkedToIt() {
         Team team = new Team("a team", true);
         when(parentTopicRepository.findAllActiveParentTopicsForTeam(team.getUuid())).thenReturn(new ArrayList<>());
         when(teamRepository.findByUuid(team.getUuid())).thenReturn(team);
@@ -392,7 +393,7 @@ public class TeamServiceTest {
     }
 
     @Test(expected = ApplicationExceptions.TeamDeleteException.class)
-    public void shouldThrowTeamDeleteExceptionWhenActiveParentTopicsAreLinkedToTeam(){
+    public void shouldThrowTeamDeleteExceptionWhenActiveParentTopicsAreLinkedToTeam() {
         List<ParentTopic> parentTopicsList = new ArrayList<>();
         parentTopicsList.add(new ParentTopic());
         when(parentTopicRepository.findAllActiveParentTopicsForTeam(team1UUID)).thenReturn(parentTopicsList);
@@ -400,11 +401,11 @@ public class TeamServiceTest {
     }
 
     @Test
-    public void ShouldAuditCreateTeam(){
+    public void ShouldAuditCreateTeam() {
 
-        Unit unit = new Unit("UNIT1", "UNIT1",true);
+        Unit unit = new Unit("UNIT1", "UNIT1", true);
 
-        TeamDto teamDto = new TeamDto( "Team1", new HashSet<>());
+        TeamDto teamDto = new TeamDto("Team1", new HashSet<>());
 
         when(unitRepository.findByUuid(unit.getUuid())).thenReturn(unit);
         teamService.createTeam(teamDto, unit.getUuid());
@@ -413,23 +414,23 @@ public class TeamServiceTest {
     }
 
     @Test
-    public void ShouldAuditUpdateTeamName(){
-        Team team = new Team( "Team1", true);
+    public void ShouldAuditUpdateTeamName() {
+        Team team = new Team("Team1", true);
 
         when(teamRepository.findByUuid(team.getUuid())).thenReturn(team);
-        teamService.updateTeamName(team.getUuid(),"" );
+        teamService.updateTeamName(team.getUuid(), "");
 
         verify(auditClient, times(1)).renameTeamAudit(team);
     }
 
 
     @Test
-    public void ShouldAuditAddUserToTeam(){
+    public void ShouldAuditAddUserToTeam() {
         UUID userUUID = UUID.randomUUID();
 
         Set<Permission> permissions = new HashSet<>();
         Unit unit = new Unit("a unit", "UNIT", true);
-        CaseType caseType = new CaseType(1L, UUID.randomUUID(), "MIN","a1", "MIN", UUID.randomUUID(), "DCU_MIN_DISPATCH", true, true);
+        CaseType caseType = new CaseType(1L, UUID.randomUUID(), "MIN", "a1", "MIN", UUID.randomUUID(), "DCU_MIN_DISPATCH", true, true);
         Permission permission = new Permission(AccessLevel.OWNER, null, caseType);
         permissions.add(permission);
         Team team = new Team("a team", true);
@@ -441,7 +442,7 @@ public class TeamServiceTest {
     }
 
     @Test
-    public void ShouldAuditMoveToNewUnit(){
+    public void ShouldAuditMoveToNewUnit() {
         UUID newUnitUUID = UUID.randomUUID();
         UUID oldUnitUUID = UUID.randomUUID();
 
@@ -460,17 +461,17 @@ public class TeamServiceTest {
 
         teamService.moveToNewUnit(newUnitUUID, team1UUID);
 
-        verify(auditClient, times(1)).moveToNewUnitAudit(team1UUID.toString(), "UNIT1" , "UNIT2");
+        verify(auditClient, times(1)).moveToNewUnitAudit(team1UUID.toString(), "UNIT1", "UNIT2");
 
     }
 
     @Test
-    public void ShouldAuditUpdateTeamPermissions(){
-        Unit unit = new Unit("a unit", "UNIT",true);
+    public void ShouldAuditUpdateTeamPermissions() {
+        Unit unit = new Unit("a unit", "UNIT", true);
         Team team = new Team("a team", true);
         team.setUnit(unit);
 
-        CaseType caseType = new CaseType(1L, UUID.randomUUID(), "MIN","a1", "MIN", UUID.randomUUID(), "DCU_MIN_DISPATCH", true, true);
+        CaseType caseType = new CaseType(1L, UUID.randomUUID(), "MIN", "a1", "MIN", UUID.randomUUID(), "DCU_MIN_DISPATCH", true, true);
 
         when(teamRepository.findByUuid(team.getUuid())).thenReturn(team);
         when(caseTypeService.getCaseType(any())).thenReturn(caseType);
@@ -486,13 +487,13 @@ public class TeamServiceTest {
     }
 
     @Test
-    public void ShouldAuditDeleteTeamPermissions(){
+    public void ShouldAuditDeleteTeamPermissions() {
         Set<Permission> permissions = new HashSet<>();
-        Unit unit = new Unit( "a unit", "UNIT", true);
+        Unit unit = new Unit("a unit", "UNIT", true);
         Team team = new Team("a team", true);
         team.addPermissions(permissions);
         team.setUnit(unit);
-        CaseType caseType = new CaseType(1L, UUID.randomUUID(), "MIN","a1", "MIN", UUID.randomUUID(), "DCU_MIN_DISPATCH", true, true);
+        CaseType caseType = new CaseType(1L, UUID.randomUUID(), "MIN", "a1", "MIN", UUID.randomUUID(), "DCU_MIN_DISPATCH", true, true);
         permissions.add(new Permission(AccessLevel.READ, team, caseType));
         permissions.add(new Permission(AccessLevel.OWNER, team, caseType));
 
@@ -509,7 +510,7 @@ public class TeamServiceTest {
     }
 
     @Test
-    public void ShouldAuditSuccessfulDeleteTeam(){
+    public void ShouldAuditSuccessfulDeleteTeam() {
         Team team = new Team("a team", true);
         when(parentTopicRepository.findAllActiveParentTopicsForTeam(team.getUuid())).thenReturn(new ArrayList<>());
         when(teamRepository.findByUuid(team.getUuid())).thenReturn(team);
@@ -523,7 +524,7 @@ public class TeamServiceTest {
     }
 
     @Test
-    public void shouldNotAuditWhenDeleteTeamThrowsException(){
+    public void shouldNotAuditWhenDeleteTeamThrowsException() {
         List<ParentTopic> parentTopicsList = new ArrayList<>();
         parentTopicsList.add(new ParentTopic());
         when(parentTopicRepository.findAllActiveParentTopicsForTeam(team1UUID)).thenReturn(parentTopicsList);
@@ -536,32 +537,32 @@ public class TeamServiceTest {
     }
 
     private List<Team> getTeams() {
-        CaseType caseType = new CaseType(1L,UUID.randomUUID(), "MIN","a1", "MIN", UUID.randomUUID(),"DCU_MIN_DISPATCH", true, true);
+        CaseType caseType = new CaseType(1L, UUID.randomUUID(), "MIN", "a1", "MIN", UUID.randomUUID(), "DCU_MIN_DISPATCH", true, true);
         Set<Permission> permissions = new HashSet<Permission>() {{
-            add(new Permission( AccessLevel.OWNER, null, caseType));
-            add(new Permission( AccessLevel.OWNER, null, caseType));
+            add(new Permission(AccessLevel.OWNER, null, caseType));
+            add(new Permission(AccessLevel.OWNER, null, caseType));
         }};
 
         return new ArrayList<Team>() {{
-            add(new Team("Team1",permissions));
-            add(new Team( "Team2", new HashSet<>()));
+            add(new Team("Team1", permissions));
+            add(new Team("Team2", new HashSet<>()));
         }};
     }
 
     @Test
-    public void shouldAuditSuccessfulRemoveUserFromTeam(){
+    public void shouldAuditSuccessfulRemoveUserFromTeam() {
         Team team = new Team("a team", true);
         UUID userUUID = UUID.randomUUID();
         UUID teamUUID = UUID.randomUUID();
 
         when(caseworkClient.getCasesForUser(userUUID, teamUUID)).thenReturn(new HashSet<>());
 
-        teamService.removeUserFromTeam(userUUID,teamUUID);
+        teamService.removeUserFromTeam(userUUID, teamUUID);
         verify(auditClient, times(1)).removeUserFromTeamAudit(userUUID, teamUUID);
     }
 
     @Test
-    public void shouldNotAuditWhenRemoveUserFromTeamThrowsException(){
+    public void shouldNotAuditWhenRemoveUserFromTeamThrowsException() {
         Team team = new Team("a team", true);
         UUID userUUID = UUID.randomUUID();
         UUID teamUUID = UUID.randomUUID();
@@ -577,6 +578,22 @@ public class TeamServiceTest {
         }
 
         verifyZeroInteractions(auditClient);
+    }
+
+    @Test
+    public void getTopicToTeamMappingByStageType() {
+        String testStageString = "STAGE_321";
+
+        List<SimpleMapItem> mockItems = List.of(mock(SimpleMapItem.class), mock(SimpleMapItem.class));
+        when(teamRepository.findTopicToTeamMappingByStageType(testStageString)).thenReturn(mockItems);
+
+        List<SimpleMapItem> results = teamService.getTopicToTeamMappingByStageType(testStageString);
+
+        assertThat(results).isNotNull();
+        assertThat(results.size()).isEqualTo(2);
+
+        verify(teamRepository).findTopicToTeamMappingByStageType(testStageString);
+        verifyNoMoreInteractions(teamRepository);
     }
 
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/TopicTeamResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/TopicTeamResourceTest.java
@@ -7,10 +7,12 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import uk.gov.digital.ho.hocs.info.api.data.SimpleMapItem;
 import uk.gov.digital.ho.hocs.info.api.dto.*;
 import uk.gov.digital.ho.hocs.info.domain.model.TopicTeam;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -49,8 +51,26 @@ public class TopicTeamResourceTest {
         UUID topicUUID = UUID.randomUUID();
 
         ResponseEntity response = topicTeamResource.addTeamToTopic(topicUUID, teamUUID, request);
-        verify(topicTeamService, times(1)).addTeamToTopic(topicUUID, teamUUID, request);
+        verify(topicTeamService).addTeamToTopic(topicUUID, teamUUID, request);
         verifyNoMoreInteractions(topicTeamService);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    public void getTopicToTeamMappingByStageType() {
+        String testStageString = "STAGE_321";
+
+        List<SimpleMapItem> mockItems = List.of(mock(SimpleMapItem.class), mock(SimpleMapItem.class));
+        when(topicTeamService.getTopicToTeamMappingByStageType(testStageString)).thenReturn(mockItems);
+
+        ResponseEntity<List<SimpleMapItem>> response = topicTeamResource.getTopicToTeamMappingByStageType(testStageString);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().size()).isEqualTo(2);
+
+        verify(topicTeamService).getTopicToTeamMappingByStageType(testStageString);
+        verifyNoMoreInteractions(topicTeamService);
     }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/TopicTeamServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/TopicTeamServiceTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.digital.ho.hocs.info.api.data.SimpleMapItem;
 import uk.gov.digital.ho.hocs.info.api.dto.AddTeamToTopicDto;
 import uk.gov.digital.ho.hocs.info.client.audit.client.AuditClient;
 import uk.gov.digital.ho.hocs.info.domain.exception.ApplicationExceptions;
@@ -13,7 +14,10 @@ import uk.gov.digital.ho.hocs.info.domain.repository.TeamLinkRepository;
 import uk.gov.digital.ho.hocs.info.domain.repository.TeamRepository;
 import uk.gov.digital.ho.hocs.info.domain.repository.TopicRepository;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -43,14 +47,14 @@ public class TopicTeamServiceTest {
 
     @Before
     public void setUp() {
-        this.topicTeamService = new TopicTeamService (teamLinkRepository,
-                     topicRepository,
-                     teamRepository,
-                     topicService,
-                     teamService,
-                     caseTypeService,
-                     stageTypeService,
-                     auditClient);
+        this.topicTeamService = new TopicTeamService(teamLinkRepository,
+                topicRepository,
+                teamRepository,
+                topicService,
+                teamService,
+                caseTypeService,
+                stageTypeService,
+                auditClient);
     }
 
     @Test
@@ -83,7 +87,7 @@ public class TopicTeamServiceTest {
 
     @Test
     public void shouldSuccessfullyAddTeamToTopic() {
-        AddTeamToTopicDto request = new AddTeamToTopicDto("MIN","DCU_MIN_MARKUP");
+        AddTeamToTopicDto request = new AddTeamToTopicDto("MIN", "DCU_MIN_MARKUP");
         UUID topicUUID = UUID.randomUUID();
         UUID teamUUID = UUID.randomUUID();
 
@@ -95,15 +99,15 @@ public class TopicTeamServiceTest {
         topicTeamService.addTeamToTopic(topicUUID, teamUUID, request);
 
 
-        verify(teamLinkRepository, times(1)).save(any());
-        verify(teamLinkRepository, times(1)).findByLinkValueAndLinkTypeAndCaseTypeAndStageType(any(), eq("TOPIC"), any(), any());
+        verify(teamLinkRepository).save(any());
+        verify(teamLinkRepository).findByLinkValueAndLinkTypeAndCaseTypeAndStageType(any(), eq("TOPIC"), any(), any());
         verifyNoMoreInteractions(teamLinkRepository);
     }
 
-    @Test (expected = ApplicationExceptions.TopicUpdateException.class)
+    @Test(expected = ApplicationExceptions.TopicUpdateException.class)
     public void shouldThrowExceptionWhenAddingNonExistentTeamToTopic() {
 
-        AddTeamToTopicDto request = new AddTeamToTopicDto("MIN","DCU_MIN_MARKUP");
+        AddTeamToTopicDto request = new AddTeamToTopicDto("MIN", "DCU_MIN_MARKUP");
         UUID topicUUID = UUID.randomUUID();
         UUID teamUUID = UUID.randomUUID();
         when(teamService.getTeam(teamUUID)).thenReturn(null);
@@ -117,7 +121,7 @@ public class TopicTeamServiceTest {
     @Test
     public void shouldNotAddTeamWhenAddingNonExistentTeamToTopic() {
 
-        AddTeamToTopicDto request = new AddTeamToTopicDto("MIN","DCU_MIN_MARKUP");
+        AddTeamToTopicDto request = new AddTeamToTopicDto("MIN", "DCU_MIN_MARKUP");
         UUID topicUUID = UUID.randomUUID();
         UUID teamUUID = UUID.randomUUID();
         when(teamService.getTeam(teamUUID)).thenReturn(null);
@@ -125,7 +129,8 @@ public class TopicTeamServiceTest {
         when(caseTypeService.getCaseType("MIN")).thenReturn(new CaseType());
         when(topicService.getTopic(topicUUID)).thenReturn(new Topic());
 
-        try { topicTeamService.addTeamToTopic(topicUUID, teamUUID, request);
+        try {
+            topicTeamService.addTeamToTopic(topicUUID, teamUUID, request);
         } catch (ApplicationExceptions.TopicUpdateException e) {
             // Do nothing.
         }
@@ -133,10 +138,10 @@ public class TopicTeamServiceTest {
         verifyZeroInteractions(teamLinkRepository);
     }
 
-    @Test (expected = ApplicationExceptions.TopicUpdateException.class)
+    @Test(expected = ApplicationExceptions.TopicUpdateException.class)
     public void shouldThrowExceptionWhenAddingInactiveTeamToTopic() {
 
-        AddTeamToTopicDto request = new AddTeamToTopicDto("MIN","DCU_MIN_MARKUP");
+        AddTeamToTopicDto request = new AddTeamToTopicDto("MIN", "DCU_MIN_MARKUP");
         UUID topicUUID = UUID.randomUUID();
         UUID teamUUID = UUID.randomUUID();
         when(teamService.getTeam(teamUUID)).thenReturn(new Team("name", false));
@@ -150,7 +155,7 @@ public class TopicTeamServiceTest {
     @Test
     public void shouldNotAddTeamWhenAddingInactiveTeamToTopic() {
 
-        AddTeamToTopicDto request = new AddTeamToTopicDto("MIN","DCU_MIN_MARKUP");
+        AddTeamToTopicDto request = new AddTeamToTopicDto("MIN", "DCU_MIN_MARKUP");
         UUID topicUUID = UUID.randomUUID();
         UUID teamUUID = UUID.randomUUID();
         when(teamService.getTeam(teamUUID)).thenReturn(new Team("name", false));
@@ -158,7 +163,8 @@ public class TopicTeamServiceTest {
         when(caseTypeService.getCaseType("MIN")).thenReturn(new CaseType());
         when(topicService.getTopic(topicUUID)).thenReturn(new Topic());
 
-        try { topicTeamService.addTeamToTopic(topicUUID, teamUUID, request);
+        try {
+            topicTeamService.addTeamToTopic(topicUUID, teamUUID, request);
         } catch (ApplicationExceptions.TopicUpdateException e) {
             // Do nothing.
         }
@@ -166,13 +172,13 @@ public class TopicTeamServiceTest {
         verifyZeroInteractions(teamLinkRepository);
     }
 
-    @Test (expected = ApplicationExceptions.TopicUpdateException.class)
+    @Test(expected = ApplicationExceptions.TopicUpdateException.class)
     public void shouldThrowExceptionWhenAddingTeamToNonexistentTopic() {
 
-        AddTeamToTopicDto request = new AddTeamToTopicDto("MIN","DCU_MIN_MARKUP");
+        AddTeamToTopicDto request = new AddTeamToTopicDto("MIN", "DCU_MIN_MARKUP");
         UUID topicUUID = UUID.randomUUID();
         UUID teamUUID = UUID.randomUUID();
-        
+
         topicTeamService.addTeamToTopic(topicUUID, teamUUID, request);
     }
 
@@ -192,10 +198,10 @@ public class TopicTeamServiceTest {
         verifyZeroInteractions(teamLinkRepository);
     }
 
-    @Test (expected = ApplicationExceptions.TopicUpdateException.class)
+    @Test(expected = ApplicationExceptions.TopicUpdateException.class)
     public void shouldThrowExceptionWhenAddingTeamToTopicAndCaseTypeIsInvalid() {
 
-        AddTeamToTopicDto request = new AddTeamToTopicDto("MIN","DCU_MIN_MARKUP");
+        AddTeamToTopicDto request = new AddTeamToTopicDto("MIN", "DCU_MIN_MARKUP");
         UUID topicUUID = UUID.randomUUID();
         UUID teamUUID = UUID.randomUUID();
 
@@ -208,12 +214,13 @@ public class TopicTeamServiceTest {
     @Test
     public void shouldNotAddTeamWhenAddingTeamToTopicAndCaseTypeIsInvalid() {
 
-        AddTeamToTopicDto request = new AddTeamToTopicDto("MIN","DCU_MIN_MARKUP");
+        AddTeamToTopicDto request = new AddTeamToTopicDto("MIN", "DCU_MIN_MARKUP");
         UUID topicUUID = UUID.randomUUID();
         UUID teamUUID = UUID.randomUUID();
         when(stageTypeService.getStageType("DCU_MIN_MARKUP")).thenReturn(new StageTypeEntity());
         when(topicService.getTopic(topicUUID)).thenReturn(new Topic());
-        try { topicTeamService.addTeamToTopic(topicUUID, teamUUID, request);
+        try {
+            topicTeamService.addTeamToTopic(topicUUID, teamUUID, request);
         } catch (ApplicationExceptions.TopicUpdateException e) {
             // Do nothing.
         }
@@ -221,10 +228,10 @@ public class TopicTeamServiceTest {
         verifyZeroInteractions(teamLinkRepository);
     }
 
-    @Test (expected = ApplicationExceptions.TopicUpdateException.class)
+    @Test(expected = ApplicationExceptions.TopicUpdateException.class)
     public void shouldThrowExceptionWhenAddingTeamToTopicAndStageTypeIsInvalid() {
 
-        AddTeamToTopicDto request = new AddTeamToTopicDto("MIN","DCU_MIN_MARKUP");
+        AddTeamToTopicDto request = new AddTeamToTopicDto("MIN", "DCU_MIN_MARKUP");
         UUID topicUUID = UUID.randomUUID();
         UUID teamUUID = UUID.randomUUID();
         when(topicService.getTopic(topicUUID)).thenReturn(new Topic());
@@ -235,11 +242,12 @@ public class TopicTeamServiceTest {
     @Test
     public void shouldNotAddTeamWhenAddingTeamToTopicAndStageTypeIsInvalid() {
 
-        AddTeamToTopicDto request = new AddTeamToTopicDto("MIN","DCU_MIN_MARKUP");
+        AddTeamToTopicDto request = new AddTeamToTopicDto("MIN", "DCU_MIN_MARKUP");
         UUID topicUUID = UUID.randomUUID();
         UUID teamUUID = UUID.randomUUID();
         when(topicService.getTopic(topicUUID)).thenReturn(new Topic());
-        try { topicTeamService.addTeamToTopic(topicUUID, teamUUID, request);
+        try {
+            topicTeamService.addTeamToTopic(topicUUID, teamUUID, request);
         } catch (ApplicationExceptions.TopicUpdateException e) {
             // Do nothing.
         }
@@ -250,7 +258,7 @@ public class TopicTeamServiceTest {
     @Test
     public void shouldUpdateTeamWhenAddingTeamToTopicAndTopicAlreadyHasATeam() {
 
-        AddTeamToTopicDto request = new AddTeamToTopicDto("MIN","DCU_MIN_MARKUP");
+        AddTeamToTopicDto request = new AddTeamToTopicDto("MIN", "DCU_MIN_MARKUP");
         UUID topicUUID = UUID.randomUUID();
         UUID teamUUID = UUID.randomUUID();
 
@@ -263,16 +271,16 @@ public class TopicTeamServiceTest {
 
         topicTeamService.addTeamToTopic(topicUUID, teamUUID, request);
 
-        verify(teamLinkRepository, times(1)).findByLinkValueAndLinkTypeAndCaseTypeAndStageType(any(), eq("TOPIC"), any(), any());
-        verify(teamLinkRepository, times(1)).save(any());
+        verify(teamLinkRepository).findByLinkValueAndLinkTypeAndCaseTypeAndStageType(any(), eq("TOPIC"), any(), any());
+        verify(teamLinkRepository).save(any());
         verifyNoMoreInteractions(teamLinkRepository);
     }
 
 
     @Test
-    public void shouldAuditAddTeamToTopic(){
+    public void shouldAuditAddTeamToTopic() {
 
-        AddTeamToTopicDto request = new AddTeamToTopicDto("MIN","DCU_MIN_MARKUP");
+        AddTeamToTopicDto request = new AddTeamToTopicDto("MIN", "DCU_MIN_MARKUP");
         UUID topicUUID = UUID.randomUUID();
         UUID teamUUID = UUID.randomUUID();
 
@@ -283,7 +291,23 @@ public class TopicTeamServiceTest {
 
         topicTeamService.addTeamToTopic(topicUUID, teamUUID, request);
 
-        verify(auditClient, times(1)).addTeamToTopicAudit(any());
+        verify(auditClient).addTeamToTopicAudit(any());
         verifyNoMoreInteractions(auditClient);
+    }
+
+    @Test
+    public void getTopicToTeamMappingByStageType() {
+        String testStageString = "STAGE_321";
+
+        List<SimpleMapItem> mockItems = List.of(mock(SimpleMapItem.class), mock(SimpleMapItem.class));
+        when(teamRepository.findTopicToTeamMappingByStageType(testStageString)).thenReturn(mockItems);
+
+        List<SimpleMapItem> results = topicTeamService.getTopicToTeamMappingByStageType(testStageString);
+
+        assertThat(results).isNotNull();
+        assertThat(results.size()).isEqualTo(2);
+
+        verify(teamRepository).findTopicToTeamMappingByStageType(testStageString);
+        verifyNoMoreInteractions(teamRepository);
     }
 }


### PR DESCRIPTION
-added endpoint for fetching simple mapping representing topic uuid to
team (display name) responsible for passed in stage
- removes some redundant call in test file to 'times(1)' and
'doNothing()'

The logic uses team_link table in the background to find all mappings
for chosen stage where link_type == 'TOPIC'.

Spring data projection has been used to map sql output to SimpleMapItem.
This is so that this generic interface could be reused in the future.
For more details about spring data projection see:
https://www.baeldung.com/spring-data-jpa-projections