### PR TITLE
HOCS-2115 - Home Office sponsorship in CPFG

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/TopicResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/TopicResource.java
@@ -68,6 +68,13 @@ public class TopicResource {
         return ResponseEntity.ok(topics.stream().map(t->TopicDto.from(t)).collect(Collectors.toSet()));
     }
 
+    @GetMapping(value = "/topics/active", produces = APPLICATION_JSON_UTF8_VALUE)
+    public ResponseEntity<Set<TopicDto>> getActiveTopics () {
+        log.info("requesting all active topics");
+        List<Topic> topics = topicService.getActiveTopics();
+        return ResponseEntity.ok(topics.stream().map(t->TopicDto.from(t)).collect(Collectors.toSet()));
+    }
+
     @GetMapping(value = "/topic/parents", produces = APPLICATION_JSON_UTF8_VALUE)
     public ResponseEntity<Set<ParentTopicDto>> getParentTopics () {
         log.info("requesting all parent topics");

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/TopicService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/TopicService.java
@@ -105,15 +105,18 @@ public class TopicService {
                 auditClient.createTopicAudit(topic);
                 return topic.getUuid();
             } else {
-                if (existingTopic.isActive()) {
+                if (!existingTopic.isActive()) {
                     log.debug(
-                            "Unable to create topic, active topic with this name already exists for this parent");
+                            "Reactivating existing inactive topic with this name for this parent");
+                    this.reactivateTopic(existingTopic.getUuid());
+
+                    return existingTopic.getUuid();
                 } else {
                     log.debug(
-                            "Unable to create topic, inactive topic with this name already exists for this parent");
+                            "Unable to create topic, active topic with this name already exists for this parent");
+                    throw new ApplicationExceptions.TopicCreationException(
+                            "Topic already exists with this name for the parent topic");
                 }
-                throw new ApplicationExceptions.TopicCreationException(
-                        "Topic already exists with this name for the parent topic");
             }
         }
     }
@@ -222,6 +225,11 @@ public class TopicService {
     public List<Topic> getTopics() {
         log.debug("Requesting all topics");
         return topicRepository.findAllBy();
+    }
+
+    public List<Topic> getActiveTopics() {
+        log.debug("Requesting all active topics");
+        return topicRepository.findAllByActiveIsTrue();
     }
 
     private List<Topic> findAllActiveAssignedTopicsByCaseType(String caseType) {

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/TopicIntegrationTests.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/TopicIntegrationTests.java
@@ -19,6 +19,7 @@ import uk.gov.digital.ho.hocs.info.domain.model.Topic;
 import uk.gov.digital.ho.hocs.info.domain.repository.ParentTopicRepository;
 import uk.gov.digital.ho.hocs.info.domain.repository.TopicRepository;
 
+import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -190,22 +191,25 @@ public class TopicIntegrationTests {
     }
 
     @Test
-    public void shouldNotCreateTopicWhenParentHasInactiveTopicWithSameNameAsGiven() {
+    public void shouldReactivateTopicWhenParentHasInactiveTopicWithSameNameAsGiven() {
 
         long numberOfTopicsBefore = topicRepository.count();
+        long numberOfActiveTopicsBefore = topicRepository.findAllByActiveIsTrue().size();
 
         CreateTopicDto request = new CreateTopicDto("test inactive topic 4");
 
         HttpEntity httpEntity = new HttpEntity(request, headers);
-        ResponseEntity<Void> result = restTemplate.exchange(
+        ResponseEntity<Map> result = restTemplate.exchange(
                 getBasePath() + "/topic/parent/" + parentTopicUUID
-                , HttpMethod.POST, httpEntity, Void.class);
+                , HttpMethod.POST, httpEntity, Map.class);
 
         long numberOfTopicsAfter = topicRepository.count();
+        long numberOfActiveTopicsAfter = topicRepository.findAllByActiveIsTrue().size();
 
-        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(numberOfTopicsAfter).isEqualTo(numberOfTopicsBefore);
-
+        assertThat(numberOfActiveTopicsAfter).isEqualTo(numberOfActiveTopicsBefore + 1);
+        assertThat(result.getBody().get("topicUUID")).isEqualTo("11111111-ffff-1111-1111-111111111134");
     }
 
     @Test

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/TopicServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/TopicServiceTest.java
@@ -59,6 +59,16 @@ public class TopicServiceTest {
     }
 
     @Test
+    public void shouldReturnAllActiveTopics() {
+        when(topicRepository.findAllByActiveIsTrue()).thenReturn(getActiveTopics());
+
+        topicService.getActiveTopics();
+
+        verify(topicRepository, times(1)).findAllByActiveIsTrue();
+        verifyNoMoreInteractions(topicRepository);
+    }
+
+    @Test
     public void shouldReturnAllParentTopics() {
         when(parentTopicRepository.findAll()).thenReturn(getParentTopics());
 
@@ -303,7 +313,7 @@ public class TopicServiceTest {
     @Test
     public void shouldFindActiveTopicsForTeams() {
         var topics = getTopics();
-       
+
         when(topicRepository.findAllActiveTopicsByTeams(any())).thenReturn(topics);
 
         var returnedTopics = topicService.findActiveTopicsForTeams(any());
@@ -323,6 +333,13 @@ public class TopicServiceTest {
     }
 
     private List<Topic> getTopics() {
+        return new ArrayList<>() {{
+            add(new Topic("Topic1", UUID.randomUUID()));
+            add(new Topic("Topic2", UUID.randomUUID()));
+        }};
+    }
+
+    private List<Topic> getActiveTopics() {
         return new ArrayList<>() {{
             add(new Topic("Topic1", UUID.randomUUID()));
             add(new Topic("Topic2", UUID.randomUUID()));


### PR DESCRIPTION
This PR along with https://github.com/UKHomeOffice/hocs-management-ui/pull/65 addresses HOCS-2115 - Home Office sponsorship in CPFG.

The issue was caused by old deactivated subtopics being shown alongside and indistinguishable from new subtopics with same name appearing in the management console. This means that there's a 50/50 chance that the user will link the wrong subtopic to a team.

Changes in this PR:
* Add endpoint to show all active topics (filtering out deactivated topics) at /topics/active
* Reactivate child topics when an attempt is made to create a subtopic matching a deactivated subtopic for a given parent
* Update tests