### PR TITLE
HOCS-2229 Use deployment when triggering databuild

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -79,10 +79,11 @@ pipeline:
       event: deployment
       environment: [cs-qa, wcs-qa]
 
-  trigger_hocs_data_build_with_semver_tag:
+  trigger-cs-downstream-data-build:
     image: plugins/downstream
     server: https://drone-gh.acp.homeoffice.gov.uk
     fork: true
+    deploy: cs-qa
     token: ${DRONE_TOKEN}
     secrets:
       - drone_token
@@ -94,11 +95,12 @@ pipeline:
       event: deployment
       environment: [cs-qa]
 
-  trigger_hocs_data_wcs_build_with_semver_tag:
+  trigger-wcs-downstream-data-build:
     image: plugins/downstream
     server: https://drone-gh.acp.homeoffice.gov.uk
     fork: true
     token: ${DRONE_TOKEN}
+    deploy: wcs-qa
     secrets:
       - drone_token
     params:


### PR DESCRIPTION
Previously we were restarting the top job of hocs-data, which caused
problems. This changes that to fire a `cs-qa` deployment to hocs-data.

The name of this deployment is arbitrary and not currently used by the
downstream pipeline, which only cares about it being *a* deployment and
doesn't differentiate between them.

This commit also shortens the name of the associated build steps, as
they were getting truncated in the Drone CI user interface.