### PR TITLE
HOCS-3720: Add Complaints Stage 2 to search

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/CaseTypeResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/CaseTypeResource.java
@@ -34,8 +34,10 @@ public class CaseTypeResource {
     }
 
     @GetMapping(value = "/caseType", params = {"bulkOnly"}, produces = APPLICATION_JSON_UTF8_VALUE)
-    ResponseEntity<Set<CaseTypeDto>> getCaseTypes(@RequestParam("bulkOnly") boolean bulkOnly) {
-        Set<CaseType> caseTypes = caseTypeService.getAllCaseTypesForUser(bulkOnly, false);
+    ResponseEntity<Set<CaseTypeDto>> getCaseTypes(
+            @RequestParam("bulkOnly") boolean bulkOnly,
+            @RequestParam(required = false, name = "addCasesWithPreviousType", defaultValue = "false") Boolean addCasesWithPreviousType) {
+        Set<CaseType> caseTypes = caseTypeService.getAllCaseTypesForUser(bulkOnly, addCasesWithPreviousType);
         return ResponseEntity.ok(caseTypes.stream().map(CaseTypeDto::from).collect(Collectors.toSet()));
     }
 

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/ProfileResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/ProfileResource.java
@@ -31,7 +31,7 @@ public class ProfileResource {
 
     @GetMapping(value = "/profileNames", produces = APPLICATION_JSON_UTF8_VALUE)
     public ResponseEntity<List<String>> getProfileNameForUser() {
-        List<String> userCaseTypes = caseTypeService.getAllCaseTypesForUser(false, false).stream().map(CaseType::getType).collect(Collectors.toList());
+        List<String> userCaseTypes = caseTypeService.getAllCaseTypesForUser(false, true).stream().map(CaseType::getType).collect(Collectors.toList());
 
         if (CollectionUtils.isEmpty(userCaseTypes)) {
             return ResponseEntity.ok(List.of());

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/CaseTypeResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/CaseTypeResourceTest.java
@@ -35,7 +35,7 @@ public class CaseTypeResourceTest {
         when(caseTypeService.getAllCaseTypesForUser(false, false)).thenReturn(getMockCaseTypes());
 
         ResponseEntity<Set<CaseTypeDto>> response =
-                caseTypeResource.getCaseTypes(false);
+                caseTypeResource.getCaseTypes(false, false);
 
         verify(caseTypeService, times(1)).getAllCaseTypesForUser(false, false);
 
@@ -68,7 +68,7 @@ public class CaseTypeResourceTest {
         when(caseTypeService.getAllCaseTypesForUser(true, false)).thenReturn(getMockCaseTypesBulk());
 
         ResponseEntity<Set<CaseTypeDto>> response =
-                caseTypeResource.getCaseTypes(true);
+                caseTypeResource.getCaseTypes(true, false);
 
         verify(caseTypeService, times(1)).getAllCaseTypesForUser(true, false);
 

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/ProfileResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/ProfileResourceTest.java
@@ -34,7 +34,7 @@ public class ProfileResourceTest {
 
     @Test
     public void getProfileNameForUser_noCaseTypes() {
-        when(caseTypeService.getAllCaseTypesForUser(false, false)).thenReturn(Set.of());
+        when(caseTypeService.getAllCaseTypesForUser(false, true)).thenReturn(Set.of());
 
         ResponseEntity<List<String>> response = profileResource.getProfileNameForUser();
 
@@ -42,7 +42,7 @@ public class ProfileResourceTest {
         assertThat(response.getStatusCodeValue()).isEqualTo(200);
         assertThat(response.getBody()).isEqualTo(List.of());
 
-        verify(caseTypeService).getAllCaseTypesForUser(false, false);
+        verify(caseTypeService).getAllCaseTypesForUser(false, true);
         verifyNoMoreInteractions(caseTypeService, profileRepository);
 
 
@@ -54,7 +54,7 @@ public class ProfileResourceTest {
         CaseType caseType2 = new CaseType(null, UUID.randomUUID(), "TEST2", "a2", "type2", UUID.randomUUID(), "TEST", true, true, null);
 
         List<String> expectedResult = new ArrayList<>(Arrays.asList("Profile1", "Profile2"));
-        when(caseTypeService.getAllCaseTypesForUser(false, false)).thenReturn(Set.of(caseType1, caseType2));
+        when(caseTypeService.getAllCaseTypesForUser(false, true)).thenReturn(Set.of(caseType1, caseType2));
         when(profileRepository.findAllProfileNamesByCaseTypesAndSystemName(anyList(), eq("system"))).thenReturn(expectedResult);
 
         ResponseEntity<List<String>> response = profileResource.getProfileNameForUser();
@@ -63,7 +63,7 @@ public class ProfileResourceTest {
         assertThat(response.getStatusCodeValue()).isEqualTo(200);
         assertThat(response.getBody()).isEqualTo(expectedResult);
 
-        verify(caseTypeService).getAllCaseTypesForUser(false, false);
+        verify(caseTypeService).getAllCaseTypesForUser(false, true);
         verify(profileRepository).findAllProfileNamesByCaseTypesAndSystemName(anyList(), eq("system"));
         verifyNoMoreInteractions(caseTypeService, profileRepository);
 


### PR DESCRIPTION
- Additional parameter on `/caseType` to allow option of returning cases with a previous type. Defaulted this to false to avoid breaking any existing calls to the endpoint.
- Modified the `/profileNames` endpoint to return all case types for user, including cases with a previous type.