### PR TITLE
HOCS-2743: improve the updateTeamName method

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/TeamService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/TeamService.java
@@ -165,13 +165,23 @@ public class TeamService {
 
     }
 
+    @CacheEvict(value = "teams", allEntries = true)
     @Transactional
-    public void updateTeamName(UUID teamUUID, String newName) {
+    public void updateTeamName(UUID teamUUID, String displayName) {
         log.debug("Updating Team {} name", teamUUID);
+
+        Team teamWithName = teamRepository.findByDisplayName(displayName);
+        if (teamWithName != null) {
+            log.debug("Team {} already exists with name, not renaming team {}.", displayName, teamUUID);
+            throw new ApplicationExceptions.EntityAlreadyExistsException(
+                    String.format("Team with name %s already exists.", displayName)
+            );
+        }
+
         Team team = getTeam(teamUUID);
-        team.setDisplayName(newName);
+        team.setDisplayName(displayName);
         auditClient.renameTeamAudit(team);
-        log.info("Team with UUID {} name updated to {}", team.getUuid().toString(), newName, value(EVENT, TEAM_RENAMED));
+        log.info("Team with UUID {} name updated to {}.", team.getUuid().toString(), displayName, value(EVENT, TEAM_RENAMED));
     }
 
     @Transactional

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/TeamRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/TeamRepository.java
@@ -18,6 +18,8 @@ public interface TeamRepository extends CrudRepository<Team, Long> {
 
     Team findByUuidOrDisplayName(UUID uuid, String displayName);
 
+    Team findByDisplayName(String displayName);
+
     Set<Team> findAll();
 
     Set<Team> findAllByActiveTrue();

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/TeamServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/TeamServiceTest.java
@@ -117,14 +117,26 @@ public class TeamServiceTest {
 
     @Test
     public void shouldUpdateName() {
+        String newTeamName = "Test";
         Team team = mock(Team.class);
+        when(teamRepository.findByDisplayName(any())).thenReturn(null);
         when(teamRepository.findByUuid(team1UUID)).thenReturn(team);
         when(team.getUuid()).thenReturn(team1UUID);
-        teamService.updateTeamName(team1UUID, "new team name");
+        teamService.updateTeamName(team1UUID, newTeamName);
 
+        verify(teamRepository, times(1)).findByDisplayName(newTeamName);
         verify(teamRepository, times(1)).findByUuid(team1UUID);
-        verify(team, times(1)).setDisplayName("new team name");
+        verify(team, times(1)).setDisplayName(newTeamName);
         verifyNoMoreInteractions(teamRepository);
+    }
+
+    @Test(expected = ApplicationExceptions.EntityAlreadyExistsException.class)
+    public void shouldUpdateName_throwWhenTeamWithNameExists() {
+        Team team = mock(Team.class);
+
+        when(teamRepository.findByDisplayName("Test")).thenReturn(team);
+
+        teamService.updateTeamName(team1UUID, "Test");
     }
 
     @Test

--- a/src/test/java/uk/gov/digital/ho/hocs/info/domain/repository/TeamRepositoryTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/domain/repository/TeamRepositoryTest.java
@@ -119,4 +119,12 @@ public class TeamRepositoryTest {
         assertThat(teams.size()).isEqualTo(1);
         assertThat(teams.iterator().next().getUuid()).isEqualTo(teamUUID);
     }
+
+    @Test()
+    public void shouldFindTeamByDisplayName() {
+        Team team = repository.findByDisplayName("a team");
+        assertThat(team.getUnit().getUuid()).isEqualTo(unitUUID);
+        assertThat(team.getUuid()).isEqualTo(team.getUuid());
+    }
+
 }


### PR DESCRIPTION
Presently, the updateTeamName service method does the rename 
blindly. This change does the following: checks if a rename conflict is 
present, evicts the cache of the teams to allow for the update.