### PR TITLE
HOCS-2452 Supporting Add User in ManagementUI

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/UserResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/UserResource.java
@@ -1,10 +1,13 @@
 package uk.gov.digital.ho.hocs.info.api;
 
+import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import uk.gov.digital.ho.hocs.info.api.dto.CreateUserDto;
+import uk.gov.digital.ho.hocs.info.api.dto.CreateUserResponse;
+import uk.gov.digital.ho.hocs.info.api.dto.UpdateUserDto;
 import uk.gov.digital.ho.hocs.info.api.dto.UserDto;
 
 import java.util.List;
@@ -50,11 +53,17 @@ public class UserResource {
     }
 
     @PostMapping(value = "/user", produces = APPLICATION_JSON_UTF8_VALUE)
-    public ResponseEntity createUser(@RequestBody CreateUserDto createUserDto) {
-        userService.createUser(createUserDto);
-        return ResponseEntity.ok().build();
+    public ResponseEntity<CreateUserResponse> createUser(@Valid @RequestBody CreateUserDto createUserDto) {
+        CreateUserResponse createUserResponse = userService.createUser(createUserDto);
+        userService.refreshUserCache();
+        return ResponseEntity.ok().body(createUserResponse);
     }
 
-
+    @PutMapping(value = "/user/{userUUID}", produces = APPLICATION_JSON_UTF8_VALUE)
+    public ResponseEntity updateUser(@PathVariable UUID userUUID, @Valid @RequestBody UpdateUserDto updateUserDto) {
+        userService.updateUser(userUUID, updateUserDto);
+        userService.refreshUserCache();
+        return ResponseEntity.ok().build();
+    }
 }
 

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/UserService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/UserService.java
@@ -6,6 +6,8 @@ import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import uk.gov.digital.ho.hocs.info.api.dto.CreateUserDto;
+import uk.gov.digital.ho.hocs.info.api.dto.CreateUserResponse;
+import uk.gov.digital.ho.hocs.info.api.dto.UpdateUserDto;
 import uk.gov.digital.ho.hocs.info.api.dto.UserDto;
 import uk.gov.digital.ho.hocs.info.client.caseworkclient.CaseworkClient;
 import uk.gov.digital.ho.hocs.info.security.KeycloakService;
@@ -44,8 +46,12 @@ public class UserService {
         return keycloakService.getAllUsers().stream().map(user -> UserDto.from(user)).collect(Collectors.toList());
     }
 
-    public void createUser(CreateUserDto createUserDto) {
-        keycloakService.createUser(createUserDto);
+    public CreateUserResponse createUser(CreateUserDto createUserDto) {
+        return keycloakService.createUser(createUserDto);
+    }
+
+    public void updateUser(UUID userUUID, UpdateUserDto updateUserDto) {
+        keycloakService.updateUser(userUUID, updateUserDto);
     }
 
     public UserDto getUserByUUID(UUID userUUID) {

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/CreateUserResponse.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/CreateUserResponse.java
@@ -1,0 +1,15 @@
+package uk.gov.digital.ho.hocs.info.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class CreateUserResponse {
+
+    @JsonProperty("userUUID")
+    String userUUID;
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/UpdateUserDto.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/UpdateUserDto.java
@@ -1,26 +1,25 @@
 package uk.gov.digital.ho.hocs.info.api.dto;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import uk.gov.digital.ho.hocs.info.utils.EmailDomainWhitelisted;
 
-@java.lang.SuppressWarnings("squid:S1068")
+@SuppressWarnings("squid:S1068")
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
-public class CreateUserDto {
-
-    @NotBlank(message = "Email is mandatory")
-    @EmailDomainWhitelisted(message = "Email domain not supported")
-    private String email;
+public class UpdateUserDto {
 
     @NotBlank(message = "First Name is mandatory")
     private String firstName;
 
     @NotBlank(message = "Last Name is mandatory")
     private String lastName;
+
+    @NotNull(message = "Enabled is mandatory")
+    private Boolean enabled;
 
 }
 

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/UserDto.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/UserDto.java
@@ -2,24 +2,24 @@ package uk.gov.digital.ho.hocs.info.api.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.keycloak.representations.idm.UserRepresentation;
 
 @AllArgsConstructor
+@NoArgsConstructor
 @Getter
 public class UserDto {
 
     private String id;
     private String username;
+    private String email;
     private String firstName;
     private String lastName;
-    private String email;
+    private boolean enabled;
 
     public static UserDto from(UserRepresentation user) {
-        return new UserDto(user.getId(),user.getUsername(), user.getFirstName(),
-                user.getLastName(),user.getEmail());
+        return new UserDto(user.getId(), user.getUsername(), user.getEmail(), user.getFirstName(), user.getLastName(), user.isEnabled());
     }
-
-
 }
 
 

--- a/src/main/java/uk/gov/digital/ho/hocs/info/security/KeycloakException.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/security/KeycloakException.java
@@ -2,11 +2,22 @@ package uk.gov.digital.ho.hocs.info.security;
 
 public class KeycloakException extends RuntimeException {
 
+    private Integer httpStatus;
+
+    public KeycloakException(String message, Integer httpStatus) {
+        super(message);
+        this.httpStatus = httpStatus;
+    }
+
     public KeycloakException(String message, Throwable cause) {
         super(message, cause);
     }
 
     public KeycloakException(String message) {
         super(message);
+    }
+
+    public Integer getHttpStatus() {
+        return httpStatus;
     }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/info/utils/EmailDomainValidator.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/utils/EmailDomainValidator.java
@@ -1,0 +1,24 @@
+package uk.gov.digital.ho.hocs.info.utils;
+
+import static java.util.Arrays.asList;
+
+import java.util.List;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EmailDomainValidator implements ConstraintValidator<EmailDomainWhitelisted, String> {
+
+    @Value("${user.email.whitelist}")
+    private List<String> whitelistedDomains = asList("homeoffice.gov.uk");
+
+    @Override
+    public void initialize(EmailDomainWhitelisted emailDomainWhitelisted) { }
+
+    @Override
+    public boolean isValid(String emailAddress, ConstraintValidatorContext cxt) {
+      return emailAddress == null || emailAddress.isBlank() || whitelistedDomains.stream().anyMatch(emailAddress::endsWith);
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/info/utils/EmailDomainWhitelisted.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/utils/EmailDomainWhitelisted.java
@@ -1,0 +1,19 @@
+package uk.gov.digital.ho.hocs.info.utils;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Documented
+@Constraint(validatedBy = EmailDomainValidator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EmailDomainWhitelisted {
+  String message() default "Email domain invalid";
+  Class<?>[] groups() default {};
+  Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -56,3 +56,5 @@ auditing.deployment.name=hocs-info-service
 
 aws.sqs.access.key=12345
 audit.aws.sqs.access.key=12345
+
+user.email.whitelist=homeoffice.gov.uk

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/UserIntegrationTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/UserIntegrationTest.java
@@ -1,0 +1,110 @@
+package uk.gov.digital.ho.hocs.info.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+import static org.springframework.test.context.jdbc.SqlConfig.TransactionMode.ISOLATED;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.UUID;
+import org.apache.http.entity.ContentType;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlConfig;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.digital.ho.hocs.info.api.dto.CreateTopicDto;
+import uk.gov.digital.ho.hocs.info.api.dto.CreateTopicResponse;
+import uk.gov.digital.ho.hocs.info.api.dto.CreateUserDto;
+import uk.gov.digital.ho.hocs.info.api.dto.CreateUserResponse;
+import uk.gov.digital.ho.hocs.info.api.dto.UpdateUserDto;
+import uk.gov.digital.ho.hocs.info.api.dto.UserDto;
+import uk.gov.digital.ho.hocs.info.domain.repository.UnitRepository;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Sql(scripts = "classpath:beforeTest.sql", config = @SqlConfig(transactionMode = ISOLATED))
+@Sql(scripts = "classpath:afterTest.sql", config = @SqlConfig(transactionMode = ISOLATED), executionPhase = AFTER_TEST_METHOD)
+@ActiveProfiles("test")
+public class UserIntegrationTest {
+
+    TestRestTemplate restTemplate = new TestRestTemplate();
+
+    private HttpHeaders headers;
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @Before
+    public void setup() throws IOException {
+        headers = new HttpHeaders();
+        headers.add(HttpHeaders.ACCEPT, ContentType.APPLICATION_JSON.toString());
+    }
+
+    @Test
+    public void shouldCreateUser() {
+
+        //create
+        CreateUserDto createUserDto = new CreateUserDto("aa" + System.currentTimeMillis() + "@homeoffice.gov.uk", "Bbbbb", "Ccccc");
+
+        HttpEntity httpEntity = new HttpEntity(createUserDto, headers);
+        ResponseEntity<CreateUserResponse> postResponse = restTemplate.exchange(
+            getBasePath() + "/user", HttpMethod.POST, httpEntity, CreateUserResponse.class);
+        CreateUserResponse createUserResponse = postResponse.getBody();
+
+        //get
+        ResponseEntity<UserDto> getResponse = restTemplate.exchange(
+            getBasePath() + "/user/" + createUserResponse.getUserUUID(), HttpMethod.GET, httpEntity, UserDto.class);
+        UserDto userDto = getResponse.getBody();
+        assertThat(userDto.getEmail()).isEqualTo(createUserDto.getEmail());
+        assertThat(userDto.getFirstName()).isEqualTo(createUserDto.getFirstName());
+        assertThat(userDto.getLastName()).isEqualTo(createUserDto.getLastName());
+        assertThat(userDto.isEnabled()).isEqualTo(true);
+    }
+
+    @Test
+    public void shouldUpdateUser() {
+
+        // create
+        CreateUserDto createUserDto = new CreateUserDto("aa" + System.currentTimeMillis() + "@homeoffice.gov.uk", "Bbbbb", "Ccccc");
+        HttpEntity httpEntity = new HttpEntity(createUserDto, headers);
+        ResponseEntity<CreateUserResponse> postResponse = restTemplate.exchange(
+            getBasePath() + "/user", HttpMethod.POST, httpEntity, CreateUserResponse.class);
+        CreateUserResponse createUserResponse = postResponse.getBody();
+
+        //update
+        UpdateUserDto updateUserDto = new UpdateUserDto("Dddddd", "Eeeeee", false);
+        HttpEntity httpEntity2 = new HttpEntity(updateUserDto, headers);
+        restTemplate.exchange(
+            getBasePath() + "/user/" + createUserResponse.getUserUUID(), HttpMethod.PUT, httpEntity2, String.class);
+
+        //get
+        ResponseEntity<UserDto> getResponse = restTemplate.exchange(
+            getBasePath() + "/user/" + createUserResponse.getUserUUID(), HttpMethod.GET, httpEntity, UserDto.class);
+        UserDto userDto = getResponse.getBody();
+        assertThat(userDto.getEmail()).isEqualTo(createUserDto.getEmail());
+        assertThat(userDto.getFirstName()).isEqualTo(updateUserDto.getFirstName());
+        assertThat(userDto.getLastName()).isEqualTo(updateUserDto.getLastName());
+        assertThat(userDto.isEnabled()).isEqualTo(updateUserDto.getEnabled());
+    }
+
+    private String getBasePath() {
+        return "http://localhost:" + port;
+    }
+}
+
+

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/UserResourceRestTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/UserResourceRestTest.java
@@ -1,0 +1,54 @@
+package uk.gov.digital.ho.hocs.info.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.digital.ho.hocs.info.api.dto.CreateUserDto;
+
+// NB. This sort of test reads the spring properties files.
+@RunWith(SpringRunner.class)
+@WebMvcTest(UserResource.class)
+public class UserResourceRestTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private UserService userService;
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  public void testCreateUserWithWhitelistedDomain() throws Exception {
+    CreateUserDto user = new CreateUserDto("mick@homeoffice.gov.uk", "firstName", "lastName");
+    mockMvc.perform(post("/user")
+        .content(mapper.writeValueAsString(user))
+        .contentType(APPLICATION_JSON_UTF8)
+    )
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  public void testCreateUserWithNonWhitelistedDomain() throws Exception {
+    CreateUserDto user = new CreateUserDto("mick@test.com", "firstName", "lastName");
+    String res = mockMvc.perform(post("/user")
+        .content(mapper.writeValueAsString(user))
+        .contentType(APPLICATION_JSON_UTF8)
+    )
+        .andExpect(status().isBadRequest())
+        .andReturn()
+        .getResponse()
+        .getContentAsString();
+    assertThat(res).isEqualTo("Email domain not supported");
+  }
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/UserResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/UserResourceTest.java
@@ -1,23 +1,25 @@
 package uk.gov.digital.ho.hocs.info.api;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import uk.gov.digital.ho.hocs.info.api.UserResource;
-import uk.gov.digital.ho.hocs.info.api.UserService;
-import uk.gov.digital.ho.hocs.info.api.dto.UserDto;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import uk.gov.digital.ho.hocs.info.api.dto.CreateUserDto;
+import uk.gov.digital.ho.hocs.info.api.dto.CreateUserResponse;
+import uk.gov.digital.ho.hocs.info.api.dto.UpdateUserDto;
+import uk.gov.digital.ho.hocs.info.api.dto.UserDto;
 
 @RunWith(MockitoJUnitRunner.class)
 public class UserResourceTest {
@@ -27,19 +29,23 @@ public class UserResourceTest {
 
     UserResource userResource;
 
+    @Before
+    public void setUp() {
+        userResource = new UserResource(userService);
+    }
+
     @Test
     public void shouldGetAllUsers() {
 
         String user1UUID = UUID.randomUUID().toString();
         String user2UUID = UUID.randomUUID().toString();
         List<UserDto> users = new ArrayList<>();
-        UserDto user1 =  new UserDto(user1UUID,"some user","FirstName", "LastName","user1@noemail.com");
-        UserDto user2 =  new UserDto(user2UUID,"some user2","FirstName2", "LastName2","user2@noemail.com");
+        UserDto user1 =  new UserDto(user1UUID,"some user", "user1@noemail.com","FirstName", "LastName", true);
+        UserDto user2 =  new UserDto(user2UUID,"some user2", "user2@noemail.com","FirstName2", "LastName2", true);
         users.addAll(Stream.of(user1, user2).collect(Collectors.toList()));
 
         when(userService.getAllUsers()).thenReturn(users);
 
-        userResource = new UserResource(userService);
         ResponseEntity<List<UserDto>> result = userResource.getAllUsers();
         assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(result.getBody().size()).isEqualTo(2);
@@ -49,11 +55,10 @@ public class UserResourceTest {
     public void shouldGetUserByUUID() {
 
         UUID userUUID = UUID.randomUUID();
-        UserDto user =  new UserDto(userUUID.toString(),"some user","FirstName", "LastName","user1@noemail.com");
+        UserDto user =  new UserDto(userUUID.toString(),"some user", "user1@noemail.com","FirstName", "LastName", true);
 
         when(userService.getUserByUUID(userUUID)).thenReturn(user);
 
-        userResource = new UserResource(userService);
         ResponseEntity<UserDto> result = userResource.getUserByUUID(userUUID);
         assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
     }
@@ -65,14 +70,13 @@ public class UserResourceTest {
         UUID teamUUID = UUID.randomUUID();
 
         List<UserDto> users = new ArrayList<>();
-        UserDto user1 =  new UserDto(user1UUID,"some user","FirstName", "LastName","user1@noemail.com");
-        UserDto user2 =  new UserDto(user2UUID,"some user2","FirstName2", "LastName2","user2@noemail.com");
+        UserDto user1 =  new UserDto(user1UUID,"some user", "user1@noemail.com","FirstName", "LastName", true);
+        UserDto user2 =  new UserDto(user2UUID,"some user2", "user2@noemail.com","FirstName2", "LastName2", true);
         users.addAll(Stream.of(user1, user2).collect(Collectors.toList()));
 
 
         when(userService.getUsersForTeam(teamUUID)).thenReturn(users);
 
-        userResource = new UserResource(userService);
         ResponseEntity<List<UserDto>> result = userResource.getUsersForTeam(teamUUID);
         assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(result.getBody().size()).isEqualTo(2);
@@ -82,13 +86,45 @@ public class UserResourceTest {
     public void shouldGetUserForTeam() {
         UUID teamUUID = UUID.randomUUID();
         UUID userUUID = UUID.randomUUID();
-        UserDto user =  new UserDto(userUUID.toString(),"some user","FirstName", "LastName","user1@noemail.com");
+        UserDto user =  new UserDto(userUUID.toString(),"some user", "user1@noemail.com","FirstName", "LastName", true);
         when(userService.getUserForTeam(teamUUID, userUUID)).thenReturn(user);
 
-        userResource = new UserResource(userService);
         ResponseEntity<UserDto> result = userResource.getUserForTeam(teamUUID, userUUID);
 
         assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(result.getBody()).isEqualTo(user);
+    }
+
+    @Test
+    public void shouldCreateUser() {
+
+        //given
+        CreateUserDto createUserDto = new CreateUserDto();
+        CreateUserResponse createUserResponse = new CreateUserResponse();
+        when(userService.createUser(createUserDto)).thenReturn(createUserResponse);
+
+        //when
+        ResponseEntity<CreateUserResponse> response = userResource.createUser(createUserDto);
+
+        //then
+        verify(userService).refreshUserCache();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(createUserResponse);
+    }
+
+    @Test
+    public void shouldUpdateUser() {
+
+        //given
+        UUID userUUID = UUID.randomUUID();
+        UpdateUserDto updateUserDto = new UpdateUserDto();
+
+        //when
+        ResponseEntity response = userResource.updateUser(userUUID, updateUserDto);
+
+        //then
+        verify(userService).updateUser(userUUID, updateUserDto);
+        verify(userService).refreshUserCache();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/dto/CreateUserDtoTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/dto/CreateUserDtoTest.java
@@ -1,0 +1,92 @@
+package uk.gov.digital.ho.hocs.info.api.dto;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import org.hibernate.validator.HibernateValidator;
+import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorFactoryImpl;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+import uk.gov.digital.ho.hocs.info.utils.EmailDomainValidator;
+
+public class CreateUserDtoTest {
+
+    private static Validator validator;
+
+    @BeforeClass
+    public static void setUp() {
+      ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+      validator = factory.getValidator();
+    }
+
+    @Test
+    public void checkEmailMandatory() {
+      CreateUserDto createUserDto = new CreateUserDto(null, "firstname", "lastname");
+      Set<ConstraintViolation<CreateUserDto>> constraintViolations = validator.validate(createUserDto);
+      assertThat(constraintViolations).hasSize(1);
+      ConstraintViolation<CreateUserDto> cv = constraintViolations.iterator().next();
+      assertThat(cv.getMessage()).isEqualTo("Email is mandatory");
+    }
+
+  @Test
+  public void checkEmailNotEmptyString() {
+    CreateUserDto createUserDto = new CreateUserDto("", "firstname", "lastname");
+    Set<ConstraintViolation<CreateUserDto>> constraintViolations = validator.validate(createUserDto);
+    assertThat(constraintViolations).hasSize(1);
+    ConstraintViolation<CreateUserDto> cv = constraintViolations.iterator().next();
+    assertThat(cv.getMessage()).isEqualTo("Email is mandatory");
+  }
+
+  @Test
+  public void checkEmailWithNonWhitelistedDomain() {
+    CreateUserDto createUserDto = new CreateUserDto("test@bbc.co.uk", "firstname", "lastname");
+    Set<ConstraintViolation<CreateUserDto>> constraintViolations = validator.validate(createUserDto);
+    assertThat(constraintViolations).hasSize(1);
+    ConstraintViolation<CreateUserDto> cv = constraintViolations.iterator().next();
+    assertThat(cv.getMessage()).isEqualTo("Email domain not supported");
+  }
+
+  @Test
+  public void checkFirstNameMandatory() {
+    CreateUserDto createUserDto = new CreateUserDto("test@homeoffice.gov.uk", null, "lastname");
+    Set<ConstraintViolation<CreateUserDto>> constraintViolations = validator.validate(createUserDto);
+    assertThat(constraintViolations).hasSize(1);
+    ConstraintViolation<CreateUserDto> cv = constraintViolations.iterator().next();
+    assertThat(cv.getMessage()).isEqualTo("First Name is mandatory");
+  }
+
+  @Test
+  public void checkFirstNameNotEmptyString() {
+    CreateUserDto createUserDto = new CreateUserDto("test@homeoffice.gov.uk", "", "lastname");
+    Set<ConstraintViolation<CreateUserDto>> constraintViolations = validator.validate(createUserDto);
+    assertThat(constraintViolations).hasSize(1);
+    ConstraintViolation<CreateUserDto> cv = constraintViolations.iterator().next();
+    assertThat(cv.getMessage()).isEqualTo("First Name is mandatory");
+  }
+
+  @Test
+  public void checkLastNameMandatory() {
+    CreateUserDto createUserDto = new CreateUserDto("test@homeoffice.gov.uk", "firstname", null);
+    Set<ConstraintViolation<CreateUserDto>> constraintViolations = validator.validate(createUserDto);
+    assertThat(constraintViolations).hasSize(1);
+    ConstraintViolation<CreateUserDto> cv = constraintViolations.iterator().next();
+    assertThat(cv.getMessage()).isEqualTo("Last Name is mandatory");
+  }
+
+  @Test
+  public void checkLastNameNotEmptyString() {
+    CreateUserDto createUserDto = new CreateUserDto("test@homeoffice.gov.uk", "firstname", "");
+    Set<ConstraintViolation<CreateUserDto>> constraintViolations = validator.validate(createUserDto);
+    assertThat(constraintViolations).hasSize(1);
+    ConstraintViolation<CreateUserDto> cv = constraintViolations.iterator().next();
+    assertThat(cv.getMessage()).isEqualTo("Last Name is mandatory");
+  }
+
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/dto/UpdateUserDtoTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/dto/UpdateUserDtoTest.java
@@ -1,0 +1,69 @@
+package uk.gov.digital.ho.hocs.info.api.dto;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class UpdateUserDtoTest {
+
+    private static Validator validator;
+
+    @BeforeClass
+    public static void setUp() {
+      ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+      validator = factory.getValidator();
+    }
+
+  @Test
+  public void checkFirstNameMandatory() {
+    UpdateUserDto updateUserDto = new UpdateUserDto(null, "lastname", true);
+    Set<ConstraintViolation<UpdateUserDto>> constraintViolations = validator.validate(updateUserDto);
+    assertThat(constraintViolations).hasSize(1);
+    ConstraintViolation<UpdateUserDto> cv = constraintViolations.iterator().next();
+    assertThat(cv.getMessage()).isEqualTo("First Name is mandatory");
+  }
+
+  @Test
+  public void checkFirstNameNotEmptyString() {
+    UpdateUserDto updateUserDto = new UpdateUserDto("", "lastname", true);
+    Set<ConstraintViolation<UpdateUserDto>> constraintViolations = validator.validate(updateUserDto);
+    assertThat(constraintViolations).hasSize(1);
+    ConstraintViolation<UpdateUserDto> cv = constraintViolations.iterator().next();
+    assertThat(cv.getMessage()).isEqualTo("First Name is mandatory");
+  }
+
+  @Test
+  public void checkLastNameMandatory() {
+    UpdateUserDto updateUserDto = new UpdateUserDto("firstname", null, true);
+    Set<ConstraintViolation<UpdateUserDto>> constraintViolations = validator.validate(updateUserDto);
+    assertThat(constraintViolations).hasSize(1);
+    ConstraintViolation<UpdateUserDto> cv = constraintViolations.iterator().next();
+    assertThat(cv.getMessage()).isEqualTo("Last Name is mandatory");
+  }
+
+  @Test
+  public void checkLastNameNotEmptyString() {
+    UpdateUserDto updateUserDto = new UpdateUserDto("firstname", "", true);
+    Set<ConstraintViolation<UpdateUserDto>> constraintViolations = validator.validate(updateUserDto);
+    assertThat(constraintViolations).hasSize(1);
+    ConstraintViolation<UpdateUserDto> cv = constraintViolations.iterator().next();
+    assertThat(cv.getMessage()).isEqualTo("Last Name is mandatory");
+  }
+
+  @Test
+  public void checkEnabledMandatory() {
+    UpdateUserDto updateUserDto = new UpdateUserDto("firstname", "lastname", null);
+    Set<ConstraintViolation<UpdateUserDto>> constraintViolations = validator.validate(updateUserDto);
+    assertThat(constraintViolations).hasSize(1);
+    ConstraintViolation<UpdateUserDto> cv = constraintViolations.iterator().next();
+    assertThat(cv.getMessage()).isEqualTo("Enabled is mandatory");
+  }
+
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -24,6 +24,8 @@ api.country.register=https://country.register.gov.uk/records.json?page-size=5000
 api.territory.register=https://territory.register.gov.uk/records.json?page-size=5000
 
 cache.user.refresh=3600
+retry.maxAttempts=3
+retry.delay=2000
 
 audit.queue.name=audit-queue
 audit.queue=seda://${audit.queue.name}
@@ -31,3 +33,5 @@ auditing.deployment.namespace=local
 auditing.deployment.name=${info.app.name} 
 
 #spring.flyway.clean-on-validation-error=true
+
+user.email.whitelist=homeoffice.gov.uk


### PR DESCRIPTION
This is to support adding users in the Management UI.

There are new new UserResource endpoints for adding and updating users, with associated changes in the services.

Exception handling has been modified, while still supporting existing behaviour. The changes were required to support meaningful validation messages in the Management UI.
1. MethodArgumentNotValidException returns the specific reason the validation failed.
2. KeyCloakException now has a statusCode property which can store the status code received from the Keycloak server. This can then be used in the response to the client.