### PR TITLE
HOCS-3064: improve allocation notes by adding additional information

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/StageTypeResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/StageTypeResource.java
@@ -15,6 +15,7 @@ import uk.gov.digital.ho.hocs.info.domain.model.Team;
 
 import java.time.LocalDate;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
@@ -33,6 +34,22 @@ public class StageTypeResource {
     ResponseEntity<Set<StageTypeDto>> getAllStageTypes() {
         Set<StageTypeEntity> stageTypes = stageTypeService.getAllStageTypes();
         return ResponseEntity.ok(stageTypes.stream().map(StageTypeDto::from).collect(Collectors.toSet()));
+    }
+
+    /**
+     * Endpoint for retrieving the name for a Stage Type by using a given Stage Type UUID
+     * @param stageTypeUUID the UUID of the stage type name that should be retrieved
+     * @return a Stage Type entity corresponding to the given UUID
+     */
+    @GetMapping(value = "/stageType/{stageTypeUUID}", produces = APPLICATION_JSON_UTF8_VALUE)
+    ResponseEntity<StageTypeDto> getStageTypeNameByUuid(String stageTypeUUID) {
+        Set<StageTypeEntity> stageTypes = stageTypeService.getAllStageTypes();
+        for (StageTypeEntity stageType : stageTypes){
+            if (stageType.getUuid() == UUID.fromString(stageTypeUUID)){
+                return ResponseEntity.ok(StageTypeDto.from(stageType));
+            }
+        }
+        return ResponseEntity.notFound().build();
     }
 
     @GetMapping(value = "/stageType/{stageType}/team", produces = APPLICATION_JSON_UTF8_VALUE)

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/StageTypeResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/StageTypeResource.java
@@ -42,10 +42,10 @@ public class StageTypeResource {
      * @return a Stage Type entity corresponding to the given UUID
      */
     @GetMapping(value = "/stageType/{stageTypeUUID}", produces = APPLICATION_JSON_UTF8_VALUE)
-    ResponseEntity<StageTypeDto> getStageTypeNameByUuid(String stageTypeUUID) {
+    ResponseEntity<StageTypeDto> getStageTypeByUuid(String stageTypeUUID) {
         Set<StageTypeEntity> stageTypes = stageTypeService.getAllStageTypes();
         for (StageTypeEntity stageType : stageTypes){
-            if (stageType.getUuid() == UUID.fromString(stageTypeUUID)){
+            if (stageType.getUuid().equals(UUID.fromString(stageTypeUUID))){
                 return ResponseEntity.ok(StageTypeDto.from(stageType));
             }
         }

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/StageTypeResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/StageTypeResourceTest.java
@@ -53,6 +53,25 @@ public class StageTypeResourceTest {
     }
 
     @Test
+    public void shouldGetStageTypeName() {
+        UUID stageUuid = UUID.randomUUID();
+        StageTypeEntity stage = new StageTypeEntity(1L, stageUuid, "stage name", "111","STAGE_TYPE", UUID.randomUUID(),1,1,1,true,team);
+        Set<StageTypeEntity> stages = new HashSet<>() {{
+            add(stage);
+        }};
+        when(stageTypeService.getAllStageTypes()).thenReturn(stages);
+
+        ResponseEntity<StageTypeDto> result = service.getStageTypeByUuid(stageUuid.toString());
+
+        StageTypeDto stageTypeDto = result.getBody();
+        assertThat(stageTypeDto.getType()).isEqualTo("STAGE_TYPE");
+        assertThat(stageTypeDto.getDisplayName()).isEqualTo("stage name");
+        assertThat(stageTypeDto.getShortCode()).isEqualTo("111");
+        assertThat(stageTypeDto.getType()).isEqualTo("STAGE_TYPE");
+
+    }
+
+    @Test
     public void shouldGetTeamForStageType() {
         Team team = new Team( "Team1" , true);
         when(stageTypeService.getTeamForStageType("STAGE_TYPE")).thenReturn(team);


### PR DESCRIPTION
Update case notes to display clearly whether they refer to a case allocation or a case rejection.

Allocation notes should show:

    The team which made the allocation
    The team the case was allocated to
    The stage at which the allocation took place

Rejection notes should show:

    The team who rejected the case
    The stage at which the rejection took place
