### PR TITLE
HOCS-2788: send rename notification to notify queue

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/TeamService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/TeamService.java
@@ -12,6 +12,7 @@ import uk.gov.digital.ho.hocs.info.api.dto.TeamDto;
 import uk.gov.digital.ho.hocs.info.client.audit.client.AuditClient;
 import uk.gov.digital.ho.hocs.info.client.caseworkclient.CaseworkClient;
 import uk.gov.digital.ho.hocs.info.client.caseworkclient.dto.GetTopicResponse;
+import uk.gov.digital.ho.hocs.info.client.notifyclient.NotifyClient;
 import uk.gov.digital.ho.hocs.info.domain.exception.ApplicationExceptions;
 import uk.gov.digital.ho.hocs.info.domain.model.*;
 import uk.gov.digital.ho.hocs.info.domain.repository.ParentTopicRepository;
@@ -36,8 +37,16 @@ public class TeamService {
     private ParentTopicRepository parentTopicRepository;
     private AuditClient auditClient;
     private CaseworkClient caseworkClient;
+    private final NotifyClient notifyClient;
 
-    public TeamService(TeamRepository teamRepository, UnitRepository unitRepository, CaseTypeService caseTypeService, ParentTopicRepository parentTopicRepository, KeycloakService keycloakService, AuditClient auditClient, CaseworkClient caseworkClient) {
+    public TeamService(TeamRepository teamRepository,
+                       UnitRepository unitRepository,
+                       CaseTypeService caseTypeService,
+                       ParentTopicRepository parentTopicRepository,
+                       KeycloakService keycloakService,
+                       AuditClient auditClient,
+                       CaseworkClient caseworkClient,
+                       NotifyClient notifyClient) {
         this.teamRepository = teamRepository;
         this.keycloakService = keycloakService;
         this.unitRepository = unitRepository;
@@ -45,6 +54,7 @@ public class TeamService {
         this.parentTopicRepository = parentTopicRepository;
         this.auditClient = auditClient;
         this.caseworkClient = caseworkClient;
+        this.notifyClient = notifyClient;
     }
 
     public Set<Team> getTeamsForUnit(UUID unitUUID) {
@@ -179,8 +189,10 @@ public class TeamService {
         }
 
         Team team = getTeam(teamUUID);
+        String oldTeamName = team.getDisplayName();
         team.setDisplayName(displayName);
         auditClient.renameTeamAudit(team);
+        notifyClient.sendTeamRenameEmail(teamUUID, oldTeamName);
         log.info("Team with UUID {} name updated to {}.", team.getUuid().toString(), displayName, value(EVENT, TEAM_RENAMED));
     }
 

--- a/src/main/java/uk/gov/digital/ho/hocs/info/application/aws/LocalStackConfiguration.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/application/aws/LocalStackConfiguration.java
@@ -8,6 +8,8 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.sns.AmazonSNS;
 import com.amazonaws.services.sns.AmazonSNSClientBuilder;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -25,6 +27,22 @@ public class LocalStackConfiguration {
         String host = String.format("http://%s:4575/", awsHost);
         AwsClientBuilder.EndpointConfiguration endpoint = new AwsClientBuilder.EndpointConfiguration(host, "eu-west-2");
         return AmazonSNSClientBuilder.standard()
+                .withClientConfiguration(new ClientConfiguration().withProtocol(Protocol.HTTP))
+                .withCredentials(awsCredentialsProvider)
+                .withEndpointConfiguration(endpoint)
+                .build();
+    }
+
+    @Bean("notifySqsClient")
+    public AmazonSQS notifySqsClient() {
+        return sqsClient();
+    }
+
+    public AmazonSQS sqsClient() {
+        String host = String.format("http://%s:4576/", awsHost);
+
+        AwsClientBuilder.EndpointConfiguration endpoint = new AwsClientBuilder.EndpointConfiguration(host, "eu-west-2");
+        return AmazonSQSClientBuilder.standard()
                 .withClientConfiguration(new ClientConfiguration().withProtocol(Protocol.HTTP))
                 .withCredentials(awsCredentialsProvider)
                 .withEndpointConfiguration(endpoint)

--- a/src/main/java/uk/gov/digital/ho/hocs/info/application/aws/SqsConfiguration.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/application/aws/SqsConfiguration.java
@@ -1,0 +1,42 @@
+package uk.gov.digital.ho.hocs.info.application.aws;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.internal.StaticCredentialsProvider;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.util.StringUtils;
+
+@Configuration
+@Profile({ "sqs"})
+public class SqsConfiguration {
+
+    @Bean
+    public AmazonSQS sqsClient(@Value("${notify.aws.sqs.access.key}") String accessKey,
+                               @Value("${notify.aws.sqs.secret.key}") String secretKey,
+                               @Value("${aws.region}") String region) {
+
+        if (StringUtils.isEmpty(accessKey)) {
+            throw new BeanCreationException("Failed to create SQS client bean. Need non-blank value for access key");
+        }
+
+        if (StringUtils.isEmpty(secretKey)) {
+            throw new BeanCreationException("Failed to create SQS client bean. Need non-blank values for secret key");
+        }
+
+        if (StringUtils.isEmpty(region)) {
+            throw new BeanCreationException("Failed to create SQS client bean. Need non-blank values for region");
+        }
+
+        return AmazonSQSClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new StaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey)))
+                .withClientConfiguration(new ClientConfiguration())
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/info/client/notifyclient/NotifyClient.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/client/notifyclient/NotifyClient.java
@@ -1,0 +1,71 @@
+package uk.gov.digital.ho.hocs.info.client.notifyclient;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.camel.ProducerTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import uk.gov.digital.ho.hocs.info.client.notifyclient.dto.TeamRenameCommand;
+import uk.gov.digital.ho.hocs.info.application.RequestData;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static net.logstash.logback.argument.StructuredArguments.value;
+import static uk.gov.digital.ho.hocs.info.application.LogEvent.EVENT;
+import static uk.gov.digital.ho.hocs.info.application.LogEvent.EXCEPTION;
+import static uk.gov.digital.ho.hocs.info.client.notifyclient.dto.EventType.NOTIFY_EMAIL_FAILED;
+import static uk.gov.digital.ho.hocs.info.client.notifyclient.dto.EventType.TEAM_RENAME_EMAIL_SENT;
+
+@Slf4j
+@Component
+public class NotifyClient {
+
+    private final String notifyQueue;
+    private final ProducerTemplate producerTemplate;
+    private final ObjectMapper objectMapper;
+    private final RequestData requestData;
+
+    @Autowired
+    public NotifyClient(ProducerTemplate producerTemplate,
+                        @Value("${notify.queue}") String notifyQueue,
+                        ObjectMapper objectMapper,
+                        RequestData requestData) {
+        this.producerTemplate = producerTemplate;
+        this.notifyQueue = notifyQueue;
+        this.objectMapper = objectMapper;
+        this.requestData = requestData;
+    }
+
+    @Async
+    public void sendTeamRenameEmail(UUID teamUUID, String oldDisplayName) {
+        sendTeamRenameChangeEmailCommand(new TeamRenameCommand(teamUUID, oldDisplayName));
+    }
+
+    @Retryable(maxAttemptsExpression = "${retry.maxAttempts}", backoff = @Backoff(delayExpression = "${retry.delay}"))
+    private void sendTeamRenameChangeEmailCommand(TeamRenameCommand command){
+        try {
+            Map<String, Object> queueHeaders = getQueueHeaders();
+            producerTemplate.sendBodyAndHeaders(notifyQueue, objectMapper.writeValueAsString(command), queueHeaders);
+            log.info("Sent team change email of type {}, correlationID: {}, UserID: {}", command.getCommand(), requestData.correlationId(), requestData.userId(), value(EVENT, TEAM_RENAME_EMAIL_SENT));
+        } catch (Exception e) {
+            logFailedToSendEmail(e);
+        }
+    }
+
+    private void logFailedToSendEmail(Exception e){
+        log.error("Failed to send email {}", value(EVENT, NOTIFY_EMAIL_FAILED), value(EXCEPTION, e));
+    }
+
+    private Map<String, Object> getQueueHeaders() {
+        return Map.of(
+        RequestData.CORRELATION_ID_HEADER, requestData.correlationId(),
+        RequestData.USER_ID_HEADER, requestData.userId(),
+        RequestData.USERNAME_HEADER, requestData.username(),
+        RequestData.GROUP_HEADER, requestData.groups());
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/info/client/notifyclient/dto/EventType.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/client/notifyclient/dto/EventType.java
@@ -1,0 +1,6 @@
+package uk.gov.digital.ho.hocs.info.client.notifyclient.dto;
+
+public enum EventType {
+    TEAM_RENAME_EMAIL_SENT,
+    NOTIFY_EMAIL_FAILED
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/info/client/notifyclient/dto/TeamRenameCommand.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/client/notifyclient/dto/TeamRenameCommand.java
@@ -1,0 +1,23 @@
+package uk.gov.digital.ho.hocs.info.client.notifyclient.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@java.lang.SuppressWarnings("squid:S1068")
+@Getter
+@NoArgsConstructor
+public class TeamRenameCommand {
+
+    private String command = "team_rename";
+
+    private UUID teamUUID;
+    private String oldDisplayName;
+
+    public TeamRenameCommand(UUID teamUUID, String oldDisplayName){
+        this.teamUUID = teamUUID;
+        this.oldDisplayName = oldDisplayName;
+    }
+
+}

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,1 +1,8 @@
 audit.queue=aws-sns://${audit.topic.name}?amazonSNSClient=#auditSnsClient
+
+notify.redrive.policy={"maxReceiveCount": "${notify.queue.maximumRedeliveries}", "deadLetterTargetArn":"arn:aws:sqs:${aws.region}:${aws.account.id}:${notify.queue.dlq.name}"}
+notify.queue=aws-sqs://${notify.queue.name}?amazonSQSClient=#notifySqsClient&messageAttributeNames=All&redrivePolicy=${notify.redrive.policy}&waitTimeSeconds=20
+notify.queue.dlq=aws-sqs://${notify.queue.dlq.name}?amazonSQSClient=#notifySqsClient&messageAttributeNames=All
+
+retry.maxAttempts=2
+retry.delay=1000

--- a/src/main/resources/application-sqs.properties
+++ b/src/main/resources/application-sqs.properties
@@ -1,0 +1,3 @@
+notify.redrive.policy={"maxReceiveCount": "${notify.queue.maximumRedeliveries}", "deadLetterTargetArn":"arn:aws:sqs:${aws.region}:${aws.account.id}:${notify.queue.dlq.name}"}
+notify.queue=aws-sqs://arn:aws:sqs:${aws.region}:${aws.account.id}:${notify.queue.name}?amazonSQSClient=#sqsClient&messageAttributeNames=All&redrivePolicy=${notify.redrive.policy}&waitTimeSeconds=0&defaultVisibilityTimeout=30&visibilityTimeout=30&extendMessageVisibility=true&messageRetentionPeriod=345600
+notify.queue.dlq=aws-sqs://arn:aws:sqs:${aws.region}:${aws.account.id}:${notify.queue.dlq.name}?amazonSQSClient=#sqsClient&messageAttributeNames=All

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -59,3 +59,14 @@ audit.aws.sqs.access.key=12345
 
 user.email.whitelist=homeoffice.gov.uk,hmpo.gov.uk
 
+notify.queue.name=notify-queue
+notify.queue=seda://${notify.queue.name}
+
+notify.queue.dlq.name=notify-queue-dlq
+notify.queue.dlq=seda://${notify.queue.dlq.name}
+
+notify.queue.maximumRedeliveries=10
+notify.queue.conversion.maximumRedeliveries=10
+notify.queue.malware.maximumRedeliveries=10
+notify.queue.redeliveryDelay=10000
+notify.queue.backOffMultiplier=2

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/TeamServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/TeamServiceTest.java
@@ -10,6 +10,7 @@ import uk.gov.digital.ho.hocs.info.api.dto.PermissionDto;
 import uk.gov.digital.ho.hocs.info.api.dto.TeamDto;
 import uk.gov.digital.ho.hocs.info.client.audit.client.AuditClient;
 import uk.gov.digital.ho.hocs.info.client.caseworkclient.CaseworkClient;
+import uk.gov.digital.ho.hocs.info.client.notifyclient.NotifyClient;
 import uk.gov.digital.ho.hocs.info.domain.exception.ApplicationExceptions;
 import uk.gov.digital.ho.hocs.info.domain.model.*;
 import uk.gov.digital.ho.hocs.info.domain.repository.ParentTopicRepository;
@@ -52,6 +53,9 @@ public class TeamServiceTest {
     @Mock
     private CaseworkClient caseworkClient;
 
+    @Mock
+    private NotifyClient notifyClient;
+
     private TeamService teamService;
 
     @Before
@@ -63,7 +67,8 @@ public class TeamServiceTest {
                 parentTopicRepository,
                 keycloakService,
                 auditClient,
-                caseworkClient);
+                caseworkClient,
+                notifyClient);
     }
 
     private UUID team1UUID = UUID.randomUUID();
@@ -122,11 +127,15 @@ public class TeamServiceTest {
         when(teamRepository.findByDisplayName(any())).thenReturn(null);
         when(teamRepository.findByUuid(team1UUID)).thenReturn(team);
         when(team.getUuid()).thenReturn(team1UUID);
+        when(team.getDisplayName()).thenReturn("__oldName__");
         teamService.updateTeamName(team1UUID, newTeamName);
 
         verify(teamRepository, times(1)).findByDisplayName(newTeamName);
         verify(teamRepository, times(1)).findByUuid(team1UUID);
         verify(team, times(1)).setDisplayName(newTeamName);
+
+        verify(auditClient).renameTeamAudit(any());
+        verify(notifyClient).sendTeamRenameEmail(team1UUID, "__oldName__");
         verifyNoMoreInteractions(teamRepository);
     }
 

--- a/src/test/java/uk/gov/digital/ho/hocs/info/client/notifiyclient/NotifyClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/client/notifiyclient/NotifyClientTest.java
@@ -1,0 +1,94 @@
+package uk.gov.digital.ho.hocs.info.client.notifiyclient;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.camel.ProducerTemplate;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.digital.ho.hocs.info.application.RequestData;
+import uk.gov.digital.ho.hocs.info.application.SpringConfiguration;
+import uk.gov.digital.ho.hocs.info.client.notifyclient.NotifyClient;
+import uk.gov.digital.ho.hocs.info.client.notifyclient.dto.TeamRenameCommand;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static java.util.UUID.randomUUID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NotifyClientTest {
+
+    @Mock
+    private RequestData requestData;
+
+    @Mock
+    ProducerTemplate producerTemplate;
+
+    private ObjectMapper mapper;
+
+    private final SpringConfiguration configuration = new SpringConfiguration();
+    private final String notifyQueue ="notify-queue";
+
+    @Captor
+    ArgumentCaptor jsonCaptor;
+
+    @Captor
+    ArgumentCaptor<HashMap<String,Object>> headerCaptor;
+
+    private NotifyClient notifyClient;
+
+    @Before
+    public void setup() {
+        when(requestData.correlationId()).thenReturn(randomUUID().toString());
+        when(requestData.userId()).thenReturn("__userID__");
+        when(requestData.groups()).thenReturn("__group__");
+        when(requestData.username()).thenReturn("__anonymous__");
+
+        mapper = configuration.initialiseObjectMapper();
+        notifyClient = new NotifyClient(producerTemplate, notifyQueue, mapper, requestData);
+    }
+
+    @Test
+    public void shouldSetRenameTeamDataFields() throws IOException {
+        UUID teamUUID = UUID.randomUUID();
+        String oldDisplayName = "TEST";
+        String command = "team_rename";
+
+        notifyClient.sendTeamRenameEmail(teamUUID, oldDisplayName);
+
+        verify(producerTemplate, times(1)).sendBodyAndHeaders(eq(notifyQueue), jsonCaptor.capture(), any());
+        TeamRenameCommand request = mapper.readValue((String)jsonCaptor.getValue(), TeamRenameCommand.class);
+
+        assertThat(request.getCommand()).isEqualTo(command);
+        assertThat(request.getOldDisplayName()).isEqualTo(oldDisplayName);
+        assertThat(request.getTeamUUID()).isEqualTo(teamUUID);
+    }
+
+    @Test
+    public void shouldSetHeaders()  {
+        Map<String, Object> expectedHeaders = Map.of(
+                RequestData.CORRELATION_ID_HEADER, requestData.correlationId(),
+                RequestData.USER_ID_HEADER, requestData.userId(),
+                RequestData.USERNAME_HEADER, requestData.username(),
+                RequestData.GROUP_HEADER, requestData.groups());
+
+        UUID currentUser = UUID.randomUUID();
+        UUID newUser = UUID.randomUUID();
+
+        notifyClient.sendTeamRenameEmail(UUID.randomUUID(), "");
+        verify(producerTemplate, times(1))
+                .sendBodyAndHeaders(eq(notifyQueue), any(), headerCaptor.capture());
+        Map headers = headerCaptor.getValue();
+
+        assertThat(headers).containsAllEntriesOf(expectedHeaders);
+    }
+
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -35,3 +35,9 @@ auditing.deployment.name=${info.app.name}
 #spring.flyway.clean-on-validation-error=true
 
 user.email.whitelist=homeoffice.gov.uk,hmpo.gov.uk
+
+notify.queue.name=notify-queue
+notify.queue=seda://${notify.queue.name}
+
+notify.queue.dlq.name=notify-queue-dlq
+notify.queue.dlq=seda://${notify.queue.dlq.name}


### PR DESCRIPTION
When a user renames a team through MUI, we should send a notification to the teams nominated contacts. To allow for this this change adds a NotifyClient that puts a command onto the hocs-notify queue. This NotifyClient is called after the rename has taken place in the `updateTeamName` method in the `TeamService`. To allow for the command to be put onto the queue this change also handles all of the required application properties.