### PR TITLE
HOCS-2242 Push Docker image on every PR build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -36,8 +36,23 @@ pipeline:
     commands:
       - docker build -t hocs-info-service .
     when:
-      branch: master
-      event: [push, tag]
+      event: [push, tag, pull_request]
+
+  install-docker-image-pr:
+    image: docker:17.09.1
+    environment:
+      - DOCKER_HOST=tcp://172.17.0.1:2375
+    secrets:
+      - docker_password
+    commands:
+      # $DRONE_PULL_REQUEST is the pull request number
+      - docker login -u="ukhomeofficedigital+hocs" -p=$${DOCKER_PASSWORD} quay.io
+      - docker tag hocs-info-service quay.io/ukhomeofficedigital/hocs-info-service:pr-$${DRONE_PULL_REQUEST}-$${DRONE_BUILD_NUMBER}
+      - docker tag hocs-info-service quay.io/ukhomeofficedigital/hocs-info-service:pr-$${DRONE_PULL_REQUEST}-latest
+      - docker push quay.io/ukhomeofficedigital/hocs-info-service:pr-$${DRONE_PULL_REQUEST}-$${DRONE_BUILD_NUMBER}
+      - docker push quay.io/ukhomeofficedigital/hocs-info-service:pr-$${DRONE_PULL_REQUEST}-latest
+    when:
+      event: [pull_request]
 
   install-docker-image:
     image: docker:17.09.1


### PR DESCRIPTION
This commit makes Drone push interim images on every pull request. This
will mean that developers can deploy them to development environments
manually where required. It's already possible to actually deploy
manually to development environments -- this just ensures there's
something useful to deploy. As Quay.io is free for open-source projects,
there's no real downside to pushing often, but here we only push when a
pull request is opened (which means we don't flood Quay too much, but
also sidestep any sanitisation problems with Docker tags). One potential
downside to this is that someone malicious could open a pull request
with bad things and force a push to our image registry, but that's okay
as long as nobody actually deploys it anywhere.

This commit also changes the behaviour to build a Docker image on most
jobs, which should have been the default anyway -- previously you could
theoretically have built the project successfully, but broken the Docker
build, and there was no way of verifying you hadn't until the post-merge
to master build failed.