### PR TITLE
Feature/hocs 2076 fix

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -121,7 +121,7 @@ pipeline:
     environment:
       - ENVIRONMENT=cs-dev
       - VERSION=build-${DRONE_BUILD_NUMBER}
-      - HOCS_INFO_SERVICE_DATA_VERSION=info-service-data-${DRONE_BUILD_NUMBER}
+      - HOCS_INFO_SERVICE_DATA_VERSION=latest
       - KUBE_SERVER=https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
     secrets:
       - hocs_info_service_dev_cs
@@ -137,7 +137,7 @@ pipeline:
     environment:
       - ENVIRONMENT=wcs-dev
       - VERSION=build-${DRONE_BUILD_NUMBER}
-      - HOCS_INFO_SERVICE_DATA_VERSION=info-service-data-${DRONE_BUILD_NUMBER}
+      - HOCS_INFO_SERVICE_DATA_VERSION=latest
       - KUBE_SERVER=https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
     secrets:
       - hocs_info_service_dev_wcs

--- a/.drone.yml
+++ b/.drone.yml
@@ -94,22 +94,6 @@ pipeline:
       event: deployment
       environment: [cs-qa]
 
-  trigger_hocs_data_builds_with_build_number:
-    image: plugins/downstream
-    server: https://drone-gh.acp.homeoffice.gov.uk
-    fork: true
-    token: ${DRONE_TOKEN}
-    secrets:
-      - drone_token
-    params:
-      - "HOCS_INFO_SERVICE_DATA_VERSION=info-service-data-${DRONE_BUILD_NUMBER}"
-    repositories:
-      - UKHomeOffice/hocs-data
-      - UKHomeOffice/hocs-data-wcs
-    when:
-      branch: master
-      event: push
-
   trigger_hocs_data_wcs_build_with_semver_tag:
     image: plugins/downstream
     server: https://drone-gh.acp.homeoffice.gov.uk


### PR DESCRIPTION
As data images are built based on a master branch push. There is no need for the `trigger_hocs_data_builds_with_build_number` step. Also to avoid passing the data image tags into the info service build, I've also changed the `dev` environment data image tag to `latest` which is the tag set in the data pipelines when we build an image on a master branch push. The semver tagging for the QA environment remains the same.