### PR TITLE
HOCS-2171: parallelise dev deployments

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -117,6 +117,7 @@ pipeline:
       event: [push, tag, deployment]
 
   deploy-to-cs-dev-from-build-number:
+    group: deploy-to-dev
     image: quay.io/ukhomeofficedigital/kd:v1.16.0
     environment:
       - ENVIRONMENT=cs-dev
@@ -133,6 +134,7 @@ pipeline:
       event: [push, tag]
 
   deploy-to-wcs-dev-from-build-number:
+    group: deploy-to-dev
     image: quay.io/ukhomeofficedigital/kd:v1.16.0
     environment:
       - ENVIRONMENT=wcs-dev


### PR DESCRIPTION
Before this commit, Drone deployments would deploy to cs-dev, and afterwards then deploy  to wcs-dev. This change makes it so the deployments to cs-dev and wcs-dev are done in parallel.