### PR TITLE
HOCS-3639: Add MPAM Enquiry Reasons via MUI

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/entity/EntityRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/entity/EntityRepository.java
@@ -37,4 +37,5 @@ public interface EntityRepository extends CrudRepository<Entity, Long> {
 
     Entity findByUuid(UUID uuid);
 
+    Optional<Entity> findBySimpleNameAndEntityListUUID(String simpleName, UUID entityListUuid);
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/entity/EntityResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/entity/EntityResource.java
@@ -32,7 +32,13 @@ class EntityResource {
     }
 
     @GetMapping(value = "/entity/list/{name}", produces = APPLICATION_JSON_UTF8_VALUE)
-    @Cacheable(value = "getEntitiesForListName", unless = "#result == null || #name == 'MPAM_CAMPAIGNS' || #name == 'EXGRATIA_BUS_REPS' || #name == 'MPAM_BUS_UNITS_1' || #name == 'MPAM_BUS_UNITS_2' || #name == 'MPAM_BUS_UNITS_3' || #name == 'MPAM_BUS_UNITS_4' || #name == 'MPAM_BUS_UNITS_5' || #name == 'MPAM_BUS_UNITS_6' || #name == 'MPAM_BUS_UNITS_7'", key = "#name")
+    @Cacheable(value = "getEntitiesForListName", unless = "#result == null || " +
+            "#name == 'MPAM_CAMPAIGNS' || #name == 'EXGRATIA_BUS_REPS' || #name == 'MPAM_BUS_UNITS_1' || " +
+            "#name == 'MPAM_BUS_UNITS_2' || #name == 'MPAM_BUS_UNITS_3' || #name == 'MPAM_BUS_UNITS_4' || " +
+            "#name == 'MPAM_BUS_UNITS_5' || #name == 'MPAM_BUS_UNITS_6' || #name == 'MPAM_BUS_UNITS_7' || " +
+            "#name == 'MPAM_ENQUIRY_REASONS_PER' || #name == 'MPAM_ENQUIRY_REASONS_GUI' || #name == 'MPAM_ENQUIRY_REASONS_DOC' || " +
+            "#name == 'MPAM_ENQUIRY_REASONS_TECH' || #name == 'MPAM_ENQUIRY_REASONS_DET' || #name == 'MPAM_ENQUIRY_REASONS_HMPO' ||" +
+            "#name == 'MPAM_ENQUIRY_REASONS_OTHER'", key = "#name")
     public ResponseEntity<List<EntityDto>> getEntitiesForListName(@PathVariable String name) {
         List<Entity> entities = entityService.getByEntityListName(name);
         return ResponseEntity.ok(entities.stream().map(EntityDto::from).collect(Collectors.toList()));

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/entity/EntityService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/entity/EntityService.java
@@ -41,15 +41,16 @@ public class EntityService {
 
     public void createEntity(String listName, EntityDto entityDto) {
 
-        Optional<Entity> existingEntity = entityRepository.findBySimpleName(entityDto.getSimpleName());
-
-        if (existingEntity.isPresent()) {
-            throw new ApplicationExceptions.EntityAlreadyExistsException("entity with this simple name already exists!");
-        }
-
         String entityListUUID = entityRepository.findEntityListUUIDBySimpleName(listName);
 
-        if (entityListUUID == null) {
+        if (entityListUUID != null) {
+            Optional<Entity> existingEntity = entityRepository.findBySimpleNameAndEntityListUUID(
+                    entityDto.getSimpleName(), UUID.fromString(entityListUUID));
+
+            if (existingEntity.isPresent()) {
+                throw new ApplicationExceptions.EntityAlreadyExistsException("entity with this simple name already exists!");
+            }
+        } else {
             throw new ApplicationExceptions.EntityNotFoundException("EntityList not found for: %s ", listName);
         }
 

--- a/src/test/java/uk/gov/digital/ho/hocs/info/domain/entity/EntityServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/domain/entity/EntityServiceTest.java
@@ -121,14 +121,13 @@ public class EntityServiceTest {
         EntityDto entityDto = new EntityDto(simpleName, uuid, data);
         ArgumentCaptor<Entity> argumentCaptor = ArgumentCaptor.forClass(Entity.class);
 
-        when(entityRepository.findBySimpleName(simpleName)).thenReturn(Optional.empty());
         when(entityRepository.findEntityListUUIDBySimpleName(listName)).thenReturn(listUUID);
 
         entityService.createEntity(listName, entityDto);
 
         verify(entityRepository).save(argumentCaptor.capture());
-        verify(entityRepository).findBySimpleName(simpleName);
         verify(entityRepository).findEntityListUUIDBySimpleName(listName);
+        verify(entityRepository).findBySimpleNameAndEntityListUUID(simpleName, UUID.fromString(listUUID));
         verifyNoMoreInteractions(entityRepository);
 
         Entity capturedEntity = argumentCaptor.getValue();
@@ -147,8 +146,13 @@ public class EntityServiceTest {
         String uuid = UUID.randomUUID().toString();
         String data = "data";
         EntityDto entityDto = new EntityDto(simpleName, uuid, data);
+        UUID listUUID = UUID.randomUUID();
 
-        when(entityRepository.findBySimpleName(simpleName)).thenReturn(Optional.of(new Entity()));
+        when(entityRepository.findEntityListUUIDBySimpleName(listName))
+                .thenReturn(listUUID.toString());
+
+        when(entityRepository.findBySimpleNameAndEntityListUUID(simpleName, listUUID))
+               .thenReturn(Optional.of(new Entity()));
 
         entityService.createEntity(listName, entityDto);
 
@@ -162,7 +166,6 @@ public class EntityServiceTest {
         String data = "data";
         EntityDto entityDto = new EntityDto(simpleName, uuid, data);
 
-        when(entityRepository.findBySimpleName(simpleName)).thenReturn(Optional.empty());
         when(entityRepository.findEntityListUUIDBySimpleName(listName)).thenReturn(null);
 
         entityService.createEntity(listName, entityDto);


### PR DESCRIPTION
- Prevents caching of MPAM Enquiry Reasons

- When creating a new entity, it now only checks for duplicates of `simpleName` within the same entity-list rather than the whole `entity` table.