### PR TITLE
HOCS-2213: fixup House Address on List Consumer API calls

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/client/ingest/ListConsumerService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/client/ingest/ListConsumerService.java
@@ -1,5 +1,6 @@
 package uk.gov.digital.ho.hocs.info.client.ingest;
 
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -8,9 +9,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.digital.ho.hocs.info.domain.exception.ApplicationExceptions;
 import uk.gov.digital.ho.hocs.info.domain.model.Country;
-import uk.gov.digital.ho.hocs.info.domain.model.House;
+import uk.gov.digital.ho.hocs.info.domain.model.enums.House;
 import uk.gov.digital.ho.hocs.info.domain.model.HouseAddress;
 import uk.gov.digital.ho.hocs.info.domain.model.Member;
+import uk.gov.digital.ho.hocs.info.domain.model.enums.HouseCodes;
 import uk.gov.digital.ho.hocs.info.domain.repository.HouseAddressRepository;
 
 import java.util.*;
@@ -22,6 +24,7 @@ public class ListConsumerService {
 
     private static final String HOUSE_LORDS = "lords/";
     private static final String HOUSE_COMMONS = "commons/";
+
     private final String apiUkParliament;
     private final String apiScottishParliament;
     private final String apiNorthernIrishAssembly;
@@ -29,8 +32,8 @@ public class ListConsumerService {
     private final String apiCountryRegister;
     private final String apiTerritoryRegister;
 
-    private HouseAddressRepository houseAddressRepository;
-    private RestTemplate restTemplate;
+    private final HouseAddressRepository houseAddressRepository;
+    private final RestTemplate restTemplate;
 
     @Autowired
     public ListConsumerService(@Value("${api.uk.parliament}") String apiUkParliament,
@@ -39,7 +42,8 @@ public class ListConsumerService {
                                @Value("${api.welsh.assembly}") String apiWelshAssembly,
                                @Value("${api.country.register}") String apiCountryRegister,
                                @Value("${api.territory.register}") String apiTerritoryRegister,
-                               HouseAddressRepository houseAddressRepository, RestTemplate restTemplate) {
+                               HouseAddressRepository houseAddressRepository,
+                               RestTemplate restTemplate) {
         this.apiUkParliament = apiUkParliament;
         this.apiScottishParliament = apiScottishParliament;
         this.apiNorthernIrishAssembly = apiNorthernIrishAssembly;
@@ -48,44 +52,116 @@ public class ListConsumerService {
         this.apiTerritoryRegister = apiTerritoryRegister;
         this.houseAddressRepository = houseAddressRepository;
         this.restTemplate = restTemplate;
-
     }
 
     public Set<Member> createFromIrishAssemblyAPI() {
         log.info("Updating Irish Assembly");
-        HouseAddress houseAddress = houseAddressRepository.findByHouseCode("NI");
-        IrishMembers irishMembers = getDataFromAPI(apiNorthernIrishAssembly, MediaType.APPLICATION_XML, IrishMembers.class);
-        return irishMembers.getMembers().stream().map(m -> new Member(House.HOUSE_NORTHERN_IRISH_ASSEMBLY.getDisplayValue(), m.getFullDisplayName()+" MLA",houseAddress.getUuid(), "NI"+m.getPersonId())).collect(Collectors.toSet());
+        try {
+            final HouseAddress houseAddress = retrieveHouseAddress(HouseCodes.IRISH_ASSEMBLY);
+
+            IrishMembers irishMembers =
+                    getDataFromAPI(apiNorthernIrishAssembly, MediaType.APPLICATION_XML, IrishMembers.class);
+
+            return irishMembers.getMembers()
+                    .stream().map(m ->
+                            new Member(House.HOUSE_NORTHERN_IRISH_ASSEMBLY.getDisplayValue(),
+                                    m.getFullDisplayName() + " MLA",
+                                    houseAddress.getUuid(),
+                                    "NI" + m.getPersonId()))
+                    .collect(Collectors.toSet());
+        } catch (ApplicationExceptions.EntityNotFoundException ex) {
+            log.info(ex.getMessage());
+            return Collections.emptySet();
+        }
     }
 
     public Set<Member> createFromScottishParliamentAPI() {
         log.info("Updating Scottish Parliament");
-        HouseAddress houseAddress = houseAddressRepository.findByHouseCode("SP");
-       ScottishMember[] scottishMembers = getDataFromAPI(apiScottishParliament, MediaType.APPLICATION_JSON, ScottishMember[].class);
-        return Arrays.stream(scottishMembers).map(m -> new Member(House.HOUSE_SCOTTISH_PARLIAMENT.getDisplayValue(), m.getName()+" MSP", houseAddress.getUuid(),"SC"+m.getPersonId())).collect(Collectors.toSet());
+        try {
+            final HouseAddress houseAddress = retrieveHouseAddress(HouseCodes.SCOTTISH_PARLIAMENT);
+
+            ScottishMember[] scottishMembers = getDataFromAPI(apiScottishParliament, MediaType.APPLICATION_JSON, ScottishMember[].class);
+
+            return Arrays.stream(scottishMembers)
+                    .map(m ->
+                            new Member(House.HOUSE_SCOTTISH_PARLIAMENT.getDisplayValue(),
+                                    m.getName()+" MSP",
+                                    houseAddress.getUuid(),
+                                    "SC"+m.getPersonId()))
+                    .collect(Collectors.toSet());
+        } catch (ApplicationExceptions.EntityNotFoundException ex) {
+            log.info(ex.getMessage());
+            return Collections.emptySet();
+        }
     }
 
     public Set<Member> createCommonsFromUKParliamentAPI() {
         log.info("Updating House of Commons");
-        HouseAddress houseAddress = houseAddressRepository.findByHouseCode("HC");
-        UKMembers ukUKMembers = getDataFromAPI(getFormattedUkEndpoint(HOUSE_COMMONS), MediaType.APPLICATION_XML, UKMembers.class);
-        return ukUKMembers.getMembers().stream().map(m -> new Member(House.HOUSE_COMMONS.getDisplayValue(),m.getFullTitle(), houseAddress.getUuid(),"CO"+m.getMemberId())).collect(Collectors.toSet());
+        try {
+            final HouseAddress houseAddress = retrieveHouseAddress(HouseCodes.HOUSE_OF_COMMONS);
+
+            UKMembers houseOfCommomsMembers = getDataFromAPI(getFormattedUkEndpoint(HOUSE_COMMONS), MediaType.APPLICATION_XML, UKMembers.class);
+
+            return houseOfCommomsMembers.getMembers()
+                    .stream().map(m ->
+                            new Member(House.HOUSE_COMMONS.getDisplayValue(),
+                                    m.getFullTitle(),
+                                    houseAddress.getUuid(),
+                                    "CO"+m.getMemberId()))
+                    .collect(Collectors.toSet());
+        } catch (ApplicationExceptions.EntityNotFoundException ex) {
+            log.info(ex.getMessage());
+            return Collections.emptySet();
+        }
     }
 
     public Set<Member> createLordsFromUKParliamentAPI() {
         log.info("Updating House of Lords");
-        HouseAddress houseAddress = houseAddressRepository.findByHouseCode("HL");
-        UKMembers ukUKMembers = getDataFromAPI(getFormattedUkEndpoint(HOUSE_LORDS), MediaType.APPLICATION_XML, UKMembers.class);
-        return ukUKMembers.getMembers().stream().map(m -> new Member(House.HOUSE_LORDS.getDisplayValue(), m.getFullTitle(), houseAddress.getUuid(),"LO"+m.getMemberId())).collect(Collectors.toSet());
+        try {
+            final HouseAddress houseAddress = retrieveHouseAddress(HouseCodes.HOUSE_OF_LORDS);
+
+            UKMembers houseOfLordsMembers = getDataFromAPI(getFormattedUkEndpoint(HOUSE_LORDS), MediaType.APPLICATION_XML, UKMembers.class);
+
+            return houseOfLordsMembers.getMembers()
+                    .stream().map(m ->
+                            new Member(House.HOUSE_LORDS.getDisplayValue(),
+                                    m.getFullTitle(),
+                                    houseAddress.getUuid(),
+                                    "LO"+m.getMemberId()))
+                    .collect(Collectors.toSet());
+        } catch (ApplicationExceptions.EntityNotFoundException ex) {
+            log.info(ex.getMessage());
+            return Collections.emptySet();
+        }
     }
 
     public Set<Member> createFromWelshAssemblyAPI() {
         log.info("Updating Welsh Assembly");
-        HouseAddress houseAddress = houseAddressRepository.findByHouseCode("WA");
-        WelshWards welshWards = getDataFromAPI(apiWelshAssembly, MediaType.APPLICATION_XML, WelshWards.class);
-        Set<WelshMembers> welshMembers = welshWards.getWards().stream().map(WelshWard::getMembers).collect(Collectors.toSet());
-        Set<WelshMember> welshMemberSet = welshMembers.stream().map(WelshMembers::getMembers).flatMap(Collection::stream).collect(Collectors.toSet());
-        return welshMemberSet.stream().map(m -> new Member(House.HOUSE_WELSH_ASSEMBLY.getDisplayValue(), m.getName(), houseAddress.getUuid(),"WE"+m.getId())).collect(Collectors.toSet());
+        try {
+            final HouseAddress houseAddress = retrieveHouseAddress(HouseCodes.WELSH_ASSEMBLY);
+
+            WelshWards welshWards = getDataFromAPI(apiWelshAssembly, MediaType.APPLICATION_XML, WelshWards.class);
+
+            Set<WelshMembers> welshMembers = welshWards.getWards().stream()
+                    .map(WelshWard::getMembers)
+                    .collect(Collectors.toSet());
+
+            Set<WelshMember> welshMemberSet = welshMembers.stream()
+                    .map(WelshMembers::getMembers)
+                    .flatMap(Collection::stream)
+                    .collect(Collectors.toSet());
+
+            return welshMemberSet.stream()
+                    .map(m ->
+                            new Member(House.HOUSE_WELSH_ASSEMBLY.getDisplayValue(),
+                                    m.getName(),
+                                    houseAddress.getUuid(),
+                                    "WE"+m.getId()))
+                    .collect(Collectors.toSet());
+        } catch(ApplicationExceptions.EntityNotFoundException ex) {
+            log.info(ex.getMessage());
+            return Collections.emptySet();
+        }
     }
 
     public Set<Country> createFromCountryRegisterAPI() {
@@ -104,10 +180,12 @@ public class ListConsumerService {
         HttpHeaders headers = new HttpHeaders();
         headers.setAccept(Collections.singletonList(mediaType));
         HttpEntity<String> entity = new HttpEntity<>("parameters", headers);
-        ResponseEntity<T> response = null;
 
+        ResponseEntity<T> response = null;
         try {
+            log.info("Attempting to hit endpoint {}, returning type {} of class {}", apiEndpoint, mediaType, returnClass.getName());
             response = restTemplate.exchange(apiEndpoint, HttpMethod.GET, entity, returnClass);
+            log.info("Response to endpoint {} is {}", apiEndpoint, response);
         } catch (Exception e) {
             log.info("exchange call exception : " + e.getMessage());
             throw new ApplicationExceptions.IngestException("ListConsumerService exchange exception : " + e.getMessage() + " endpoint : " +
@@ -117,8 +195,17 @@ public class ListConsumerService {
         return response.getBody();
     }
 
-    private String getFormattedUkEndpoint(final String house) {
+    private String getFormattedUkEndpoint(@NonNull final String house) {
         return String.format(apiUkParliament, house);
     }
 
+    private HouseAddress retrieveHouseAddress(@NonNull final HouseCodes houseCode) {
+        HouseAddress houseAddress = houseAddressRepository.findByHouseCode(houseCode.getHouseCode());
+
+        if (houseAddress == null) {
+            throw new ApplicationExceptions.EntityNotFoundException(
+                    String.format("House address for code %s could not be found.", houseCode.getHouseCode()));
+        }
+        return houseAddress;
+    }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/enums/House.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/enums/House.java
@@ -1,4 +1,4 @@
-package uk.gov.digital.ho.hocs.info.domain.model;
+package uk.gov.digital.ho.hocs.info.domain.model.enums;
 
 import lombok.Getter;
 
@@ -12,9 +12,9 @@ public enum House {
     HOUSE_WELSH_ASSEMBLY("Welsh Assembly");
 
     @Getter
-    private String displayValue;
+    private final String displayValue;
 
-    House(String value) {
+    House(final String value) {
         displayValue = value;
     }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/enums/HouseCodes.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/enums/HouseCodes.java
@@ -1,0 +1,19 @@
+package uk.gov.digital.ho.hocs.info.domain.model.enums;
+
+import lombok.Getter;
+
+public enum HouseCodes {
+
+    IRISH_ASSEMBLY("NI"),
+    HOUSE_OF_COMMONS("HC"),
+    HOUSE_OF_LORDS("HL"),
+    SCOTTISH_PARLIAMENT("SP"),
+    WELSH_ASSEMBLY("WA");
+
+    @Getter
+    private final String houseCode;
+
+    HouseCodes(final String houseCode) {
+        this.houseCode = houseCode;
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/info/client/ingest/ListConsumerServicesTests.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/client/ingest/ListConsumerServicesTests.java
@@ -1,0 +1,67 @@
+package uk.gov.digital.ho.hocs.info.client.ingest;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.digital.ho.hocs.info.domain.exception.ApplicationExceptions;
+import uk.gov.digital.ho.hocs.info.domain.model.HouseAddress;
+import uk.gov.digital.ho.hocs.info.domain.model.Member;
+import uk.gov.digital.ho.hocs.info.domain.repository.HouseAddressRepository;
+
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ListConsumerServicesTests {
+
+    @Mock
+    private HouseAddressRepository houseAddressRepository;
+
+    @Mock
+    private RestTemplate restTemplate;
+
+
+    private ListConsumerService listConsumerService;
+
+    @Before
+    public void setUp() {
+        this.listConsumerService =
+                new ListConsumerService("Test1",
+                        "Test2",
+                        "Test3",
+                        "Test4",
+                        "Test5",
+                        "Test6",
+                        houseAddressRepository,
+                        restTemplate);
+    }
+
+    @Test(expected = ApplicationExceptions.IngestException.class)
+    public void getDataFromAPI_whenRestTemplateThrowsException_handlesException() {
+        when(houseAddressRepository.findByHouseCode(any())).thenReturn(new HouseAddress());
+        when(restTemplate.exchange(eq("Test3"), eq(HttpMethod.GET), any(), eq(IrishMembers.class)))
+                .thenThrow(new RestClientException("Test"));
+
+        listConsumerService.createFromIrishAssemblyAPI();
+    }
+
+    @Test
+    public void retrieveHouseAddress_whenRepoReturnsNull_shouldReturnEmptyCollection() {
+        when(houseAddressRepository.findByHouseCode(any())).thenReturn(null);
+
+        Set<Member> members = listConsumerService.createFromIrishAssemblyAPI();
+
+        verify(houseAddressRepository).findByHouseCode(any());
+
+        assert(members).isEmpty();
+    }
+}


### PR DESCRIPTION
Currently if a house address does not exist within the database for specific API then when we come to populating the members we get a Null Pointer Exception. This is causing specific live systems fail with this during a CronJob to refresh the members list. As the CronJob is set to restart 3 times this is triggering our SysDig alerts.

This change improves the general checking and makes it so that it fails graciously if a HouseAddress does not exist in the system. We now get a log output if the HouseAddress does not exist but it continues to try for the rest. 