### PR TITLE
HOCS-2260: remove incomplete mapping annotation

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/CaseTypeResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/CaseTypeResource.java
@@ -83,7 +83,6 @@ public class CaseTypeResource {
         return ResponseEntity.ok(caseTypeService.calculateWorkingDaysElapsedForCaseType(caseType, fromDate));
     }
 
-    @PostMapping
     public ResponseEntity createCaseType(CreateCaseTypeDto caseType) {
         caseTypeService.createCaseType(caseType);
         return ResponseEntity.ok().build();


### PR DESCRIPTION
This bug fix removes the @PostMapping annotation from the createCaseType method in CaseTypeResource. It has no parameters and did not function as an endpoint. It does not appear to be called. The method shall remain only the annotation is to be removed.
The side effect of no params means the annotation is applied to the base url and other http verbs appear to be blocked causing problems with swagger-ui. 