### PR TITLE
HOCS-2583 Move a team to a different unit via MUI - fix

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/PatchTeamDto.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/PatchTeamDto.java
@@ -15,6 +15,6 @@ public class PatchTeamDto {
     @JsonProperty("displayName")
     private String displayName;
 
-    @JsonProperty("unitUuid")
+    @JsonProperty("unitUUID")
     private UUID unitUuid;
 }


### PR DESCRIPTION
The change unit functionality is broken due to a case mismatch - 'UUID' is used throughout the MUI, but 'Uuid' is the more common variant in hocs-info-service. Standardising this would be a long task spanning all of the repos, so this fix updates the PatchTeamDto to accept the variant used in the MUI.