### PR TITLE
HOCS-3684: use sort_order entity column

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/entity/Entity.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/entity/Entity.java
@@ -40,6 +40,19 @@ public class Entity {
     @Column(name = "active")
     private boolean active;
 
+    @Getter
+    @Column(name = "sort_order")
+    private int sortOrder;
+
+    public Entity(UUID uuid, String simpleName, String data, UUID entityListUUID, boolean active, int sortOrder) {
+        this.uuid = uuid;
+        this.simpleName = simpleName;
+        this.data = data;
+        this.entityListUUID = entityListUUID;
+        this.active = active;
+        this.sortOrder = sortOrder;
+    }
+
     public void update(EntityDto entityDto) {
         this.data = entityDto.getData();
     }

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/entity/EntityList.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/entity/EntityList.java
@@ -1,0 +1,45 @@
+package uk.gov.digital.ho.hocs.info.domain.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.UUID;
+
+
+@NoArgsConstructor
+@AllArgsConstructor
+@javax.persistence.Entity
+@Table(name = "entity_list")
+public class EntityList {
+
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Getter
+    @Column(name = "uuid", unique = true)
+    private UUID uuid;
+
+    @Getter
+    @Column(name = "display_name")
+    private String displayName;
+
+    @Column(name = "simple_name", unique = true)
+    @Getter
+    private String simpleName;
+
+    @Getter
+    @Column(name = "active")
+    private boolean active;
+
+    public EntityList(UUID uuid, String displayName, String simpleName, boolean active) {
+        this.uuid = uuid;
+        this.displayName = displayName;
+        this.simpleName = simpleName;
+        this.active = active;
+    }
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/entity/EntityRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/entity/EntityRepository.java
@@ -27,7 +27,7 @@ public interface EntityRepository extends CrudRepository<Entity, Long> {
             "                  join entity_list el on el.uuid = e.entity_list_uuid\n" +
             " where el.simple_name = ?1" +
             " and e.active = TRUE" +
-            " order by e.id", nativeQuery = true)
+            " order by e.sort_order", nativeQuery = true)
     List<Entity> findByEntityListSimpleName(String listSimpleName);
 
     @Query(value = "select Cast(el.uuid as varchar) id from entity_list el where el.simple_name = ?1", nativeQuery = true)

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/entity/EntityService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/entity/EntityService.java
@@ -53,7 +53,7 @@ public class EntityService {
             throw new ApplicationExceptions.EntityNotFoundException("EntityList not found for: %s ", listName);
         }
 
-        Entity newEntity = new Entity(null, UUID.randomUUID(), entityDto.getSimpleName(), entityDto.getData(), UUID.fromString(entityListUUID), true);
+        Entity newEntity = new Entity(null, UUID.randomUUID(), entityDto.getSimpleName(), entityDto.getData(), UUID.fromString(entityListUUID), true, 10);
 
         entityRepository.save(newEntity);
 

--- a/src/main/resources/db/postgresql/V1_47__3684_AddEntitySortOrder.sql
+++ b/src/main/resources/db/postgresql/V1_47__3684_AddEntitySortOrder.sql
@@ -1,0 +1,15 @@
+ALTER TABLE entity
+    ADD COLUMN sort_order INTEGER;
+
+-- Gives us some leeway between the values for additions and deletions
+UPDATE entity
+SET sort_order = id * 10;
+
+-- Make column not null after amending existing values
+ALTER TABLE entity
+    ALTER COLUMN sort_order SET NOT NULL;
+
+-- Make a unique constraint between the entity_list_uuid and sort order to stop
+-- 2 items having the same sort_order
+ALTER TABLE entity
+    ADD CONSTRAINT entity_uuid_sort_order_unique UNIQUE (entity_list_uuid, sort_order);

--- a/src/test/java/uk/gov/digital/ho/hocs/info/domain/entity/EntityRepositoryTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/domain/entity/EntityRepositoryTest.java
@@ -1,0 +1,58 @@
+package uk.gov.digital.ho.hocs.info.domain.entity;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+public class EntityRepositoryTest {
+
+    private final EntityList entityList =
+            new EntityList(UUID.randomUUID(), "Test Name", "TEST_NAME", true);
+    @Autowired
+    private TestEntityManager entityManager;
+    @Autowired
+    private EntityRepository repository;
+
+    @Before
+    public void setup() {
+        entityManager.persistAndFlush(entityList);
+    }
+
+    @After
+    public void teardown() {
+        entityManager.clear();
+    }
+
+    @Test()
+    public void shouldReturnList_bySortOrder() {
+        List<Entity> entities = List.of(
+                new Entity(UUID.randomUUID(), "simple", "{}", entityList.getUuid(), true, 20),
+                new Entity(UUID.randomUUID(), "simple2", "{}", entityList.getUuid(), true, 10)
+        );
+
+        entities.forEach(entityManager::persistAndFlush);
+
+        List<Entity> fetchedEntities = repository.findByEntityListSimpleName(entityList.getSimpleName());
+
+        assertThat(fetchedEntities).isEqualTo(
+                entities.stream().sorted(Comparator.comparing(Entity::getSortOrder)).collect(Collectors.toList()));
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/info/domain/entity/EntityResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/domain/entity/EntityResourceTest.java
@@ -35,7 +35,7 @@ public class EntityResourceTest {
         String caseType = "C1";
         String simpleName = "name123";
         String data = "{ title: 'Title 321' }";
-        Set<Entity> entitiesToReturn = Set.of(new Entity(1L, UUID.randomUUID(), simpleName, data, UUID.randomUUID(), true));
+        Set<Entity> entitiesToReturn = Set.of(new Entity(1L, UUID.randomUUID(), simpleName, data, UUID.randomUUID(), true, 10));
 
         when(entityService.getBySimpleName("caseType", caseType, "summary")).thenReturn(entitiesToReturn);
 
@@ -58,8 +58,8 @@ public class EntityResourceTest {
         String data1 = "{ title: 'Title One' }";
         String simpleName2 = "nameTwo";
         String data2 = "{ title: 'Title Two' }";
-        Entity entity1 = new Entity(1L, UUID.randomUUID(), simpleName1, data1, UUID.randomUUID(), true);
-        Entity entity2 = new Entity(2L, UUID.randomUUID(), simpleName2, data2, UUID.randomUUID(), true);
+        Entity entity1 = new Entity(1L, UUID.randomUUID(), simpleName1, data1, UUID.randomUUID(), true, 10);
+        Entity entity2 = new Entity(2L, UUID.randomUUID(), simpleName2, data2, UUID.randomUUID(), true, 10);
         List<Entity> entitiesToReturn = List.of(entity1, entity2);
 
         when(entityService.getByEntityListName(listName)).thenReturn(entitiesToReturn);
@@ -103,7 +103,7 @@ public class EntityResourceTest {
         String data = "{ title: 'Title 321' }";
         UUID uuid = UUID.randomUUID();
         UUID listUuid = UUID.randomUUID();
-        Entity entity = new Entity(1L, uuid, simpleName, data, listUuid, true);
+        Entity entity = new Entity(1L, uuid, simpleName, data, listUuid, true, 10);
         when(entityService.getEntity(testUUID)).thenReturn(entity);
 
         ResponseEntity<EntityDto> response = entityResource.getEntity(testUUID);

--- a/src/test/java/uk/gov/digital/ho/hocs/info/domain/entity/EntityServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/domain/entity/EntityServiceTest.java
@@ -41,7 +41,7 @@ public class EntityServiceTest {
         String data = "{ title: 'Title 321' }";
         UUID uuid = UUID.randomUUID();
         UUID listUuid = UUID.randomUUID();
-        Set<Entity> entitiesToReturn = Set.of(new Entity(1L, uuid, simpleName, data, listUuid, true));
+        Set<Entity> entitiesToReturn = Set.of(new Entity(1L, uuid, simpleName, data, listUuid, true, 10));
 
         when(entityRepository.findBySimpleName(owner, ownerType, list)).thenReturn(entitiesToReturn);
 
@@ -85,8 +85,8 @@ public class EntityServiceTest {
         String data1 = "{ title: 'Title One' }";
         String simpleName2 = "nameTwo";
         String data2 = "{ title: 'Title Two' }";
-        Entity entity1 = new Entity(1L, UUID.randomUUID(), simpleName1, data1, UUID.randomUUID(), true);
-        Entity entity2 = new Entity(2L, UUID.randomUUID(), simpleName2, data2, UUID.randomUUID(), true);
+        Entity entity1 = new Entity(1L, UUID.randomUUID(), simpleName1, data1, UUID.randomUUID(), true, 10);
+        Entity entity2 = new Entity(2L, UUID.randomUUID(), simpleName2, data2, UUID.randomUUID(), true, 10);
         List<Entity> entitiesToReturn = List.of(entity1, entity2);
 
         when(entityRepository.findByEntityListSimpleName(listName)).thenReturn(entitiesToReturn);

--- a/src/test/java/uk/gov/digital/ho/hocs/info/domain/entity/EntityTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/domain/entity/EntityTest.java
@@ -21,12 +21,11 @@ public class EntityTest {
 
     @Before
     public void before(){
-        this.entity = new Entity(id, uuid, simpleName, data, listUuid, active);
+        this.entity = new Entity(id, uuid, simpleName, data, listUuid, active, 10);
     }
 
     @Test
     public void updateShouldOnlyAmendData(){
-
         String newSimpleName = "name";
         String newUuid = UUID.randomUUID().toString();
         String newData = "data";
@@ -39,6 +38,5 @@ public class EntityTest {
         assertThat(entity.getEntityListUUID()).isEqualTo(listUuid);
         assertThat(entity.isActive()).isEqualTo(active);
         assertThat(entity.getData()).isEqualTo(newData);
-
     }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/info/domain/entity/dto/EntityDtoTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/domain/entity/dto/EntityDtoTest.java
@@ -11,17 +11,15 @@ public class EntityDtoTest {
 
     @Test
     public void from() {
-
         String simpleName = "name123";
         UUID uuid = UUID.randomUUID();
         String data = "{ title: 'Title 321' }";
-        Entity entity = new Entity(1L, uuid, simpleName, data, UUID.randomUUID(), true);
+        Entity entity = new Entity(1L, uuid, simpleName, data, UUID.randomUUID(), true, 10);
 
         EntityDto entityDto = EntityDto.from(entity);
 
         assertThat(entityDto.getSimpleName()).isEqualTo(simpleName);
         assertThat(entityDto.getData()).isEqualTo(data);
         assertThat(entityDto.getUuid()).isEqualTo(uuid.toString());
-
     }
 }


### PR DESCRIPTION
As the entity table now has a column for the sort_order of an entity, we
should now use this instead of ordering on the row id.
To support testing the EntityList model has been added.