### PR TITLE
HOCS-1853: add standard lines endpoints 

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/StandardLineResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/StandardLineResource.java
@@ -47,6 +47,12 @@ public class StandardLineResource {
         return ResponseEntity.ok(GetStandardLineResponse.from(standardLine));
     }
 
+    @GetMapping(value = "/user/{userUUID}/standardLine", produces = APPLICATION_JSON_UTF8_VALUE)
+    public ResponseEntity<List<GetStandardLineResponse>> getStandardLinesForUser(@PathVariable UUID userUUID) {
+        List<StandardLine> standardLines = standardLineService.getStandardLinesForUser(userUUID);
+        return ResponseEntity.ok(standardLines.stream().map(GetStandardLineResponse::from).collect(Collectors.toList()));
+    }
+
     @GetMapping(value = "/standardLine/all", produces = APPLICATION_JSON_UTF8_VALUE)
     public ResponseEntity<List<GetStandardLineResponse>> getAllStandardLines() {
         List<StandardLine> standardLines = standardLineService.getAllStandardLines();

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/TopicService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/TopicService.java
@@ -214,6 +214,11 @@ public class TopicService {
         }
     }
 
+    public List<Topic> findActiveTopicsForTeams(List<UUID> teamsUuids) {
+        log.debug("Requesting all active topics for the following teams: {}", teamsUuids);
+        return topicRepository.findAllActiveTopicsByTeams(teamsUuids);
+    }
+
     public List<Topic> getTopics() {
         log.debug("Requesting all topics");
         return topicRepository.findAllBy();

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/ConfigurationDto.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/ConfigurationDto.java
@@ -22,6 +22,9 @@ public class ConfigurationDto {
     @JsonProperty("bulkCreateEnabled")
     private boolean bulkCreateEnabled;
 
+    @JsonProperty("viewStandardLinesEnabled")
+    private boolean viewStandardLinesEnabled;
+
     @JsonProperty("deadlinesEnabled")
     private boolean deadlinesEnabled;
 
@@ -44,6 +47,7 @@ public class ConfigurationDto {
         return new ConfigurationDto(
                 configuration.getDisplayName(),
                 configuration.isBulkCreateEnabled(),
+                configuration.isViewStandardLinesEnabled(),
                 configuration.isDeadlinesEnabled(),
                 workstackTypeColumns,
                 profileDtos,

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/Configuration.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/Configuration.java
@@ -28,6 +28,9 @@ public class Configuration implements Serializable {
     @Column(name = "bulk_create_enabled")
     private boolean bulkCreateEnabled;
 
+    @Column(name = "view_standard_lines_enabled")
+    private boolean viewStandardLinesEnabled;
+
     @Column(name = "deadlines_enabled")
     private boolean deadlinesEnabled;
 

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/StandardLineRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/StandardLineRepository.java
@@ -16,11 +16,14 @@ public interface StandardLineRepository extends CrudRepository<StandardLine, Str
     @Query(value = "SELECT sl.* FROM standard_line sl WHERE sl.topic_uuid = ?1 AND sl.expires > ?2", nativeQuery = true)
     StandardLine findStandardLinesByTopicAndExpires(UUID topicUUID, LocalDateTime currentDate);
 
+    @Query(value = "SELECT sl.* FROM standard_line sl WHERE sl.topic_uuid IN ?1", nativeQuery = true)
+    List<StandardLine> findStandardLinesByTopics(List<UUID> topicUUID);
+
     @Query(value = "SELECT sl.* FROM standard_line sl WHERE sl.expires > ?1", nativeQuery = true)
     Set<StandardLine> findStandardLinesByExpires(LocalDateTime currentDate);
 
     @Query(value = "SELECT sl.* FROM standard_line sl, topic t where sl.topic_uuid = t.uuid order by t.display_name, sl.display_name ", nativeQuery = true)
     List<StandardLine> findAllStandardLines();
-
+    
     StandardLine findByUuid(UUID uuid);
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/TopicRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/TopicRepository.java
@@ -33,4 +33,7 @@ public interface TopicRepository extends CrudRepository<Topic, String> {
 
     @Query(value = "SELECT DISTINCT t.* from info.topic t join info.team_link tl on cast(t.uuid as text) = tl.link_value join info.parent_topic pt on t.parent_topic_uuid = pt.uuid where tl.case_type = ?1 and pt.active = true and t.active = true order by t.display_name", nativeQuery = true)
     List<Topic>  findAllActiveAssignedTopicsByCaseType(String caseType);
+
+    @Query(value = "SELECT DISTINCT t.* FROM info.team_link tl INNER JOIN info.topic t ON cast(t.uuid as text) = tl.link_value WHERE tl.responsible_team_uuid in ?1 AND t.active = TRUE", nativeQuery = true)
+    List<Topic> findAllActiveTopicsByTeams(List<UUID> teamsUuids);
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/ConfigurationResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/ConfigurationResourceTest.java
@@ -43,14 +43,14 @@ public class ConfigurationResourceTest {
         List<Profile> profiles =  Arrays.asList(new Profile("testProfile", "system", true, searchFields));
 
         String readOnlyCaseViewAdapter = "Adapter";
-        when(configurationService.getConfiguration("system")).thenReturn(new Configuration(systemName, systemDisplayName, false, true, workstackTypes, profiles, false, readOnlyCaseViewAdapter));
+        when(configurationService.getConfiguration("system")).thenReturn(new Configuration(systemName, systemDisplayName, false, false, true, workstackTypes, profiles, false, readOnlyCaseViewAdapter));
 
         ResponseEntity<ConfigurationDto> result = configurationResource.getConfiguration();
-
 
         Assert.assertEquals("Status code incorrect", 200, result.getStatusCode().value());
         Assert.assertEquals("Display name do not match", systemDisplayName, result.getBody().getDisplayName());
         Assert.assertEquals("Bulk Create setting is incorrect", false, result.getBody().isBulkCreateEnabled());
+        Assert.assertEquals("View Standard Lines setting is incorrect", false, result.getBody().isViewStandardLinesEnabled());
         Assert.assertEquals("Deadlines Enabled setting is incorrect", true, result.getBody().isDeadlinesEnabled());
         Assert.assertEquals("AutoCreateAndAllocateEnabled do not match", false, result.getBody().isAutoCreateAndAllocateEnabled());
         Assert.assertEquals("ReadOnlyCaseViewAdapter do not match", readOnlyCaseViewAdapter, result.getBody().getReadOnlyCaseViewAdapter());

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/ConfigurationServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/ConfigurationServiceTest.java
@@ -40,13 +40,14 @@ public class ConfigurationServiceTest {
         List<SearchField> searchFields = Arrays.asList(new SearchField(10L, "profile", "name", "component", "validationRules", "properties"));
         List<Profile> profiles =  Arrays.asList(new Profile("testProfile", "system", true, searchFields));
         String readOnlyCaseViewAdapter = "Adapter";
-        when(configurationRepository.findBySystemName(systemName)).thenReturn(new Configuration(systemName, systemDisplayName, false, false, workstackTypes, profiles, true, readOnlyCaseViewAdapter));
+        when(configurationRepository.findBySystemName(systemName)).thenReturn(new Configuration(systemName, systemDisplayName, false, false, false, workstackTypes, profiles, true, readOnlyCaseViewAdapter));
 
         Configuration result = configurationService.getConfiguration(systemName);
 
         Assert.assertEquals("System name incorrect", systemName, result.getSystemName());
         Assert.assertEquals("Display name do not match", systemDisplayName, result.getDisplayName());
         Assert.assertEquals("Bulk Create Setting is incorrect", false, result.isBulkCreateEnabled());
+        Assert.assertEquals("View Standard Lines setting is incorrect", false, result.isViewStandardLinesEnabled());
         Assert.assertEquals("Deadlines Enabled Setting is incorrect", false, result.isDeadlinesEnabled());
         Assert.assertEquals("AutoCreateAndAllocateEnabled do not match", true, result.isAutoCreateAndAllocateEnabled());
         Assert.assertEquals("ReadOnlyCaseViewAdapter do not match", readOnlyCaseViewAdapter, result.getReadOnlyCaseViewAdapter());

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/StandardLineResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/StandardLineResourceTest.java
@@ -151,4 +151,21 @@ public class StandardLineResourceTest {
         assertThat(response).isNotNull();
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     }
+
+    @Test
+    public void getStandardLinesForUser(){
+        List<StandardLine> standardLines = List.of(new StandardLine("DisplayName", uuid, LocalDateTime.now()));
+
+        when(standardLineService.getStandardLinesForUser(any())).thenReturn(standardLines);
+
+        ResponseEntity<List<GetStandardLineResponse>> response = standardLineResource.getStandardLinesForUser(any());
+        verify(standardLineService).getStandardLinesForUser(any());
+        verifyNoMoreInteractions(standardLineService);
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().size()).isEqualTo(1);
+        assertThat(response.getBody().get(0).getDisplayName()).isEqualTo("DisplayName");
+        assertThat(response.getBody().get(0).getTopicUUID()).isEqualTo(uuid);
+    }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/TopicServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/TopicServiceTest.java
@@ -40,8 +40,8 @@ public class TopicServiceTest {
 
     private TopicService topicService;
 
-    private UUID uuid = UUID.randomUUID();
-    private UUID parentUuid = UUID.randomUUID();
+    private final UUID uuid = UUID.randomUUID();
+    private final UUID parentUuid = UUID.randomUUID();
 
     @Before
     public void setUp() {
@@ -167,15 +167,12 @@ public class TopicServiceTest {
 
     @Test (expected = ApplicationExceptions.TopicCreationException.class)
     public void shouldNotCreateTopicWhenParentAlreadyHasTopicWithGivenName() {
-
         CreateTopicDto request = new CreateTopicDto("Topic");
         ParentTopic parentTopic = new ParentTopic("ParentTopic", false);
-        Topic topic = new Topic("Topic", UUID.randomUUID());
 
         when(parentTopicRepository.findByUuid(any())).thenReturn(parentTopic);
 
         topicService.createTopic(request, UUID.randomUUID());
-
     }
 
     @Test
@@ -290,7 +287,7 @@ public class TopicServiceTest {
     public void shouldReturnTopicsForCaseType() {
         UUID caseUUID = UUID.randomUUID();
         var topics = getTopics();
-        GetCaseworkCaseDataResponse getCaseworkCaseDataResponse = new GetCaseworkCaseDataResponse(caseUUID, ZonedDateTime.now(), "", "", new HashMap<String, String>(), UUID.randomUUID(), UUID.randomUUID());
+        GetCaseworkCaseDataResponse getCaseworkCaseDataResponse = new GetCaseworkCaseDataResponse(caseUUID, ZonedDateTime.now(), "", "", new HashMap<>(), UUID.randomUUID(), UUID.randomUUID());
         when(caseworkClient.getCase(any())).thenReturn(getCaseworkCaseDataResponse);
 
         when(topicRepository.findAllActiveAssignedTopicsByCaseType(any())).thenReturn(topics);
@@ -303,19 +300,32 @@ public class TopicServiceTest {
         assertThat(returnedTopics).containsAll(topics);
     }
 
-    private List<ParentTopic> getParentTopics() {
-        return new ArrayList<ParentTopic>() {{
-            add(new ParentTopic(1l, UUID.randomUUID(), "ParentTopic1", new HashSet<>(), true));
-            add(new ParentTopic(2l, UUID.randomUUID(), "ParentTopic2", new HashSet<>(), true));
-        }};
+    @Test
+    public void shouldFindActiveTopicsForTeams() {
+        var topics = getTopics();
+       
+        when(topicRepository.findAllActiveTopicsByTeams(any())).thenReturn(topics);
 
+        var returnedTopics = topicService.findActiveTopicsForTeams(any());
+
+        verify(topicRepository).findAllActiveTopicsByTeams(any());
+        verifyNoMoreInteractions(topicRepository);
+
+        assertThat(returnedTopics).isNotNull();
+        assertThat(returnedTopics).containsAll(topics);
+    }
+
+    private List<ParentTopic> getParentTopics() {
+        return new ArrayList<>() {{
+            add(new ParentTopic(1L, UUID.randomUUID(), "ParentTopic1", new HashSet<>(), true));
+            add(new ParentTopic(2L, UUID.randomUUID(), "ParentTopic2", new HashSet<>(), true));
+        }};
     }
 
     private List<Topic> getTopics() {
-        return new ArrayList<Topic>() {{
+        return new ArrayList<>() {{
             add(new Topic("Topic1", UUID.randomUUID()));
             add(new Topic("Topic2", UUID.randomUUID()));
         }};
-
     }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/dto/ConfigurationDtoTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/dto/ConfigurationDtoTest.java
@@ -41,7 +41,7 @@ public class ConfigurationDtoTest {
         List<Profile> profiles = Arrays.asList(new Profile(profileName, systemName, false, searchFields));
 
         String readOnlyCaseViewAdapter = "Adapter";
-        Configuration configuration = new Configuration(systemName, systemDisplayName, true, true, workstackTypes, profiles, true, readOnlyCaseViewAdapter);
+        Configuration configuration = new Configuration(systemName, systemDisplayName, true, true, true, workstackTypes, profiles, true, readOnlyCaseViewAdapter);
 
 
         ConfigurationDto dto = ConfigurationDto.from(configuration);
@@ -49,6 +49,7 @@ public class ConfigurationDtoTest {
         Assert.assertEquals("Display name do not match", systemDisplayName, dto.getDisplayName());
         Assert.assertEquals("Bulk Create setting is incorrect", true, dto.isBulkCreateEnabled());
         Assert.assertEquals("Deadline Enabled setting is incorrect", true, dto.isDeadlinesEnabled());
+        Assert.assertEquals("View Standard Lines setting is incorrect", true, dto.isViewStandardLinesEnabled());
         Assert.assertEquals("AutoCreateAndAllocateEnabled setting is incorrect", true, dto.isAutoCreateAndAllocateEnabled());
         Assert.assertEquals("ReadOnlyCaseViewAdapter setting is incorrect", readOnlyCaseViewAdapter, dto.getReadOnlyCaseViewAdapter());
 

--- a/src/test/java/uk/gov/digital/ho/hocs/info/domain/repository/StandardLineRepositoryTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/domain/repository/StandardLineRepositoryTest.java
@@ -1,0 +1,121 @@
+package uk.gov.digital.ho.hocs.info.domain.repository;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.digital.ho.hocs.info.domain.model.*;
+import java.time.LocalDateTime;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+@AutoConfigureTestDatabase(replace= AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+public class StandardLineRepositoryTest {
+    
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private StandardLineRepository repository;
+
+    private final UUID topicUUID = UUID.randomUUID();
+    private final UUID documentUuid = UUID.randomUUID();
+
+    @Test()
+    public void shouldFindAllStandardLines() {
+        var topic1 = new Topic("Test Topic", UUID.randomUUID());
+        var standardLine1 = new StandardLine("Test", topic1.getUuid(), LocalDateTime.now());
+        var standardLine2 = new StandardLine("Test2", topic1.getUuid(), LocalDateTime.now());
+        standardLine1.setDocumentUUID(documentUuid);
+        standardLine2.setDocumentUUID(documentUuid);
+
+        entityManager.persist(topic1);
+        entityManager.persist(standardLine1);
+        entityManager.persist(standardLine2);
+        
+        var standardLines = repository.findAllStandardLines();
+        assertThat(standardLines).isNotNull();
+        assertThat(standardLines.size()).isEqualTo(2);
+    }
+
+    @Test()
+    public void shouldFindByStandardLinesUuid() {
+        var standardLine1 = new StandardLine("Test", topicUUID, LocalDateTime.now());
+        standardLine1.setDocumentUUID(documentUuid);
+
+        entityManager.persist(standardLine1);
+
+        var standardLine = repository.findByUuid(standardLine1.getUuid());
+        assertThat(standardLine).isNotNull();
+        assertThat(standardLine).isEqualTo(standardLine1);
+    }
+
+    @Test()
+    public void shouldFindByStandardLineExpiry() {
+        var standardLine1 = new StandardLine("Test", topicUUID, LocalDateTime.now().plusDays(1));
+        var standardLine2 = new StandardLine("Test", topicUUID, LocalDateTime.now().minusDays(1));
+        standardLine1.setDocumentUUID(documentUuid);
+        standardLine2.setDocumentUUID(documentUuid);
+
+        entityManager.persist(standardLine1);
+        entityManager.persist(standardLine2);
+
+        var standardLine = repository.findStandardLinesByExpires(LocalDateTime.now());
+        assertThat(standardLine).isNotNull();
+        assertThat(standardLine.size()).isEqualTo(1);
+        assertThat(standardLine.contains(standardLine1)).isTrue();
+    }
+
+    @Test()
+    public void shouldFindByStandardLineTopicAndExpiry() {
+        var standardLine1 = new StandardLine("Test", topicUUID, LocalDateTime.now().plusDays(1));
+        var standardLine2 = new StandardLine("Test", UUID.randomUUID(), LocalDateTime.now().plusDays(1));
+        var standardLine3 = new StandardLine("Test", topicUUID, LocalDateTime.now().minusDays(1));
+        var standardLine4 = new StandardLine("Test", UUID.randomUUID(), LocalDateTime.now().minusDays(1));
+        
+        var listStandardLines = 
+                List.of(standardLine1, standardLine2, standardLine3, standardLine4);
+        
+        listStandardLines.forEach(standardLine -> {
+            standardLine.setDocumentUUID(documentUuid);
+            entityManager.persist(standardLine);
+        });
+        
+        var standardLine = repository.findStandardLinesByTopicAndExpires(topicUUID, LocalDateTime.now());
+        assertThat(standardLine).isNotNull();
+        assertThat(standardLine).isEqualTo(standardLine1); 
+    }
+
+    @Test()
+    public void findStandardLinesByTopics() {
+        UUID uuid = UUID.randomUUID();
+        var standardLine1 = new StandardLine("Test", topicUUID, LocalDateTime.now().plusDays(1));
+        var standardLine2 = new StandardLine("Test", uuid, LocalDateTime.now().plusDays(1));
+        var standardLine3 = new StandardLine("Test", topicUUID, LocalDateTime.now().minusDays(1));
+        var standardLine4 = new StandardLine("Test", UUID.randomUUID(), LocalDateTime.now().minusDays(1));
+
+        var listUuid = List.of(topicUUID, uuid);
+        var listStandardLines =
+                List.of(standardLine1, standardLine2, standardLine3, standardLine4);
+
+        listStandardLines.forEach(standardLine -> {
+            standardLine.setDocumentUUID(documentUuid);
+            entityManager.persist(standardLine);
+        });
+
+        var standardLines = repository.findStandardLinesByTopics(listUuid);
+        assertThat(standardLines).isNotNull();
+        assertThat(standardLines.size()).isEqualTo(3);
+        assertThat(standardLines.containsAll(List.of(standardLine1, standardLine2, standardLine3))).isTrue();
+    }
+
+
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/info/domain/repository/TopicRepositoryTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/domain/repository/TopicRepositoryTest.java
@@ -97,4 +97,55 @@ public class TopicRepositoryTest {
         assertThat(topics.get(0).getDisplayName()).isEqualTo("ChildTopic1");
         assertThat(topics.get(1).getDisplayName()).isEqualTo("ChildTopic3");
     }
+    
+    @Test()
+    public void shouldFindAllActiveTopicsByTeams() {
+        ParentTopic parentTopic1 = new ParentTopic("ParentTopic1");
+        ParentTopic parentTopic2 = new ParentTopic("ParentTopic2");
+        parentTopic2.setActive(false);
+        Topic childTopic1 = new Topic("ChildTopic1", parentTopic1.getUuid());
+        Topic childTopic2 = new Topic("ChildTopic2", parentTopic1.getUuid());
+        childTopic2.setActive(false);
+        
+        Unit unit = new Unit("__UNIT1__", "__U1__", true);
+        CaseType caseType = new CaseType("__CASETYPE__", "CT", "__CASETYPE__", unit.getUuid(), "__STAGETYPE__", false, true);
+        Team team = new Team("__Team1__", true);
+        team.setUnit(unit);
+        
+        StageTypeEntity stageTypeEntity = new StageTypeEntity(UUID.randomUUID(), "__STAGETYPE__", "__STAGETYPE__", "__STAGETYPE__", caseType.getUuid(), 1,1,1,true, team);
+        TeamLink teamLink1 = new TeamLink(childTopic1.getUuid().toString(), "TOPIC", team.getUuid(), "__CASETYPE__", "__STAGETYPE__");
+        TeamLink teamLink2 = new TeamLink(childTopic2.getUuid().toString(), "TOPIC", team.getUuid(), "__CASETYPE__", "__STAGETYPE__");
+       
+        this.entityManager.persist(childTopic1);
+        this.entityManager.persist(childTopic2);
+        this.entityManager.persist(parentTopic1);
+        this.entityManager.persist(parentTopic2);
+        this.entityManager.persist(unit);
+        this.entityManager.persist(caseType);
+        this.entityManager.persist(team);
+        this.entityManager.persist(stageTypeEntity);
+        this.entityManager.persist(teamLink1);
+        this.entityManager.persist(teamLink2);
+      
+        List<Topic> topics = repository.findAllActiveTopicsByTeams(List.of(team.getUuid()));
+
+        assertThat(topics).isNotNull();
+        assertThat(topics.size()).isEqualTo(1);
+        assertThat(topics.get(0).getDisplayName()).isEqualTo("ChildTopic1");
+    }
+
+    @Test()
+    public void shouldFindAllActiveTopicsByTeams_NoTopics_ReturnsEmpty() {
+        Unit unit = new Unit("__UNIT1__", "__U1__", true);
+        Team team = new Team("__Team1__", true);
+        team.setUnit(unit);
+
+        this.entityManager.persist(unit);
+        this.entityManager.persist(team);
+
+        List<Topic> topics = repository.findAllActiveTopicsByTeams(List.of(team.getUuid()));
+
+        assertThat(topics).isNotNull();
+        assertThat(topics.size()).isEqualTo(0);
+    }
 }


### PR DESCRIPTION
This pull request adds the following functionality: 

- Pulls back the configuration from the database for viewing the standard lines button in the header. 
- Added functionality to be able to get all of the teams that are associated with a user at that time.
- Added the ability to get all of the active standard lines linked to a topic that is associated with a team. This will populate the new frontend screen to show the user all of the standard lines so that they can be downloaded.

Tests have been added for all of the features above. Tests have also been added to cover all of the standard lines endpoints.