### PR TITLE
HOCS-2124 : add logging for failed members list retrieval

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/client/ingest/ListConsumerService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/client/ingest/ListConsumerService.java
@@ -109,7 +109,9 @@ public class ListConsumerService {
         try {
             response = restTemplate.exchange(apiEndpoint, HttpMethod.GET, entity, returnClass);
         } catch (Exception e) {
-            throw new ApplicationExceptions.IngestException("Members Not Found at " + apiEndpoint);
+            log.info("exchange call exception : " + e.getMessage());
+            throw new ApplicationExceptions.IngestException("ListConsumerService exchange exception : " + e.getMessage() + " endpoint : " +
+                    apiEndpoint + " headers : " + headers.toString() + " media type : " +  mediaType.toString());
         }
 
         return response.getBody();


### PR DESCRIPTION
Add more detailed logging for investigation into members/refresh service failing on prod like environments.