### PR TITLE
HOCS-2214 : Multi.Contrib. endpoints for returning Somu Types

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/SomuTypeResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/SomuTypeResource.java
@@ -1,0 +1,37 @@
+package uk.gov.digital.ho.hocs.info.api;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.digital.ho.hocs.info.api.dto.SomuTypeDto;
+import uk.gov.digital.ho.hocs.info.domain.model.SomuType;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
+
+@RestController
+public class SomuTypeResource {
+
+    private final SomuTypeService somuTypeService;
+
+    @Autowired
+    public SomuTypeResource(SomuTypeService somuTypeService) {
+        this.somuTypeService = somuTypeService;
+    }
+
+    @GetMapping(value = "/somuType", produces = APPLICATION_JSON_UTF8_VALUE)
+    ResponseEntity<Set<SomuTypeDto>> getAllSomuTypes() {
+        Set<SomuType> stageTypes = somuTypeService.getAllSomuTypes();
+        return ResponseEntity.ok(stageTypes.stream().map(SomuTypeDto::from).collect(Collectors.toSet()));
+    }
+
+    @GetMapping(value = "/somuType/{caseType}/{type}", produces = APPLICATION_JSON_UTF8_VALUE)
+    ResponseEntity<SomuTypeDto> getSomuTypeForCaseTypeAndType(@PathVariable String caseType, @PathVariable String type) {
+        SomuType somuType = somuTypeService.getSomuTypeForCaseTypeAndType(caseType, type);
+        return ResponseEntity.ok(SomuTypeDto.from(somuType));
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/SomuTypeResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/SomuTypeResource.java
@@ -3,6 +3,7 @@ package uk.gov.digital.ho.hocs.info.api;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import uk.gov.digital.ho.hocs.info.api.dto.CreateSomuTypeDto;
 import uk.gov.digital.ho.hocs.info.api.dto.SomuTypeDto;
 import uk.gov.digital.ho.hocs.info.domain.model.SomuType;
 
@@ -22,8 +23,8 @@ public class SomuTypeResource {
     }
 
     @GetMapping(value = "/somuType", produces = APPLICATION_JSON_UTF8_VALUE)
-    ResponseEntity<Set<SomuTypeDto>> getAllSomuTypes() {
-        Set<SomuType> stageTypes = somuTypeService.getAllSomuTypes();
+    ResponseEntity<Set<SomuTypeDto>> getAllActiveSomuTypes() {
+        Set<SomuType> stageTypes = somuTypeService.getAllActiveSomuTypes();
         return ResponseEntity.ok(stageTypes.stream().map(SomuTypeDto::from).collect(Collectors.toSet()));
     }
 
@@ -33,13 +34,13 @@ public class SomuTypeResource {
         return ResponseEntity.ok(SomuTypeDto.from(somuType));
     }
 
-    @PostMapping(value = "/somuType/{caseType}/{type}", produces = APPLICATION_JSON_UTF8_VALUE)
-    ResponseEntity<SomuTypeDto> upsertSomuTypeForCaseTypeAndType(@PathVariable String caseType, @PathVariable String type, @RequestBody String schema) {
-        SomuType somuType = somuTypeService.upsertSomuTypeForCaseTypeAndType(caseType, type, schema);
+    @PostMapping(value = "/somuType", produces = APPLICATION_JSON_UTF8_VALUE)
+    ResponseEntity<SomuTypeDto> upsertSomuTypeForCaseTypeAndType(@RequestBody CreateSomuTypeDto somuTypeDto) {
+        SomuType somuType = somuTypeService.upsertSomuTypeForCaseTypeAndType(somuTypeDto.getCaseType(), somuTypeDto.getType(), somuTypeDto.getSchema());
         return ResponseEntity.ok(SomuTypeDto.from(somuType));
     }
 
-    @DeleteMapping(value = "/somuType/{caseType}/{type}", produces = APPLICATION_JSON_UTF8_VALUE)
+    @DeleteMapping(value = "/somuType/{caseType}/{type}")
     ResponseEntity deleteSomuTypeForCaseTypeAndType(@PathVariable String caseType, @PathVariable String type) {
         somuTypeService.deleteSomuTypeForCaseTypeAndType(caseType, type);
         return ResponseEntity.ok().build();

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/SomuTypeResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/SomuTypeResource.java
@@ -2,9 +2,7 @@ package uk.gov.digital.ho.hocs.info.api;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import uk.gov.digital.ho.hocs.info.api.dto.SomuTypeDto;
 import uk.gov.digital.ho.hocs.info.domain.model.SomuType;
 
@@ -33,5 +31,17 @@ public class SomuTypeResource {
     ResponseEntity<SomuTypeDto> getSomuTypeForCaseTypeAndType(@PathVariable String caseType, @PathVariable String type) {
         SomuType somuType = somuTypeService.getSomuTypeForCaseTypeAndType(caseType, type);
         return ResponseEntity.ok(SomuTypeDto.from(somuType));
+    }
+
+    @PostMapping(value = "/somuType/{caseType}/{type}", produces = APPLICATION_JSON_UTF8_VALUE)
+    ResponseEntity<SomuTypeDto> upsertSomuTypeForCaseTypeAndType(@PathVariable String caseType, @PathVariable String type, @RequestBody String schema) {
+        SomuType somuType = somuTypeService.upsertSomuTypeForCaseTypeAndType(caseType, type, schema);
+        return ResponseEntity.ok(SomuTypeDto.from(somuType));
+    }
+
+    @DeleteMapping(value = "/somuType/{caseType}/{type}", produces = APPLICATION_JSON_UTF8_VALUE)
+    ResponseEntity deleteSomuTypeForCaseTypeAndType(@PathVariable String caseType, @PathVariable String type) {
+        somuTypeService.deleteSomuTypeForCaseTypeAndType(caseType, type);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/SomuTypeResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/SomuTypeResource.java
@@ -23,8 +23,8 @@ public class SomuTypeResource {
     }
 
     @GetMapping(value = "/somuType", produces = APPLICATION_JSON_UTF8_VALUE)
-    ResponseEntity<Set<SomuTypeDto>> getAllActiveSomuTypes() {
-        Set<SomuType> stageTypes = somuTypeService.getAllActiveSomuTypes();
+    ResponseEntity<Set<SomuTypeDto>> getAllSomuTypes() {
+        Set<SomuType> stageTypes = somuTypeService.getAllSomuTypes();
         return ResponseEntity.ok(stageTypes.stream().map(SomuTypeDto::from).collect(Collectors.toSet()));
     }
 
@@ -36,13 +36,7 @@ public class SomuTypeResource {
 
     @PostMapping(value = "/somuType", produces = APPLICATION_JSON_UTF8_VALUE)
     ResponseEntity<SomuTypeDto> upsertSomuTypeForCaseTypeAndType(@RequestBody CreateSomuTypeDto somuTypeDto) {
-        SomuType somuType = somuTypeService.upsertSomuTypeForCaseTypeAndType(somuTypeDto.getCaseType(), somuTypeDto.getType(), somuTypeDto.getSchema());
+        SomuType somuType = somuTypeService.upsertSomuTypeForCaseTypeAndType(somuTypeDto.getCaseType(), somuTypeDto.getType(), somuTypeDto.getSchema(), somuTypeDto.getActive());
         return ResponseEntity.ok(SomuTypeDto.from(somuType));
-    }
-
-    @DeleteMapping(value = "/somuType/{caseType}/{type}")
-    ResponseEntity deleteSomuTypeForCaseTypeAndType(@PathVariable String caseType, @PathVariable String type) {
-        somuTypeService.deleteSomuTypeForCaseTypeAndType(caseType, type);
-        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/SomuTypeService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/SomuTypeService.java
@@ -20,10 +20,10 @@ public class SomuTypeService {
         this.somuTypeRepository = somuTypeRepository;
     }
 
-    Set<SomuType> getAllActiveSomuTypes() {
-        log.debug("Getting all active SomuTypes");
-        Set<SomuType> somuTypes = somuTypeRepository.findAllActive();
-        log.info("Got {} active SomuTypes", somuTypes.size());
+    Set<SomuType> getAllSomuTypes() {
+        log.debug("Getting all SomuTypes");
+        Set<SomuType> somuTypes = somuTypeRepository.findAll();
+        log.info("Got all {} SomuTypes", somuTypes.size());
         return somuTypes;
     }
 
@@ -34,32 +34,19 @@ public class SomuTypeService {
         return somuType;
     }
 
-    SomuType upsertSomuTypeForCaseTypeAndType(String caseType, String type, String schema) {
+    SomuType upsertSomuTypeForCaseTypeAndType(String caseType, String type, String schema, boolean active) {
         log.debug("Upserting SomuTypes for Case Type {} and Type {}", caseType, type);
         SomuType somuType = somuTypeRepository.findByCaseTypeAndType(caseType, type);
         if (somuType == null) {
-            somuType = new SomuType(caseType, type, schema, true);
+            somuType = new SomuType(caseType, type, schema, active);
             somuTypeRepository.save(somuType);
             log.info("Inserted SomuType {} for Case Type {} and Type {}", somuType.getUuid(), caseType, type);
         } else {
             somuType.setSchema(schema);
+            somuType.setActive(active);
             somuTypeRepository.save(somuType);
             log.info("Updated SomuType {} for Case Type {} and Type {}", somuType.getUuid(), caseType, type);
         }
         return somuType;
-    }
-
-    void deleteSomuTypeForCaseTypeAndType(String caseType, String type) {
-        log.debug("Deleting SomuTypes for Case Type {} and Type {}", caseType, type);
-        SomuType somuType = somuTypeRepository.findByCaseTypeAndType(caseType, type);
-        if (somuType == null) {
-            throw new ApplicationExceptions.EntityNotFoundException(
-                    String.format("SomuType {}/{} not found", caseType, type));
-        } else {
-            somuType.delete();
-            somuTypeRepository.save(somuType);
-        }
-        log.info("Deleted SomuType {} for Case Type {} and Type {}", somuType.getUuid(), caseType, type);
-        return;
     }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/SomuTypeService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/SomuTypeService.java
@@ -1,0 +1,35 @@
+package uk.gov.digital.ho.hocs.info.api;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.digital.ho.hocs.info.domain.model.SomuType;
+import uk.gov.digital.ho.hocs.info.domain.repository.SomuTypeRepository;
+
+import java.util.Set;
+
+@Service
+@Slf4j
+public class SomuTypeService {
+
+    private final SomuTypeRepository somuTypeRepository;
+
+    @Autowired
+    public SomuTypeService(SomuTypeRepository somuTypeRepository) {
+        this.somuTypeRepository = somuTypeRepository;
+    }
+
+    Set<SomuType> getAllSomuTypes() {
+        log.debug("Getting all SomuTypes");
+        Set<SomuType> somuTypes = somuTypeRepository.findAllBy();
+        log.info("Got {} SomuTypes", somuTypes.size());
+        return somuTypes;
+    }
+
+    SomuType getSomuTypeForCaseTypeAndType(String caseType, String type) {
+        log.debug("Getting SomuTypes for Case Type {} and Type {}", caseType, type);
+        SomuType somuType = somuTypeRepository.findByCaseTypeAndType(caseType, type);
+        log.info("Got SomuType {} for Case Type {} and Type {}", somuType.getUuid(), caseType, type);
+        return somuType;
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/SomuTypeService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/SomuTypeService.java
@@ -3,6 +3,7 @@ package uk.gov.digital.ho.hocs.info.api;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import uk.gov.digital.ho.hocs.info.domain.exception.ApplicationExceptions;
 import uk.gov.digital.ho.hocs.info.domain.model.SomuType;
 import uk.gov.digital.ho.hocs.info.domain.repository.SomuTypeRepository;
 
@@ -31,5 +32,34 @@ public class SomuTypeService {
         SomuType somuType = somuTypeRepository.findByCaseTypeAndType(caseType, type);
         log.info("Got SomuType {} for Case Type {} and Type {}", somuType.getUuid(), caseType, type);
         return somuType;
+    }
+
+    SomuType upsertSomuTypeForCaseTypeAndType(String caseType, String type, String schema) {
+        log.debug("Upserting SomuTypes for Case Type {} and Type {}", caseType, type);
+        SomuType somuType = somuTypeRepository.findByCaseTypeAndType(caseType, type);
+        if (somuType == null) {
+        somuType = new SomuType(caseType, type, schema, true);
+            somuTypeRepository.save(somuType);
+            log.info("Inserted SomuType {} for Case Type {} and Type {}", somuType.getUuid(), caseType, type);
+        } else {
+            somuType.setSchema(schema);
+            somuTypeRepository.save(somuType);
+            log.info("Updated SomuType {} for Case Type {} and Type {}", somuType.getUuid(), caseType, type);
+        }
+        return somuType;
+    }
+
+    void deleteSomuTypeForCaseTypeAndType(String caseType, String type) {
+        log.debug("Deleting SomuTypes for Case Type {} and Type {}", caseType, type);
+        SomuType somuType = somuTypeRepository.findByCaseTypeAndType(caseType, type);
+        if (somuType == null) {
+            throw new ApplicationExceptions.EntityNotFoundException(
+                    String.format("SomuType {}/{} not found", caseType, type));
+        } else {
+            somuType.delete();
+            somuTypeRepository.save(somuType);
+        }
+        log.info("Deleted SomuType {} for Case Type {} and Type {}", somuType.getUuid(), caseType, type);
+        return;
     }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/SomuTypeService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/SomuTypeService.java
@@ -20,10 +20,10 @@ public class SomuTypeService {
         this.somuTypeRepository = somuTypeRepository;
     }
 
-    Set<SomuType> getAllSomuTypes() {
-        log.debug("Getting all SomuTypes");
-        Set<SomuType> somuTypes = somuTypeRepository.findAllBy();
-        log.info("Got {} SomuTypes", somuTypes.size());
+    Set<SomuType> getAllActiveSomuTypes() {
+        log.debug("Getting all active SomuTypes");
+        Set<SomuType> somuTypes = somuTypeRepository.findAllActive();
+        log.info("Got {} active SomuTypes", somuTypes.size());
         return somuTypes;
     }
 
@@ -38,7 +38,7 @@ public class SomuTypeService {
         log.debug("Upserting SomuTypes for Case Type {} and Type {}", caseType, type);
         SomuType somuType = somuTypeRepository.findByCaseTypeAndType(caseType, type);
         if (somuType == null) {
-        somuType = new SomuType(caseType, type, schema, true);
+            somuType = new SomuType(caseType, type, schema, true);
             somuTypeRepository.save(somuType);
             log.info("Inserted SomuType {} for Case Type {} and Type {}", somuType.getUuid(), caseType, type);
         } else {

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/CreateSomuTypeDto.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/CreateSomuTypeDto.java
@@ -18,4 +18,7 @@ public class CreateSomuTypeDto {
 
     @JsonProperty("schema")
     private String schema;
+
+    @JsonProperty("active")
+    private Boolean active;
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/CreateSomuTypeDto.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/CreateSomuTypeDto.java
@@ -1,0 +1,21 @@
+package uk.gov.digital.ho.hocs.info.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class CreateSomuTypeDto {
+
+    @JsonProperty("caseType")
+    private String caseType;
+
+    @JsonProperty("type")
+    private String type;
+
+    @JsonProperty("schema")
+    private String schema;
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/SomuTypeDto.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/SomuTypeDto.java
@@ -1,0 +1,32 @@
+package uk.gov.digital.ho.hocs.info.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import uk.gov.digital.ho.hocs.info.domain.model.SomuType;
+
+@AllArgsConstructor
+@Getter
+public class SomuTypeDto {
+
+    @JsonProperty("caseType")
+    private String caseType;
+
+    @JsonProperty("type")
+    private String type;
+
+    @JsonProperty("schema")
+    private String schema;
+
+    @JsonProperty("active")
+    private boolean active;
+
+    public static SomuTypeDto from(SomuType somuType) {
+
+        return new SomuTypeDto(
+                somuType.getCaseType(),
+                somuType.getType(),
+                somuType.getSchema(),
+                somuType.isActive());
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/SomuType.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/SomuType.java
@@ -3,6 +3,7 @@ package uk.gov.digital.ho.hocs.info.domain.model;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import javax.persistence.*;
 import java.util.UUID;
@@ -28,6 +29,7 @@ public class SomuType {
     @Column(name = "type")
     private String type;
 
+    @Setter
     @Column(name = "schema")
     private String schema = "{}";
 
@@ -40,5 +42,9 @@ public class SomuType {
         this.type = type;
         this.schema = schema;
         this.active = active;
+    }
+
+    public void delete() {
+        active = false;
     }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/SomuType.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/SomuType.java
@@ -1,0 +1,44 @@
+package uk.gov.digital.ho.hocs.info.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.UUID;
+
+@Entity
+@Table(name = "somu_type")
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class SomuType {
+
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "uuid")
+    private UUID uuid;
+
+    @Column(name = "case_type")
+    private String caseType;
+
+    @Column(name = "type")
+    private String type;
+
+    @Column(name = "schema")
+    private String schema = "{}";
+
+    @Column(name = "active")
+    private boolean active;
+
+    public SomuType(String caseType, String type, String schema, boolean active) {
+        this.uuid = UUID.randomUUID();
+        this.caseType = caseType;
+        this.type = type;
+        this.schema = schema;
+        this.active = active;
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/SomuType.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/SomuType.java
@@ -33,6 +33,7 @@ public class SomuType {
     @Column(name = "schema")
     private String schema = "{}";
 
+    @Setter
     @Column(name = "active")
     private boolean active;
 
@@ -42,9 +43,5 @@ public class SomuType {
         this.type = type;
         this.schema = schema;
         this.active = active;
-    }
-
-    public void delete() {
-        active = false;
     }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/SomuTypeRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/SomuTypeRepository.java
@@ -1,5 +1,6 @@
 package uk.gov.digital.ho.hocs.info.domain.repository;
 
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 import uk.gov.digital.ho.hocs.info.domain.model.SomuType;
@@ -10,6 +11,9 @@ import java.util.Set;
 public interface SomuTypeRepository extends CrudRepository<SomuType, String> {
 
     SomuType findByCaseTypeAndType(String caseType, String type);
-    Set<SomuType> findAllBy();
+
+    @Query(value = "SELECT * FROM somu_type WHERE active = true", nativeQuery = true)
+    Set<SomuType> findAllActive();
+
     Set<SomuType> findAllByCaseType(String caseType);
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/SomuTypeRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/SomuTypeRepository.java
@@ -1,0 +1,15 @@
+package uk.gov.digital.ho.hocs.info.domain.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+import uk.gov.digital.ho.hocs.info.domain.model.SomuType;
+
+import java.util.Set;
+
+@Repository
+public interface SomuTypeRepository extends CrudRepository<SomuType, String> {
+
+    SomuType findByCaseTypeAndType(String caseType, String type);
+    Set<SomuType> findAllBy();
+    Set<SomuType> findAllByCaseType(String caseType);
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/SomuTypeRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/SomuTypeRepository.java
@@ -1,6 +1,5 @@
 package uk.gov.digital.ho.hocs.info.domain.repository;
 
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 import uk.gov.digital.ho.hocs.info.domain.model.SomuType;
@@ -12,8 +11,7 @@ public interface SomuTypeRepository extends CrudRepository<SomuType, String> {
 
     SomuType findByCaseTypeAndType(String caseType, String type);
 
-    @Query(value = "SELECT * FROM somu_type WHERE active = true", nativeQuery = true)
-    Set<SomuType> findAllActive();
+    Set<SomuType> findAll();
 
     Set<SomuType> findAllByCaseType(String caseType);
 }

--- a/src/main/resources/db/postgresql/V1_77__2195_Multiple_Contributions_Add_Somu.sql
+++ b/src/main/resources/db/postgresql/V1_77__2195_Multiple_Contributions_Add_Somu.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS somu_type
+(
+  id                BIGSERIAL   PRIMARY KEY,
+  uuid              UUID        NOT NULL,
+  case_type         TEXT        NOT NULL,
+  type              VARCHAR(20) NOT NULL,
+  schema            JSONB       NOT NULL DEFAULT '{}',
+  active            BOOLEAN     NOT NULL DEFAULT TRUE,
+  
+  CONSTRAINT somu_type_uuid_unique UNIQUE (uuid),
+  CONSTRAINT somu_type_type_unique UNIQUE (type),
+  CONSTRAINT somu_type_case_type_type_unique UNIQUE (case_type, type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_somu_type_uuid ON somu_type(uuid);
+CREATE INDEX IF NOT EXISTS idx_somu_type_case_type_type ON somu_type(case_type, type);

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/SomuTypeResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/SomuTypeResourceTest.java
@@ -6,6 +6,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.http.ResponseEntity;
+import uk.gov.digital.ho.hocs.info.api.dto.CreateSomuTypeDto;
 import uk.gov.digital.ho.hocs.info.api.dto.SomuTypeDto;
 import uk.gov.digital.ho.hocs.info.domain.model.SomuType;
 
@@ -35,9 +36,9 @@ public class SomuTypeResourceTest {
         Set<SomuType> somuTypes = new HashSet<SomuType>() {{
             add(somuType);
         }};
-        when(somuTypeService.getAllSomuTypes()).thenReturn(somuTypes);
+        when(somuTypeService.getAllActiveSomuTypes()).thenReturn(somuTypes);
 
-        ResponseEntity<Set<SomuTypeDto>> result = somuTypeResource.getAllSomuTypes();
+        ResponseEntity<Set<SomuTypeDto>> result = somuTypeResource.getAllActiveSomuTypes();
 
         assertThat(result).isNotNull();
         assertThat(result.getStatusCodeValue()).isEqualTo(200);
@@ -48,7 +49,7 @@ public class SomuTypeResourceTest {
         assertThat(somuTypeDto.getType()).isEqualTo("Type");
         assertThat(somuTypeDto.getSchema()).isEqualTo("{}");
         assertThat(somuTypeDto.isActive()).isTrue();
-        verify(somuTypeService).getAllSomuTypes();
+        verify(somuTypeService).getAllActiveSomuTypes();
         verifyNoMoreInteractions(somuTypeService);
     }
 
@@ -75,8 +76,9 @@ public class SomuTypeResourceTest {
     public void upsertSomuTypeForCaseTypeAndType() {
         SomuType somuType = new SomuType(1L, UUID.randomUUID(), "CaseType", "Type", "{}", true);
         when(somuTypeService.upsertSomuTypeForCaseTypeAndType("CaseType", "Type", "{}")).thenReturn(somuType);
+        CreateSomuTypeDto createSomuTypeDto = new CreateSomuTypeDto("CaseType", "Type", "{}");
 
-        ResponseEntity<SomuTypeDto> result = somuTypeResource.upsertSomuTypeForCaseTypeAndType("CaseType", "Type", "{}");
+        ResponseEntity<SomuTypeDto> result = somuTypeResource.upsertSomuTypeForCaseTypeAndType(createSomuTypeDto);
 
         assertThat(result).isNotNull();
         assertThat(result.getStatusCodeValue()).isEqualTo(200);

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/SomuTypeResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/SomuTypeResourceTest.java
@@ -36,9 +36,9 @@ public class SomuTypeResourceTest {
         Set<SomuType> somuTypes = new HashSet<SomuType>() {{
             add(somuType);
         }};
-        when(somuTypeService.getAllActiveSomuTypes()).thenReturn(somuTypes);
+        when(somuTypeService.getAllSomuTypes()).thenReturn(somuTypes);
 
-        ResponseEntity<Set<SomuTypeDto>> result = somuTypeResource.getAllActiveSomuTypes();
+        ResponseEntity<Set<SomuTypeDto>> result = somuTypeResource.getAllSomuTypes();
 
         assertThat(result).isNotNull();
         assertThat(result.getStatusCodeValue()).isEqualTo(200);
@@ -49,7 +49,7 @@ public class SomuTypeResourceTest {
         assertThat(somuTypeDto.getType()).isEqualTo("Type");
         assertThat(somuTypeDto.getSchema()).isEqualTo("{}");
         assertThat(somuTypeDto.isActive()).isTrue();
-        verify(somuTypeService).getAllActiveSomuTypes();
+        verify(somuTypeService).getAllSomuTypes();
         verifyNoMoreInteractions(somuTypeService);
     }
 
@@ -75,8 +75,8 @@ public class SomuTypeResourceTest {
     @Test
     public void upsertSomuTypeForCaseTypeAndType() {
         SomuType somuType = new SomuType(1L, UUID.randomUUID(), "CaseType", "Type", "{}", true);
-        when(somuTypeService.upsertSomuTypeForCaseTypeAndType("CaseType", "Type", "{}")).thenReturn(somuType);
-        CreateSomuTypeDto createSomuTypeDto = new CreateSomuTypeDto("CaseType", "Type", "{}");
+        when(somuTypeService.upsertSomuTypeForCaseTypeAndType("CaseType", "Type", "{}", true)).thenReturn(somuType);
+        CreateSomuTypeDto createSomuTypeDto = new CreateSomuTypeDto("CaseType", "Type", "{}", true);
 
         ResponseEntity<SomuTypeDto> result = somuTypeResource.upsertSomuTypeForCaseTypeAndType(createSomuTypeDto);
 
@@ -88,19 +88,7 @@ public class SomuTypeResourceTest {
         assertThat(somuTypeDto.getType()).isEqualTo("Type");
         assertThat(somuTypeDto.getSchema()).isEqualTo("{}");
         assertThat(somuTypeDto.isActive()).isTrue();
-        verify(somuTypeService).upsertSomuTypeForCaseTypeAndType("CaseType", "Type", "{}");
-        verifyNoMoreInteractions(somuTypeService);
-    }
-
-    @Test
-    public void deleteSomuTypeForCaseTypeAndType() {
-
-        ResponseEntity result = somuTypeResource.deleteSomuTypeForCaseTypeAndType("CaseType", "Type");
-
-        assertThat(result).isNotNull();
-        assertThat(result.getStatusCodeValue()).isEqualTo(200);
-        assertThat(result.getBody()).isNull();
-        verify(somuTypeService).deleteSomuTypeForCaseTypeAndType("CaseType", "Type");
+        verify(somuTypeService).upsertSomuTypeForCaseTypeAndType("CaseType", "Type", "{}", true);
         verifyNoMoreInteractions(somuTypeService);
     }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/SomuTypeResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/SomuTypeResourceTest.java
@@ -1,0 +1,63 @@
+package uk.gov.digital.ho.hocs.info.api;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.ResponseEntity;
+import uk.gov.digital.ho.hocs.info.api.dto.SomuTypeDto;
+import uk.gov.digital.ho.hocs.info.domain.model.SomuType;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SomuTypeResourceTest {
+
+    @Mock
+    SomuTypeService somuTypeService;
+
+    SomuTypeResource somuTypeResource;
+
+    @Before
+    public void setup() {
+        somuTypeResource = new SomuTypeResource(somuTypeService);
+    }
+
+    @Test
+    public void getAllSomuTypes() {
+        SomuType somuType = new SomuType(1L, UUID.randomUUID(), "CaseType", "Type", "{}", true);
+        Set<SomuType> somuTypes = new HashSet<SomuType>() {{
+            add(somuType);
+        }};
+        when(somuTypeService.getAllSomuTypes()).thenReturn(somuTypes);
+
+        ResponseEntity<Set<SomuTypeDto>> result = somuTypeResource.getAllSomuTypes();
+
+        assertThat(result.getBody().size()).isEqualTo(1);
+        SomuTypeDto somuTypeDto = (SomuTypeDto) result.getBody().toArray()[0];
+        assertThat(somuTypeDto.getCaseType()).isEqualTo("CaseType");
+        assertThat(somuTypeDto.getType()).isEqualTo("Type");
+        assertThat(somuTypeDto.getSchema()).isEqualTo("{}");
+        assertThat(somuTypeDto.isActive()).isTrue();
+    }
+
+    @Test
+    public void getSomuTypeForCaseTypeAndType() {
+        SomuType somuType = new SomuType(1L, UUID.randomUUID(), "CaseType", "Type", "{}", true);
+        when(somuTypeService.getSomuTypeForCaseTypeAndType("CaseType", "Type")).thenReturn(somuType);
+
+        ResponseEntity<SomuTypeDto> result = somuTypeResource.getSomuTypeForCaseTypeAndType("CaseType", "Type");
+
+        SomuTypeDto somuTypeDto = result.getBody();
+        assertThat(somuTypeDto.getCaseType()).isEqualTo("CaseType");
+        assertThat(somuTypeDto.getType()).isEqualTo("Type");
+        assertThat(somuTypeDto.getSchema()).isEqualTo("{}");
+        assertThat(somuTypeDto.isActive()).isTrue();
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/SomuTypeResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/SomuTypeResourceTest.java
@@ -14,7 +14,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SomuTypeResourceTest {
@@ -39,12 +39,17 @@ public class SomuTypeResourceTest {
 
         ResponseEntity<Set<SomuTypeDto>> result = somuTypeResource.getAllSomuTypes();
 
+        assertThat(result).isNotNull();
+        assertThat(result.getStatusCodeValue()).isEqualTo(200);
+        assertThat(result.getBody()).isNotNull();
         assertThat(result.getBody().size()).isEqualTo(1);
         SomuTypeDto somuTypeDto = (SomuTypeDto) result.getBody().toArray()[0];
         assertThat(somuTypeDto.getCaseType()).isEqualTo("CaseType");
         assertThat(somuTypeDto.getType()).isEqualTo("Type");
         assertThat(somuTypeDto.getSchema()).isEqualTo("{}");
         assertThat(somuTypeDto.isActive()).isTrue();
+        verify(somuTypeService).getAllSomuTypes();
+        verifyNoMoreInteractions(somuTypeService);
     }
 
     @Test
@@ -54,10 +59,46 @@ public class SomuTypeResourceTest {
 
         ResponseEntity<SomuTypeDto> result = somuTypeResource.getSomuTypeForCaseTypeAndType("CaseType", "Type");
 
+        assertThat(result).isNotNull();
+        assertThat(result.getStatusCodeValue()).isEqualTo(200);
+        assertThat(result.getBody()).isNotNull();
         SomuTypeDto somuTypeDto = result.getBody();
         assertThat(somuTypeDto.getCaseType()).isEqualTo("CaseType");
         assertThat(somuTypeDto.getType()).isEqualTo("Type");
         assertThat(somuTypeDto.getSchema()).isEqualTo("{}");
         assertThat(somuTypeDto.isActive()).isTrue();
+        verify(somuTypeService).getSomuTypeForCaseTypeAndType("CaseType", "Type");
+        verifyNoMoreInteractions(somuTypeService);
+    }
+
+    @Test
+    public void upsertSomuTypeForCaseTypeAndType() {
+        SomuType somuType = new SomuType(1L, UUID.randomUUID(), "CaseType", "Type", "{}", true);
+        when(somuTypeService.upsertSomuTypeForCaseTypeAndType("CaseType", "Type", "{}")).thenReturn(somuType);
+
+        ResponseEntity<SomuTypeDto> result = somuTypeResource.upsertSomuTypeForCaseTypeAndType("CaseType", "Type", "{}");
+
+        assertThat(result).isNotNull();
+        assertThat(result.getStatusCodeValue()).isEqualTo(200);
+        assertThat(result.getBody()).isNotNull();
+        SomuTypeDto somuTypeDto = result.getBody();
+        assertThat(somuTypeDto.getCaseType()).isEqualTo("CaseType");
+        assertThat(somuTypeDto.getType()).isEqualTo("Type");
+        assertThat(somuTypeDto.getSchema()).isEqualTo("{}");
+        assertThat(somuTypeDto.isActive()).isTrue();
+        verify(somuTypeService).upsertSomuTypeForCaseTypeAndType("CaseType", "Type", "{}");
+        verifyNoMoreInteractions(somuTypeService);
+    }
+
+    @Test
+    public void deleteSomuTypeForCaseTypeAndType() {
+
+        ResponseEntity result = somuTypeResource.deleteSomuTypeForCaseTypeAndType("CaseType", "Type");
+
+        assertThat(result).isNotNull();
+        assertThat(result.getStatusCodeValue()).isEqualTo(200);
+        assertThat(result.getBody()).isNull();
+        verify(somuTypeService).deleteSomuTypeForCaseTypeAndType("CaseType", "Type");
+        verifyNoMoreInteractions(somuTypeService);
     }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/SomuTypeServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/SomuTypeServiceTest.java
@@ -36,9 +36,9 @@ public class SomuTypeServiceTest {
         Set<SomuType> somuTypes = new HashSet<SomuType>() {{
             add(somuType);
         }};
-        when(somuTypeRepository.findAllBy()).thenReturn(somuTypes);
+        when(somuTypeRepository.findAllActive()).thenReturn(somuTypes);
 
-        Set<SomuType> result = service.getAllSomuTypes();
+        Set<SomuType> result = service.getAllActiveSomuTypes();
 
         assertThat(result.size()).isEqualTo(1);
         assertThat(result).isEqualTo(somuTypes);

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/SomuTypeServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/SomuTypeServiceTest.java
@@ -5,7 +5,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.digital.ho.hocs.info.domain.exception.ApplicationExceptions;
 import uk.gov.digital.ho.hocs.info.domain.model.SomuType;
 import uk.gov.digital.ho.hocs.info.domain.repository.SomuTypeRepository;
 
@@ -13,7 +12,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.*;
 
@@ -36,9 +34,9 @@ public class SomuTypeServiceTest {
         Set<SomuType> somuTypes = new HashSet<SomuType>() {{
             add(somuType);
         }};
-        when(somuTypeRepository.findAllActive()).thenReturn(somuTypes);
+        when(somuTypeRepository.findAll()).thenReturn(somuTypes);
 
-        Set<SomuType> result = service.getAllActiveSomuTypes();
+        Set<SomuType> result = service.getAllSomuTypes();
 
         assertThat(result.size()).isEqualTo(1);
         assertThat(result).isEqualTo(somuTypes);
@@ -59,7 +57,7 @@ public class SomuTypeServiceTest {
     public void upsertSomuTypeForCaseTypeAndTypeWhenInsert() {
         when(somuTypeRepository.findByCaseTypeAndType("CaseType", "Type")).thenReturn(null);
 
-        SomuType result = service.upsertSomuTypeForCaseTypeAndType("CaseType", "Type", "{}");
+        SomuType result = service.upsertSomuTypeForCaseTypeAndType("CaseType", "Type", "{}", true);
 
         assertThat(result).isNotNull();
         assertThat(result.getUuid()).isNotNull();
@@ -77,7 +75,7 @@ public class SomuTypeServiceTest {
         SomuType somuType = new SomuType(1L, UUID.randomUUID(), "CaseType", "Type", "{}", true);
         when(somuTypeRepository.findByCaseTypeAndType("CaseType", "Type")).thenReturn(somuType);
 
-        SomuType result = service.upsertSomuTypeForCaseTypeAndType("CaseType", "Type", "{'test':true}");
+        SomuType result = service.upsertSomuTypeForCaseTypeAndType("CaseType", "Type", "{'test':true}", true);
 
         assertThat(result).isNotNull();
         assertThat(result.getUuid()).isNotNull();
@@ -87,30 +85,6 @@ public class SomuTypeServiceTest {
         assertThat(result.isActive()).isTrue();
         verify(somuTypeRepository).findByCaseTypeAndType("CaseType", "Type");
         verify(somuTypeRepository).save(somuType);
-        verifyNoMoreInteractions(somuTypeRepository);
-    }
-
-    @Test
-    public void deleteSomuTypeForCaseTypeAndTypeWhenFound() {
-        SomuType somuType = new SomuType(1L, UUID.randomUUID(), "CaseType", "Type", "{}", true);
-        when(somuTypeRepository.findByCaseTypeAndType("CaseType", "Type")).thenReturn(somuType);
-
-        service.deleteSomuTypeForCaseTypeAndType("CaseType", "Type");
-
-        assertThat(somuType.isActive()).isFalse();
-        verify(somuTypeRepository).findByCaseTypeAndType("CaseType", "Type");
-        verify(somuTypeRepository).save(somuType);
-        verifyNoMoreInteractions(somuTypeRepository);
-    }
-
-    @Test
-    public void deleteSomuTypeForCaseTypeAndTypeWhenNotFound() {
-        when(somuTypeRepository.findByCaseTypeAndType("CaseType", "Type")).thenReturn(null);
-
-        assertThatThrownBy(() -> service.deleteSomuTypeForCaseTypeAndType("CaseType", "Type"))
-                .isInstanceOf(ApplicationExceptions.EntityNotFoundException.class);
-
-        verify(somuTypeRepository).findByCaseTypeAndType("CaseType", "Type");
         verifyNoMoreInteractions(somuTypeRepository);
     }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/SomuTypeServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/SomuTypeServiceTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.digital.ho.hocs.info.domain.exception.ApplicationExceptions;
 import uk.gov.digital.ho.hocs.info.domain.model.SomuType;
 import uk.gov.digital.ho.hocs.info.domain.repository.SomuTypeRepository;
 
@@ -12,8 +13,9 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SomuTypeServiceTest {
@@ -51,5 +53,64 @@ public class SomuTypeServiceTest {
         SomuType result = service.getSomuTypeForCaseTypeAndType("CaseType", "Type");
 
         assertThat(result).isEqualTo(somuType);
+    }
+
+    @Test
+    public void upsertSomuTypeForCaseTypeAndTypeWhenInsert() {
+        when(somuTypeRepository.findByCaseTypeAndType("CaseType", "Type")).thenReturn(null);
+
+        SomuType result = service.upsertSomuTypeForCaseTypeAndType("CaseType", "Type", "{}");
+
+        assertThat(result).isNotNull();
+        assertThat(result.getUuid()).isNotNull();
+        assertThat(result.getCaseType()).isEqualTo("CaseType");
+        assertThat(result.getType()).isEqualTo("Type");
+        assertThat(result.getSchema()).isEqualTo("{}");
+        assertThat(result.isActive()).isTrue();
+        verify(somuTypeRepository).findByCaseTypeAndType("CaseType", "Type");
+        verify(somuTypeRepository).save(any(SomuType.class));
+        verifyNoMoreInteractions(somuTypeRepository);
+    }
+
+    @Test
+    public void upsertSomuTypeForCaseTypeAndTypeWhenUpdate() {
+        SomuType somuType = new SomuType(1L, UUID.randomUUID(), "CaseType", "Type", "{}", true);
+        when(somuTypeRepository.findByCaseTypeAndType("CaseType", "Type")).thenReturn(somuType);
+
+        SomuType result = service.upsertSomuTypeForCaseTypeAndType("CaseType", "Type", "{'test':true}");
+
+        assertThat(result).isNotNull();
+        assertThat(result.getUuid()).isNotNull();
+        assertThat(result.getCaseType()).isEqualTo("CaseType");
+        assertThat(result.getType()).isEqualTo("Type");
+        assertThat(result.getSchema()).isEqualTo("{'test':true}");
+        assertThat(result.isActive()).isTrue();
+        verify(somuTypeRepository).findByCaseTypeAndType("CaseType", "Type");
+        verify(somuTypeRepository).save(somuType);
+        verifyNoMoreInteractions(somuTypeRepository);
+    }
+
+    @Test
+    public void deleteSomuTypeForCaseTypeAndTypeWhenFound() {
+        SomuType somuType = new SomuType(1L, UUID.randomUUID(), "CaseType", "Type", "{}", true);
+        when(somuTypeRepository.findByCaseTypeAndType("CaseType", "Type")).thenReturn(somuType);
+
+        service.deleteSomuTypeForCaseTypeAndType("CaseType", "Type");
+
+        assertThat(somuType.isActive()).isFalse();
+        verify(somuTypeRepository).findByCaseTypeAndType("CaseType", "Type");
+        verify(somuTypeRepository).save(somuType);
+        verifyNoMoreInteractions(somuTypeRepository);
+    }
+
+    @Test
+    public void deleteSomuTypeForCaseTypeAndTypeWhenNotFound() {
+        when(somuTypeRepository.findByCaseTypeAndType("CaseType", "Type")).thenReturn(null);
+
+        assertThatThrownBy(() -> service.deleteSomuTypeForCaseTypeAndType("CaseType", "Type"))
+                .isInstanceOf(ApplicationExceptions.EntityNotFoundException.class);
+
+        verify(somuTypeRepository).findByCaseTypeAndType("CaseType", "Type");
+        verifyNoMoreInteractions(somuTypeRepository);
     }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/SomuTypeServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/SomuTypeServiceTest.java
@@ -1,0 +1,55 @@
+package uk.gov.digital.ho.hocs.info.api;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.digital.ho.hocs.info.domain.model.SomuType;
+import uk.gov.digital.ho.hocs.info.domain.repository.SomuTypeRepository;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SomuTypeServiceTest {
+
+    @Mock
+    private SomuTypeRepository somuTypeRepository;
+
+    private SomuTypeService service;
+
+    @Before
+    public void setup() {
+        service = new SomuTypeService(somuTypeRepository);
+    }
+
+    @Test
+    public void getAllSomuTypes() {
+        SomuType somuType = new SomuType(1L, UUID.randomUUID(), "CaseType", "Type", "{}", true);
+        Set<SomuType> somuTypes = new HashSet<SomuType>() {{
+            add(somuType);
+        }};
+        when(somuTypeRepository.findAllBy()).thenReturn(somuTypes);
+
+        Set<SomuType> result = service.getAllSomuTypes();
+
+        assertThat(result.size()).isEqualTo(1);
+        assertThat(result).isEqualTo(somuTypes);
+        assertThat(result.toArray()[0]).isEqualTo(somuType);
+    }
+
+    @Test
+    public void getSomuTypeForCaseTypeAndType() {
+        SomuType somuType = new SomuType(1L, UUID.randomUUID(), "CaseType", "Type", "{}", true);
+        when(somuTypeRepository.findByCaseTypeAndType("CaseType", "Type")).thenReturn(somuType);
+
+        SomuType result = service.getSomuTypeForCaseTypeAndType("CaseType", "Type");
+
+        assertThat(result).isEqualTo(somuType);
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/dto/SomuTypeDtoTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/dto/SomuTypeDtoTest.java
@@ -1,0 +1,26 @@
+package uk.gov.digital.ho.hocs.info.api.dto;
+
+import org.junit.Test;
+import uk.gov.digital.ho.hocs.info.domain.model.SomuType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SomuTypeDtoTest {
+
+    @Test
+    public void from() {
+        SomuType somuType = new SomuType(
+                "caseType",
+                "type",
+                "schema",
+                true);
+
+        SomuTypeDto somuTypeDto = SomuTypeDto.from(somuType);
+
+        assertThat(somuTypeDto).isNotNull();
+        assertThat(somuTypeDto.getCaseType()).isEqualTo("caseType");
+        assertThat(somuTypeDto.getType()).isEqualTo("type");
+        assertThat(somuTypeDto.getSchema()).isEqualTo("schema");
+        assertThat(somuTypeDto.isActive()).isTrue();
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/info/domain/model/SomuTypeTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/domain/model/SomuTypeTest.java
@@ -18,15 +18,9 @@ public class SomuTypeTest {
     }
 
     @Test
-    public void deleteSetsActiveFlagToFalse() {
-        SomuType somuType = new SomuType(
-                "caseType",
-                "type",
-                "schema",
-                true);
+    public void schemaDefault() {
+        SomuType somuType = new SomuType();
 
-        somuType.delete();
-
-        assertThat(somuType.isActive()).isFalse();
+        assertThat(somuType.getSchema()).isEqualTo("{}");
     }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/info/domain/model/SomuTypeTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/domain/model/SomuTypeTest.java
@@ -1,0 +1,19 @@
+package uk.gov.digital.ho.hocs.info.domain.model;
+
+import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SomuTypeTest {
+
+    @Test
+    public void shouldGenerateUuid() {
+        SomuType somuType = new SomuType(
+                "caseType",
+                "type",
+                "schema",
+                true);
+
+        assertThat(somuType.getCaseType()).isEqualTo("caseType");
+        assertThat(somuType.getType()).isEqualTo("type");
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/info/domain/model/SomuTypeTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/domain/model/SomuTypeTest.java
@@ -16,4 +16,17 @@ public class SomuTypeTest {
         assertThat(somuType.getCaseType()).isEqualTo("caseType");
         assertThat(somuType.getType()).isEqualTo("type");
     }
+
+    @Test
+    public void deleteSetsActiveFlagToFalse() {
+        SomuType somuType = new SomuType(
+                "caseType",
+                "type",
+                "schema",
+                true);
+
+        somuType.delete();
+
+        assertThat(somuType.isActive()).isFalse();
+    }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/info/domain/repository/SomuTypeRepositoryTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/domain/repository/SomuTypeRepositoryTest.java
@@ -10,6 +10,8 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.digital.ho.hocs.info.domain.model.SomuType;
 
+import java.util.stream.Collectors;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
@@ -25,16 +27,17 @@ public class SomuTypeRepositoryTest {
     private SomuTypeRepository repository;
 
     @Test()
-    public void findAllBy() {
+    public void findAllActive() {
         var somuType1 = new SomuType("CaseType1", "Type1", "{}", false);
         var somuType2 = new SomuType("CaseType2", "Type2", "{}", true);
         entityManager.persist(somuType1);
         entityManager.persist(somuType2);
 
-        var somuTypes = repository.findAllBy();
+        var somuTypes = repository.findAllActive();
 
         assertThat(somuTypes).isNotNull();
-        assertThat(somuTypes.size()).isGreaterThan(1);
+        assertThat(somuTypes.size()).isGreaterThan(0);
+        assertThat(somuTypes.stream().filter(st -> st.isActive() == false).collect(Collectors.toSet())).isEmpty();
     }
 
     @Test()

--- a/src/test/java/uk/gov/digital/ho/hocs/info/domain/repository/SomuTypeRepositoryTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/domain/repository/SomuTypeRepositoryTest.java
@@ -28,13 +28,13 @@ public class SomuTypeRepositoryTest {
     public void findAllBy() {
         var somuType1 = new SomuType("CaseType1", "Type1", "{}", false);
         var somuType2 = new SomuType("CaseType2", "Type2", "{}", true);
-        entityManager.persist(somuType1);
-        entityManager.persist(somuType2);
+//        entityManager.persist(somuType1);
+//        entityManager.persist(somuType2);
 
         var somuTypes = repository.findAllBy();
 
         assertThat(somuTypes).isNotNull();
-        assertThat(somuTypes.size()).isGreaterThan(1);
+//        assertThat(somuTypes.size()).isGreaterThan(1);
     }
 
     @Test()

--- a/src/test/java/uk/gov/digital/ho/hocs/info/domain/repository/SomuTypeRepositoryTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/domain/repository/SomuTypeRepositoryTest.java
@@ -1,0 +1,66 @@
+package uk.gov.digital.ho.hocs.info.domain.repository;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.digital.ho.hocs.info.domain.model.SomuType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+@AutoConfigureTestDatabase(replace= AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+public class SomuTypeRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private SomuTypeRepository repository;
+
+    @Test()
+    public void findAllBy() {
+        var somuType1 = new SomuType("CaseType1", "Type1", "{}", false);
+        var somuType2 = new SomuType("CaseType2", "Type2", "{}", true);
+        entityManager.persist(somuType1);
+        entityManager.persist(somuType2);
+
+        var somuTypes = repository.findAllBy();
+
+        assertThat(somuTypes).isNotNull();
+        assertThat(somuTypes.size()).isEqualTo(2);
+    }
+
+    @Test()
+    public void findAllByCaseType() {
+        var somuType1 = new SomuType("CaseType1", "Type1", "{}", false);
+        var somuType2 = new SomuType("CaseType2", "Type2", "{}", true);
+        entityManager.persist(somuType1);
+        entityManager.persist(somuType2);
+
+        var somuTypes = repository.findAllByCaseType("CaseType1");
+
+        assertThat(somuTypes).isNotNull();
+        assertThat(somuTypes.size()).isEqualTo(1);
+    }
+
+    @Test()
+    public void findByCaseTypeAndType() {
+        var somuType1 = new SomuType("CaseType1", "Type1", "{}", false);
+        var somuType2 = new SomuType("CaseType2", "Type2", "{}", true);
+        entityManager.persist(somuType1);
+        entityManager.persist(somuType2);
+
+        var somuType = repository.findByCaseTypeAndType("CaseType1", "Type1");
+
+        assertThat(somuType).isNotNull();
+        assertThat(somuType.getCaseType()).isEqualTo("CaseType1");
+        assertThat(somuType.getType()).isEqualTo("Type1");
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/info/domain/repository/SomuTypeRepositoryTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/domain/repository/SomuTypeRepositoryTest.java
@@ -28,13 +28,13 @@ public class SomuTypeRepositoryTest {
     public void findAllBy() {
         var somuType1 = new SomuType("CaseType1", "Type1", "{}", false);
         var somuType2 = new SomuType("CaseType2", "Type2", "{}", true);
-//        entityManager.persist(somuType1);
-//        entityManager.persist(somuType2);
+        entityManager.persist(somuType1);
+        entityManager.persist(somuType2);
 
         var somuTypes = repository.findAllBy();
 
         assertThat(somuTypes).isNotNull();
-//        assertThat(somuTypes.size()).isGreaterThan(1);
+        assertThat(somuTypes.size()).isGreaterThan(1);
     }
 
     @Test()

--- a/src/test/java/uk/gov/digital/ho/hocs/info/domain/repository/SomuTypeRepositoryTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/domain/repository/SomuTypeRepositoryTest.java
@@ -39,8 +39,8 @@ public class SomuTypeRepositoryTest {
 
     @Test()
     public void findAllByCaseType() {
-        var somuType1 = new SomuType("CaseType3", "Type1", "{}", false);
-        var somuType2 = new SomuType("CaseType4", "Type2", "{}", true);
+        var somuType1 = new SomuType("CaseType3", "Type3", "{}", false);
+        var somuType2 = new SomuType("CaseType4", "Type4", "{}", true);
         entityManager.persist(somuType1);
         entityManager.persist(somuType2);
 
@@ -52,15 +52,15 @@ public class SomuTypeRepositoryTest {
 
     @Test()
     public void findByCaseTypeAndType() {
-        var somuType1 = new SomuType("CaseType5", "Type1", "{}", false);
-        var somuType2 = new SomuType("CaseType6", "Type2", "{}", true);
+        var somuType1 = new SomuType("CaseType5", "Type5", "{}", false);
+        var somuType2 = new SomuType("CaseType6", "Type6", "{}", true);
         entityManager.persist(somuType1);
         entityManager.persist(somuType2);
 
-        var somuType = repository.findByCaseTypeAndType("CaseType5", "Type1");
+        var somuType = repository.findByCaseTypeAndType("CaseType5", "Type5");
 
         assertThat(somuType).isNotNull();
         assertThat(somuType.getCaseType()).isEqualTo("CaseType5");
-        assertThat(somuType.getType()).isEqualTo("Type1");
+        assertThat(somuType.getType()).isEqualTo("Type5");
     }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/info/domain/repository/SomuTypeRepositoryTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/domain/repository/SomuTypeRepositoryTest.java
@@ -33,11 +33,10 @@ public class SomuTypeRepositoryTest {
         entityManager.persist(somuType1);
         entityManager.persist(somuType2);
 
-        var somuTypes = repository.findAllActive();
+        var somuTypes = repository.findAll();
 
         assertThat(somuTypes).isNotNull();
         assertThat(somuTypes.size()).isGreaterThan(0);
-        assertThat(somuTypes.stream().filter(st -> st.isActive() == false).collect(Collectors.toSet())).isEmpty();
     }
 
     @Test()

--- a/src/test/java/uk/gov/digital/ho/hocs/info/domain/repository/SomuTypeRepositoryTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/domain/repository/SomuTypeRepositoryTest.java
@@ -34,17 +34,17 @@ public class SomuTypeRepositoryTest {
         var somuTypes = repository.findAllBy();
 
         assertThat(somuTypes).isNotNull();
-        assertThat(somuTypes.size()).isEqualTo(2);
+        assertThat(somuTypes.size()).isGreaterThan(1);
     }
 
     @Test()
     public void findAllByCaseType() {
-        var somuType1 = new SomuType("CaseType1", "Type1", "{}", false);
-        var somuType2 = new SomuType("CaseType2", "Type2", "{}", true);
+        var somuType1 = new SomuType("CaseType3", "Type1", "{}", false);
+        var somuType2 = new SomuType("CaseType4", "Type2", "{}", true);
         entityManager.persist(somuType1);
         entityManager.persist(somuType2);
 
-        var somuTypes = repository.findAllByCaseType("CaseType1");
+        var somuTypes = repository.findAllByCaseType("CaseType3");
 
         assertThat(somuTypes).isNotNull();
         assertThat(somuTypes.size()).isEqualTo(1);
@@ -52,15 +52,15 @@ public class SomuTypeRepositoryTest {
 
     @Test()
     public void findByCaseTypeAndType() {
-        var somuType1 = new SomuType("CaseType1", "Type1", "{}", false);
-        var somuType2 = new SomuType("CaseType2", "Type2", "{}", true);
+        var somuType1 = new SomuType("CaseType5", "Type1", "{}", false);
+        var somuType2 = new SomuType("CaseType6", "Type2", "{}", true);
         entityManager.persist(somuType1);
         entityManager.persist(somuType2);
 
-        var somuType = repository.findByCaseTypeAndType("CaseType1", "Type1");
+        var somuType = repository.findByCaseTypeAndType("CaseType5", "Type1");
 
         assertThat(somuType).isNotNull();
-        assertThat(somuType.getCaseType()).isEqualTo("CaseType1");
+        assertThat(somuType.getCaseType()).isEqualTo("CaseType5");
         assertThat(somuType.getType()).isEqualTo("Type1");
     }
 }


### PR DESCRIPTION
Endpoints added to Info for new Somu Types:

1. Get all.
2. Get by Case Type and Type.
3. Post to Upsert a Somu Type.

Includes SQL script to add Somu Type table, for use by unit tests during build.
Stopped thinking of "active=false" as being deleted.