### PR TITLE
HOCS-2419: add case type schema endpoint

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/CaseTypeSchemaResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/CaseTypeSchemaResource.java
@@ -1,0 +1,28 @@
+package uk.gov.digital.ho.hocs.info.api;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
+
+@RestController
+public class CaseTypeSchemaResource {
+
+    private final CaseTypeSchemaService caseTypeSchemaService;
+
+    @Autowired
+    public CaseTypeSchemaResource(CaseTypeSchemaService caseTypeSchemaService) {
+        this.caseTypeSchemaService = caseTypeSchemaService;
+    }
+
+    @GetMapping(value = "/caseType/{caseType}/stages", produces = APPLICATION_JSON_UTF8_VALUE)
+    public ResponseEntity<List<String>> getCaseTypeStages(@PathVariable String caseType) {
+        return ResponseEntity.ok(caseTypeSchemaService.getCaseTypeStages(caseType));
+    }
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/CaseTypeSchemaService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/CaseTypeSchemaService.java
@@ -1,0 +1,40 @@
+package uk.gov.digital.ho.hocs.info.api;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.digital.ho.hocs.info.domain.exception.ApplicationExceptions;
+import uk.gov.digital.ho.hocs.info.domain.repository.CaseTypeRepository;
+import uk.gov.digital.ho.hocs.info.domain.repository.CaseTypeSchemaRepository;
+
+import java.util.List;
+
+@Service
+@Slf4j
+public class CaseTypeSchemaService {
+
+    private final CaseTypeSchemaRepository caseTypeSchemaRepository;
+    private final CaseTypeRepository caseTypeRepository;
+
+    @Autowired
+    public CaseTypeSchemaService(CaseTypeSchemaRepository caseTypeSchemaRepository,
+                                 CaseTypeRepository caseTypeRepository) {
+        this.caseTypeSchemaRepository = caseTypeSchemaRepository;
+        this.caseTypeRepository = caseTypeRepository;
+    }
+
+    List<String> getCaseTypeStages(String type) {
+        log.debug("Getting CaseType stages for type {}", type);
+
+        if (caseTypeRepository.findByType(type) == null) {
+            String errorMessage = String.format("CaseType %s does not exist", type);
+            log.error(errorMessage);
+            throw new ApplicationExceptions.EntityNotFoundException(errorMessage);
+        }
+
+        List<String> caseTypeDistinctStages = caseTypeSchemaRepository.findDistinctStagesByCaseType(type);
+        log.info("Got {} CaseTypes Stages for CaseType {}", caseTypeDistinctStages.size(), type);
+        return caseTypeDistinctStages;
+    }
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/CaseTypeSchema.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/CaseTypeSchema.java
@@ -1,0 +1,38 @@
+package uk.gov.digital.ho.hocs.info.domain.model;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.io.Serializable;
+import java.util.UUID;
+
+@Entity
+@Table(name = "case_type_schema")
+@NoArgsConstructor
+@Getter
+@EqualsAndHashCode(of = {"id"})
+public class CaseTypeSchema implements Serializable {
+
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "case_type")
+    private String caseType;
+
+    @Column(name = "stage_type")
+    private String stageType;
+
+    @Column(name = "schema_uuid")
+    private UUID schemaUuid;
+
+    public CaseTypeSchema(String caseType, String stageType, UUID schemaUuid) {
+        this.caseType = caseType;
+        this.stageType = stageType;
+        this.schemaUuid = schemaUuid;
+    }
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/CaseTypeSchemaRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/CaseTypeSchemaRepository.java
@@ -1,0 +1,16 @@
+package uk.gov.digital.ho.hocs.info.domain.repository;
+
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+import uk.gov.digital.ho.hocs.info.domain.model.CaseTypeSchema;
+
+import java.util.List;
+
+@Repository
+public interface CaseTypeSchemaRepository extends CrudRepository<CaseTypeSchema, String> {
+
+    @Query(value = "SELECT DISTINCT(stage_type) FROM case_type_schema WHERE case_type = ?1", nativeQuery = true)
+    List<String> findDistinctStagesByCaseType(String caseType);
+
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/CaseTypeSchemaResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/CaseTypeSchemaResourceTest.java
@@ -1,0 +1,87 @@
+package uk.gov.digital.ho.hocs.info.api;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import uk.gov.digital.ho.hocs.info.domain.exception.ApplicationExceptions;
+
+import java.util.List;
+import java.util.ArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CaseTypeSchemaResourceTest {
+
+    @Mock
+    private CaseTypeSchemaService caseTypeSchemaService;
+
+    private CaseTypeSchemaResource caseTypeSchemaResource;
+
+    private final static String TEST_CASE_TYPE = "Test";
+
+    @Before
+    public void setUp() {
+        caseTypeSchemaResource = new CaseTypeSchemaResource(caseTypeSchemaService);
+    }
+
+    @Test
+    public void shouldReturnStagesForValidCaseType() {
+        when(caseTypeSchemaService.getCaseTypeStages(TEST_CASE_TYPE)).thenReturn(getMockStageTypes(5));
+
+        ResponseEntity<List<String>> response =
+                caseTypeSchemaResource.getCaseTypeStages(TEST_CASE_TYPE);
+
+        verify(caseTypeSchemaService, times(1)).getCaseTypeStages(eq(TEST_CASE_TYPE));
+        verifyNoMoreInteractions(caseTypeSchemaService);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().size()).isEqualTo(5);
+    }
+
+    @Test
+    public void shouldReturnEmptyStagesForValidCaseType() {
+        when(caseTypeSchemaService.getCaseTypeStages(TEST_CASE_TYPE)).thenReturn(getZeroMockStageTypes());
+
+        ResponseEntity<List<String>> response =
+                caseTypeSchemaResource.getCaseTypeStages(TEST_CASE_TYPE);
+
+        verify(caseTypeSchemaService, times(1)).getCaseTypeStages(eq(TEST_CASE_TYPE));
+        verifyNoMoreInteractions(caseTypeSchemaService);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().size()).isEqualTo(0);
+    }
+
+    @Test(expected = ApplicationExceptions.EntityNotFoundException.class)
+    public void shouldThrowExceptionForInvalidCaseType() {
+        when(caseTypeSchemaService.getCaseTypeStages(TEST_CASE_TYPE))
+                .thenThrow(new ApplicationExceptions.EntityNotFoundException(
+                        String.format("CaseType %s does not exist.", TEST_CASE_TYPE)));
+
+        caseTypeSchemaResource.getCaseTypeStages(TEST_CASE_TYPE);
+        verifyNoMoreInteractions(caseTypeSchemaResource);
+    }
+
+    private List<String> getZeroMockStageTypes() {
+        return getMockStageTypes(0);
+    }
+
+    private List<String> getMockStageTypes(int amount) {
+        List<String> mockStageTypes = new ArrayList<>();
+        for(int i = 0; i < amount; ++i) {
+            mockStageTypes.add(String.format("Test_Stage_%d", i));
+        }
+        return mockStageTypes;
+    }
+
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/CaseTypeSchemaServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/CaseTypeSchemaServiceTest.java
@@ -1,0 +1,101 @@
+package uk.gov.digital.ho.hocs.info.api;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.digital.ho.hocs.info.domain.exception.ApplicationExceptions;
+import uk.gov.digital.ho.hocs.info.domain.model.CaseType;
+import uk.gov.digital.ho.hocs.info.domain.repository.CaseTypeRepository;
+import uk.gov.digital.ho.hocs.info.domain.repository.CaseTypeSchemaRepository;
+
+import java.util.List;
+import java.util.ArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CaseTypeSchemaServiceTest {
+
+    @Mock
+    private CaseTypeSchemaRepository caseTypeSchemaRepository;
+
+    @Mock
+    private CaseTypeRepository caseTypeRepository;
+
+    private CaseTypeSchemaService caseTypeSchemaService;
+
+    private static final String TEST_CASE_TYPE = "TEST";
+
+    @Before
+    public void setUp() {
+        this.caseTypeSchemaService = new CaseTypeSchemaService(caseTypeSchemaRepository, caseTypeRepository);
+    }
+
+    @Test
+    public void shouldReturnStagesForValidCaseType() {
+        when(caseTypeRepository.findByType(TEST_CASE_TYPE))
+                .thenReturn(new CaseType());
+
+        when(caseTypeSchemaRepository.findDistinctStagesByCaseType(TEST_CASE_TYPE))
+                .thenReturn(getMockStageTypes(5));
+
+        List<String> stageTypes = caseTypeSchemaService.getCaseTypeStages(TEST_CASE_TYPE);
+
+        verify(caseTypeRepository, times(1)).findByType(TEST_CASE_TYPE);
+        verifyNoMoreInteractions(caseTypeRepository);
+
+        verify(caseTypeSchemaRepository, times(1)).findDistinctStagesByCaseType(TEST_CASE_TYPE);
+        verifyNoMoreInteractions(caseTypeSchemaRepository);
+
+        assertThat(stageTypes.size()).isEqualTo(5);
+    }
+
+    @Test(expected = ApplicationExceptions.EntityNotFoundException.class)
+    public void shouldThrowExceptionForInvalidCaseType() {
+        when(caseTypeRepository.findByType(TEST_CASE_TYPE))
+                .thenReturn(null);
+
+        caseTypeSchemaService.getCaseTypeStages(TEST_CASE_TYPE);
+
+        verify(caseTypeRepository, times(1)).findByType(TEST_CASE_TYPE);
+        verifyNoMoreInteractions(caseTypeRepository);
+
+        verify(caseTypeSchemaRepository, times(0)).findDistinctStagesByCaseType(TEST_CASE_TYPE);
+        verifyZeroInteractions(caseTypeSchemaRepository);
+    }
+
+    @Test
+    public void shouldReturnEmptyStagesForValidCaseType() {
+        when(caseTypeRepository.findByType(TEST_CASE_TYPE))
+                .thenReturn(new CaseType());
+
+        when(caseTypeSchemaRepository.findDistinctStagesByCaseType(TEST_CASE_TYPE))
+                .thenReturn(getZeroMockStageTypes());
+
+        List<String> stageTypes = caseTypeSchemaService.getCaseTypeStages(TEST_CASE_TYPE);
+
+        verify(caseTypeRepository, times(1)).findByType(TEST_CASE_TYPE);
+        verifyNoMoreInteractions(caseTypeRepository);
+
+        verify(caseTypeSchemaRepository, times(1)).findDistinctStagesByCaseType(TEST_CASE_TYPE);
+        verifyNoMoreInteractions(caseTypeSchemaRepository);
+
+        assertThat(stageTypes.size()).isEqualTo(0);
+    }
+
+    private List<String> getZeroMockStageTypes() {
+        return getMockStageTypes(0);
+    }
+
+    private List<String> getMockStageTypes(int amount) {
+        List<String> mockStageTypes = new ArrayList<>();
+        for(int i = 0; i < amount; ++i) {
+            mockStageTypes.add(String.format("Test_Stage_%d", i));
+        }
+        return mockStageTypes;
+    }
+
+}


### PR DESCRIPTION
At present we have no endpoint that returns a distinct list 
of the stages that are associated with a case type. 
This change adds a endpoint that queries the case_type_schema 
table for distinct stage types and returns them as a list.