### PR TITLE
HOCS3243 add dev tool to resolve team code

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/TeamResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/TeamResource.java
@@ -8,11 +8,13 @@ import org.springframework.web.bind.annotation.*;
 import uk.gov.digital.ho.hocs.info.api.dto.*;
 import uk.gov.digital.ho.hocs.info.domain.exception.ApplicationExceptions;
 import uk.gov.digital.ho.hocs.info.domain.model.Team;
+import uk.gov.digital.ho.hocs.info.security.Base64UUID;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
+import static org.springframework.http.MediaType.TEXT_PLAIN_VALUE;
 import static net.logstash.logback.argument.StructuredArguments.value;
 import static uk.gov.digital.ho.hocs.info.application.LogEvent.*;
 
@@ -126,6 +128,11 @@ public class TeamResource {
     public ResponseEntity<TeamDto> getTeam(@PathVariable UUID teamUUID) {
         Team team = teamService.getTeam(teamUUID);
         return ResponseEntity.ok(TeamDto.from(team));
+    }
+
+    @GetMapping(value = "/team/{teamUUID}/code", produces = TEXT_PLAIN_VALUE)
+    public ResponseEntity<String> getTeamCode(@PathVariable UUID teamUUID) {
+        return ResponseEntity.ok(Base64UUID.uuidToBase64String(teamUUID));
     }
 
     @GetMapping(value = "/team/{teamUUID}/unit", produces = APPLICATION_JSON_UTF8_VALUE)

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/TeamResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/TeamResourceTest.java
@@ -15,6 +15,7 @@ import uk.gov.digital.ho.hocs.info.domain.exception.ApplicationExceptions;
 import uk.gov.digital.ho.hocs.info.domain.model.Team;
 import uk.gov.digital.ho.hocs.info.domain.model.Unit;
 import uk.gov.digital.ho.hocs.info.security.AccessLevel;
+import uk.gov.digital.ho.hocs.info.security.Base64UUID;
 
 import java.util.HashSet;
 import java.util.List;
@@ -194,6 +195,16 @@ public class TeamResourceTest {
         teamResource.getUnitByTeam(teamUUID);
     }
 
+    @Test
+    public void shouldGetTeamCodeForUUID() {
+        UUID teamUUID = UUID.randomUUID();
+        String teamCode = Base64UUID.uuidToBase64String(teamUUID);
+
+        ResponseEntity<String> result = teamResource.getTeamCode(teamUUID);
+
+        assertThat(result.getBody()).isEqualTo(teamCode);
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
 
     @Test
     public void shouldCreateNewTeam() {


### PR DESCRIPTION
added an endpoint on info service which returns a base64 code (for use in ModHeader) for a given team UUID.