### PR TITLE
HOCS-2674: remove team caching

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/TeamResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/TeamResource.java
@@ -30,7 +30,6 @@ public class TeamResource {
     @PostMapping(value = "/unit/{unitUUID}/teams")
     public ResponseEntity<TeamDto> createUpdateTeam(@PathVariable String unitUUID, @RequestBody TeamDto team) {
         Team createdTeam = teamService.createTeam(team, UUID.fromString(unitUUID));
-        teamService.refreshTeamCache();
         return ResponseEntity.ok(TeamDto.from(createdTeam));
     }
 

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/TeamService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/TeamService.java
@@ -1,9 +1,6 @@
 package uk.gov.digital.ho.hocs.info.api;
 
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.CachePut;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.digital.ho.hocs.info.api.dto.PermissionDto;
@@ -64,22 +61,15 @@ public class TeamService {
         return teams;
     }
 
-    @Cacheable("teams")
     public Set<Team> getAllActiveTeams() {
         return getTeams();
     }
 
-    @Cacheable("teamsAll")
     public Set<Team> getAllTeams() {
         log.debug("Getting all Teams");
         Set<Team> allTeams = teamRepository.findAll();
         log.info("Got {} Teams", allTeams.size());
         return allTeams;
-    }
-
-    @CachePut("teams")
-    public Set<Team> refreshTeamCache() {
-        return getTeams();
     }
 
     private Set<Team> getTeams() {
@@ -175,7 +165,6 @@ public class TeamService {
 
     }
 
-    @CacheEvict(value = "teams", allEntries = true)
     @Transactional
     public void updateTeamName(UUID teamUUID, String displayName) {
         log.debug("Updating Team {} name", teamUUID);
@@ -205,7 +194,6 @@ public class TeamService {
         log.info("Team with UUID {} letter name updated to {}", team.getUuid().toString(), newLetterName, value(EVENT, TEAM_RENAMED));
     }
 
-    @CacheEvict(value = "teamMembers", key = "#teamUUID")
     public void addUserToTeam(UUID userUUID, UUID teamUUID) {
         log.debug("Adding User {} to Team {}", userUUID, teamUUID);
         Team team = getTeam(teamUUID);
@@ -281,7 +269,6 @@ public class TeamService {
     }
 
     @Transactional
-    @CacheEvict(value = "teamMembers", allEntries = true)
     public void removeUserFromTeam(UUID userUUID, UUID teamUUID) {
         log.debug("Removing User {} from Team {}", userUUID, teamUUID);
 

--- a/src/main/java/uk/gov/digital/ho/hocs/info/application/CacheScheduler.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/application/CacheScheduler.java
@@ -15,15 +15,9 @@ import uk.gov.digital.ho.hocs.info.api.UserService;
 public class CacheScheduler {
 
     private UserService userService;
-    private TeamService teamService;
 
     @Scheduled(fixedDelayString = "${cache.user.refresh}000")
     public void refreshUserCache(){
         userService.refreshUserCache();
-    }
-
-    @Scheduled(fixedDelayString = "${cache.team.refresh}000")
-    public void refreshTeamCache(){
-        teamService.refreshTeamCache();
     }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/info/CacheSchedulerTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/CacheSchedulerTest.java
@@ -17,20 +17,10 @@ public class CacheSchedulerTest {
     @Mock
     UserService userService;
 
-    @Mock
-    TeamService teamService;
-
     @Test
     public void shouldCallUserServiceRefresh() {
-        service = new CacheScheduler(userService, teamService);
+        service = new CacheScheduler(userService);
         service.refreshUserCache();
         verify(userService, times(1)).refreshUserCache();
-    }
-
-    @Test
-    public void shouldCallTeamServiceRefresh() {
-        service = new CacheScheduler(userService, teamService);
-        service.refreshTeamCache();
-        verify(teamService, times(1)).refreshTeamCache();
     }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/TeamResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/TeamResourceTest.java
@@ -201,7 +201,6 @@ public class TeamResourceTest {
         assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
 
         verify(teamService).createTeam(teamDto, unitUUID);
-        verify(teamService).refreshTeamCache();
         verifyNoMoreInteractions(teamService);
     }
 


### PR DESCRIPTION
At present we have individual service caches, which can become out 
of date easily as we run multiple service pods. This causes potential 
inaccuracies of data between pods. This side effect means the user 
does not always see up to to date teams now we support adding 
them dynamically through MUI.