### PR TITLE
HOCS-2095: Downgrade Apache Camel Version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
 	ext {
 		springBootVersion = '2.1.3.RELEASE'
-		camelVersion = '2.23.1'
+		camelVersion = '2.23.0'
 	}
 	repositories {
 		mavenCentral()


### PR DESCRIPTION
As a result of a continuing error when removing a user from a team, the error revolves around Apache Camel. To rule out a potential version mismatch, this commit brings it inline with other projects (2.23.0).