### PR TITLE
HOCS-2642: exclude target

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -119,6 +119,9 @@ trigger:
     exclude:
       - pull_request
       - tag
+  target:
+    exclude:
+      - restart*
 
 services:
   - name: docker


### PR DESCRIPTION
In the deployment pipeline we let through any promotions, as when 
we restart we aren't triggering an actual `promote` but more a 
restart this means we should exclude this from the deployment 
pipeline.