### PR TITLE
HOCS-3631: case deadline dates

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/CaseTypeService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/CaseTypeService.java
@@ -136,11 +136,11 @@ public class CaseTypeService {
         if (fromDate == null || now.isBefore(fromDate) || now.isEqual(fromDate)) {
             return 0;
         }
-        List<LocalDate> exemptions = holidayDateRepository.findAllByCaseType(caseType).stream().map(ExemptionDate::getDate).collect(Collectors.toList());
+        Set<LocalDate> exemptions = holidayDateRepository.findAllByCaseType(caseType).stream().map(ExemptionDate::getDate).collect(Collectors.toSet());
         LocalDate date = fromDate;
         int workingDays = 0;
         while (date.isBefore(now)) {
-            if (!DateUtils.isWeekend(date) && !exemptions.contains(date)) {
+            if (!DateUtils.isDateNonWorkingDay(date, exemptions)) {
                 workingDays++;
             }
 

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/Deadline.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/Deadline.java
@@ -4,7 +4,6 @@ import lombok.Getter;
 import uk.gov.digital.ho.hocs.info.utils.DateUtils;
 
 import java.io.Serializable;
-import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -23,15 +22,23 @@ public class Deadline implements Serializable {
         if (sla == -2 && caseDeadline != null){
             return caseDeadline;
         }
+
         Set<LocalDate> holidayDates = holidays.stream().map(ExemptionDate::getDate).collect(Collectors.toSet());
+
+        // Start deadline from the next first working day.
+        while (DateUtils.isDateNonWorkingDay(deadline, holidayDates)) {
+            deadline = deadline.plusDays(1);
+        }
+
         int i = 1;
         while (i <= sla) {
             deadline = deadline.plusDays(1);
             // Only increment Mon-Fri and non-holidays
-            if (!(DateUtils.isWeekend(deadline) || holidayDates.contains(deadline))) {
+            if (!(DateUtils.isDateNonWorkingDay(deadline, holidayDates))) {
                 ++i;
             }
         }
         return deadline;
     }
+
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/info/utils/DateUtils.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/utils/DateUtils.java
@@ -2,13 +2,19 @@ package uk.gov.digital.ho.hocs.info.utils;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.util.Set;
 
 public final class DateUtils {
 
-    public static boolean isWeekend(LocalDate date) {
-        if (date == null) {
+    private static boolean isWeekend(LocalDate date) {
+        return date.getDayOfWeek() == DayOfWeek.SATURDAY || date.getDayOfWeek() == DayOfWeek.SUNDAY;
+    }
+
+    public static boolean isDateNonWorkingDay(LocalDate date, Set<LocalDate> holidayDates) {
+        if (date == null || holidayDates == null) {
             return false;
         }
-        return date.getDayOfWeek() == DayOfWeek.SATURDAY || date.getDayOfWeek() == DayOfWeek.SUNDAY;
+
+        return (DateUtils.isWeekend(date) || holidayDates.contains(date));
     }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/info/domain/model/DeadlineTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/domain/model/DeadlineTest.java
@@ -1,0 +1,54 @@
+package uk.gov.digital.ho.hocs.info.domain.model;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DeadlineTest {
+
+    @Test
+    public void deadline_withMinusTwoSla_andCaseDeadline() {
+        assertThat(Deadline.calculateDeadline(LocalDate.parse("2020-01-01"),
+                LocalDate.parse("2020-01-02"), -2, Collections.emptySet()))
+                .isEqualTo(LocalDate.parse("2020-01-02"));
+    }
+
+    @Test
+    public void deadline_withMinusTwoSla_noCaseDeadline() {
+        assertThat(Deadline.calculateDeadline(LocalDate.parse("2020-01-01"),
+                null, -2, Collections.emptySet()))
+                .isEqualTo(LocalDate.parse("2020-01-01"));
+    }
+
+    @Test
+    public void deadline_withSlaNoExemptions_sameWeek() {
+        assertThat(Deadline.calculateDeadline(LocalDate.parse("2020-01-01"), null, 2, Collections.emptySet()))
+                .isEqualTo(LocalDate.parse("2020-01-03"));
+    }
+
+    @Test
+    public void deadline_withSlaNoExemptions_acrossWeekend() {
+        assertThat(Deadline.calculateDeadline(LocalDate.parse("2020-01-01"), null, 5, Collections.emptySet()))
+                .isEqualTo(LocalDate.parse("2020-01-08"));
+    }
+
+    @Test
+    public void deadline_withSlaNoExemptions_startSaturday() {
+        assertThat(Deadline.calculateDeadline(LocalDate.parse("2020-01-04"), null, 3, Collections.emptySet()))
+                .isEqualTo(LocalDate.parse("2020-01-09"));
+    }
+
+    @Test
+    public void deadline_withSlaMondayExemption_startSaturday() {
+        assertThat(Deadline.calculateDeadline(LocalDate.parse("2020-01-04"), null, 3, Set.of(new ExemptionDate(1L, LocalDate.parse("2020-01-06")))))
+                .isEqualTo(LocalDate.parse("2020-01-10"));
+    }
+
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/info/utils/DateUtilsTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/utils/DateUtilsTest.java
@@ -3,48 +3,68 @@ package uk.gov.digital.ho.hocs.info.utils;
 import org.junit.Test;
 
 import java.time.LocalDate;
+import java.util.Collections;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class DateUtilsTest {
 
+    private final Set<LocalDate> nonWorkingDateFriday = Set.of(LocalDate.parse("2020-01-01"));
+    private final Set<LocalDate> nonWorkingDateOther = Set.of(LocalDate.parse("2020-01-02"));
+
     @Test
-    public void isWeekend_null(){
-        assertThat(DateUtils.isWeekend(null)).isFalse();
+    public void isDateNonWorkingDay_dateNull(){
+        assertThat(DateUtils.isDateNonWorkingDay(null, Collections.emptySet())).isFalse();
     }
 
     @Test
-    public void isWeekend_monday(){
-        assertThat(DateUtils.isWeekend(LocalDate.parse("2020-05-11"))).isFalse();
+    public void isDateNonWorkingDay_exemptionsNull(){
+        assertThat(DateUtils.isDateNonWorkingDay(LocalDate.parse("2020-01-01"), null)).isFalse();
     }
 
     @Test
-    public void isWeekend_tuesday(){
-        assertThat(DateUtils.isWeekend(LocalDate.parse("2020-05-12"))).isFalse();
+    public void isDateNonWorkingDay_mondayDate_emptyExemption(){
+        assertThat(DateUtils.isDateNonWorkingDay(LocalDate.parse("2020-05-11"), Collections.emptySet())).isFalse();
     }
 
     @Test
-    public void isWeekend_wednesday(){
-        assertThat(DateUtils.isWeekend(LocalDate.parse("2020-05-13"))).isFalse();
+    public void isDateNonWorkingDay_tuesdayDate_emptyExemption(){
+        assertThat(DateUtils.isDateNonWorkingDay(LocalDate.parse("2020-05-12"), Collections.emptySet())).isFalse();
     }
 
     @Test
-    public void isWeekend_thursday(){
-        assertThat(DateUtils.isWeekend(LocalDate.parse("2020-05-14"))).isFalse();
+    public void isDateNonWorkingDay_wednesdayDate_emptyExemption(){
+        assertThat(DateUtils.isDateNonWorkingDay(LocalDate.parse("2020-05-13"), Collections.emptySet())).isFalse();
     }
 
     @Test
-    public void isWeekend_friday(){
-        assertThat(DateUtils.isWeekend(LocalDate.parse("2020-05-15"))).isFalse();
+    public void isDateNonWorkingDay_thursdayDate_emptyExemption(){
+        assertThat(DateUtils.isDateNonWorkingDay(LocalDate.parse("2020-05-14"), Collections.emptySet())).isFalse();
     }
 
     @Test
-    public void isWeekend_saturday(){
-        assertThat(DateUtils.isWeekend(LocalDate.parse("2020-05-16"))).isTrue();
+    public void isDateNonWorkingDay_fridayDate_emptyExemption(){
+        assertThat(DateUtils.isDateNonWorkingDay(LocalDate.parse("2020-05-15"), Collections.emptySet())).isFalse();
     }
 
     @Test
-    public void isWeekend_sunday(){
-        assertThat(DateUtils.isWeekend(LocalDate.parse("2020-05-17"))).isTrue();
+    public void isDateNonWorkingDay_saturdayDate_emptyExemption(){
+        assertThat(DateUtils.isDateNonWorkingDay(LocalDate.parse("2020-05-16"), Collections.emptySet())).isTrue();
+    }
+
+    @Test
+    public void isDateNonWorkingDay_sundayDate_emptyExemption(){
+        assertThat(DateUtils.isDateNonWorkingDay(LocalDate.parse("2020-05-17"), Collections.emptySet())).isTrue();
+    }
+
+    @Test
+    public void isDateNonWorkingDay_fridayDate_exempt(){
+        assertThat(DateUtils.isDateNonWorkingDay(LocalDate.parse("2020-01-01"), nonWorkingDateFriday)).isTrue();
+    }
+
+    @Test
+    public void isDateNonWorkingDay_fridayDate_exemptOther(){
+        assertThat(DateUtils.isDateNonWorkingDay(LocalDate.parse("2020-01-01"), nonWorkingDateOther)).isFalse();
     }
 }


### PR DESCRIPTION
Currently cases that have been received on a non-working day have that date be the start of the counter. It should be that the next working day starts the counter. As a result this change moves the received date forward to the next working day ready for the countdown to begin.

To support this change a simplification of the DateUtil class has been added. 