### PR TITLE
HOCS-2616: add hmpo to whitelist domain

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -57,4 +57,4 @@ auditing.deployment.name=hocs-info-service
 aws.sqs.access.key=12345
 audit.aws.sqs.access.key=12345
 
-user.email.whitelist=homeoffice.gov.uk
+user.email.whitelist=homeoffice.gov.uk,hmpo.gov.uk

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/UserResourceRestTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/UserResourceRestTest.java
@@ -15,6 +15,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.digital.ho.hocs.info.api.dto.CreateUserDto;
 
+import java.util.List;
+
 // NB. This sort of test reads the spring properties files.
 @RunWith(SpringRunner.class)
 @WebMvcTest(UserResource.class)
@@ -29,13 +31,17 @@ public class UserResourceRestTest {
   private final ObjectMapper mapper = new ObjectMapper();
 
   @Test
-  public void testCreateUserWithWhitelistedDomain() throws Exception {
-    CreateUserDto user = new CreateUserDto("mick@homeoffice.gov.uk", "firstName", "lastName");
-    mockMvc.perform(post("/user")
-        .content(mapper.writeValueAsString(user))
-        .contentType(APPLICATION_JSON_UTF8)
-    )
-        .andExpect(status().isOk());
+  public void testCreateUserWithWhitelistedDomains() throws Exception {
+    List<String> whitelistedDomains = List.of("mick@homeoffice.gov.uk", "mick@hmpo.gov.uk");
+
+    for (String domain :
+            whitelistedDomains) {
+      CreateUserDto user = new CreateUserDto(domain, "firstName", "lastName");
+      mockMvc.perform(post("/user")
+              .content(mapper.writeValueAsString(user))
+              .contentType(APPLICATION_JSON_UTF8)
+      ).andExpect(status().isOk());
+    }
   }
 
   @Test

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -34,4 +34,4 @@ auditing.deployment.name=${info.app.name}
 
 #spring.flyway.clean-on-validation-error=true
 
-user.email.whitelist=homeoffice.gov.uk
+user.email.whitelist=homeoffice.gov.uk,hmpo.gov.uk


### PR DESCRIPTION
As we currently store the whitelisted domains in 
the `application.properties` file. We need to add 
an extra record so that the `@hmpo.gov.uk` email 
address is whitelisted and thus new user accounts 
can be created with it.