### PR TITLE
HOCS-2262-Add active/inactive column to Topics extract

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/TeamResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/TeamResource.java
@@ -4,6 +4,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import uk.gov.digital.ho.hocs.info.api.dto.*;
 import uk.gov.digital.ho.hocs.info.domain.model.Team;
+import uk.gov.digital.ho.hocs.info.domain.model.Unit;
 
 import java.util.Set;
 import java.util.UUID;
@@ -96,6 +97,16 @@ public class TeamResource {
         Team team = teamService.getTeam(teamUUID);
         return ResponseEntity.ok(UnitDto.from(team.getUnit()));
     }
+
+    @GetMapping(value = "/team/{teamUUID}/move_options", produces = APPLICATION_JSON_UTF8_VALUE)
+    public ResponseEntity<Set<TeamDto>> getMoveToAnotherTeamOptions(@PathVariable UUID teamUUID) {
+        Team team = teamService.getTeam(teamUUID); // todo: this
+        final Unit unit = team.getUnit();
+
+        Set<Team> teams = teamService.findActiveTeamsByUnitUuid(team.getUnit().getUuid());
+        return ResponseEntity.ok(teams.stream().map(TeamDto::from).collect(Collectors.toSet()));
+    }
+
 
     @GetMapping(value = "/team")
     public ResponseEntity<Set<TeamDto>> getActiveTeams() {

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/TopicDto.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/TopicDto.java
@@ -18,6 +18,9 @@ public class TopicDto {
     @JsonProperty("value")
     private UUID uuid;
 
+    @JsonProperty("active")
+    private boolean active;
+
     public static TopicDto from (Topic topic) {
-        return new TopicDto(topic.getDisplayName(), topic.getUuid()); }
+        return new TopicDto(topic.getDisplayName(), topic.getUuid(), topic.isActive()); }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/Team.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/Team.java
@@ -82,4 +82,11 @@ public class Team implements Serializable {
         newPermissions.forEach(this::deletePermission);
     }
 
+    public Unit getUnit() {
+        return unit;
+    }
+
+    public void setUnit(Unit unit) {
+        this.unit = unit;
+    }
 }


### PR DESCRIPTION
This PR along with https://github.com/UKHomeOffice/hocs-audit/pull/75 addresses HOCS-2262-Add active/inactive column to Topics extract

Changes in this PR:
* Add active boolean field to topic endpoints json