### PR TITLE
HOCS-2642: change to use restart file

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -372,11 +372,8 @@ steps:
     image: quay.io/ukhomeofficedigital/kd:v1.16.0
     commands:
       - cd kube-hocs-info-service
-      - ./deploy.sh
+      - ./restart.sh
     environment:
-      JUST_RESTART: true
-      VERSION: dummy
-      HOCS_INFO_SERVICE_DATA_VERSION: latest
       ENVIRONMENT: cs-dev
       KUBE_TOKEN:
         from_secret: hocs_info_service_cs_dev
@@ -391,11 +388,8 @@ steps:
     image: quay.io/ukhomeofficedigital/kd:v1.16.0
     commands:
       - cd kube-hocs-info-service
-      - ./deploy.sh
+      - ./restart.sh
     environment:
-      JUST_RESTART: true
-      VERSION: dummy
-      HOCS_INFO_SERVICE_DATA_VERSION: latest
       ENVIRONMENT: wcs-dev
       KUBE_TOKEN:
         from_secret: hocs_info_service_wcs_dev


### PR DESCRIPTION
Currently we have issues with caching issues on drone when doing 
restarts. To fix this we have introduced a restart shell file to handle 
the restarting of the services. As a result multiple of the environment
variables can be removed.