### PR TITLE
HOCS-2399: rework tests to use the new uuid column

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/WorkstackColumn.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/WorkstackColumn.java
@@ -7,6 +7,7 @@ import lombok.ToString;
 
 import javax.persistence.*;
 import java.io.Serializable;
+import java.util.UUID;
 
 @javax.persistence.Entity
 @Table(name = "workstack_column")
@@ -16,9 +17,8 @@ import java.io.Serializable;
 public class WorkstackColumn implements Serializable {
 
     @Id
-    @Column(name = "id")
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @Column(name = "uuid")
+    private UUID id;
 
     @Getter
     @Column(name = "display_name")

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/WorkstackType.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/WorkstackType.java
@@ -33,7 +33,7 @@ public class WorkstackType implements Serializable {
     @JoinTable(
             name = "workstack_column_type",
             joinColumns = @JoinColumn(name = "workstack_type_type", referencedColumnName = "type"),
-            inverseJoinColumns = @JoinColumn(name = "workstack_column_id", referencedColumnName = "id")
+            inverseJoinColumns = @JoinColumn(name = "workstack_column_uuid", referencedColumnName = "uuid")
     )
     @OrderColumn(name = "workstack_column_order")
     @ListIndexBase(value = 1)

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/ConfigurationResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/ConfigurationResourceTest.java
@@ -14,6 +14,7 @@ import uk.gov.digital.ho.hocs.info.domain.model.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 import static org.mockito.Mockito.*;
 
@@ -36,7 +37,7 @@ public class ConfigurationResourceTest {
         String systemName = "system";
         String systemDisplayName = "Test System Name";
 
-        List<WorkstackColumn> workstackColumns = Arrays.asList(new WorkstackColumn(10L, "columnName1", "adapter", "renderer", "valueKey", true, "cssClass", "SortStrategy"));
+        List<WorkstackColumn> workstackColumns = Arrays.asList(new WorkstackColumn(UUID.randomUUID(), "columnName1", "adapter", "renderer", "valueKey", true, "cssClass", "SortStrategy"));
         List<WorkstackType> workstackTypes = Arrays.asList(new WorkstackType(10L, systemName, "some_type", workstackColumns));
 
         List<SearchField> searchFields = Arrays.asList(new SearchField(10L, "system", "name", "component", "validationRules", "properties"));

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/ConfigurationServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/ConfigurationServiceTest.java
@@ -12,6 +12,7 @@ import uk.gov.digital.ho.hocs.info.domain.repository.ConfigurationRepository;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 import static org.mockito.Mockito.*;
 
@@ -35,7 +36,7 @@ public class ConfigurationServiceTest {
     public void shouldReturnConfiguration() throws Exception {
         String systemName = "profile";
         String systemDisplayName = "Test System Name";
-        List<WorkstackColumn> workstackColumns = Arrays.asList(new WorkstackColumn(10L, "columnName1", "adapter", "renderer", "valueKey", true, "cssClass", "SortStrategy"));
+        List<WorkstackColumn> workstackColumns = Arrays.asList(new WorkstackColumn(UUID.randomUUID(), "columnName1", "adapter", "renderer", "valueKey", true, "cssClass", "SortStrategy"));
         List<WorkstackType> workstackTypes = Arrays.asList(new WorkstackType(10L, systemName, "some_type", workstackColumns));
         List<SearchField> searchFields = Arrays.asList(new SearchField(10L, "profile", "name", "component", "validationRules", "properties"));
         List<Profile> profiles =  Arrays.asList(new Profile("testProfile", "system", true, searchFields));

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/dto/ConfigurationDtoTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/dto/ConfigurationDtoTest.java
@@ -6,6 +6,7 @@ import uk.gov.digital.ho.hocs.info.domain.model.*;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 
 public class ConfigurationDtoTest {
@@ -32,7 +33,7 @@ public class ConfigurationDtoTest {
 
         String workstackType = "SomeType";
 
-        List<WorkstackColumn> workstackColumns = Arrays.asList(new WorkstackColumn(10L, columnDisplayName, columnDataAdapter, columnRenderer, columnDataValueKey, columnFilterable, columnHeaderClassName, columnSortStrategy));
+        List<WorkstackColumn> workstackColumns = Arrays.asList(new WorkstackColumn(UUID.randomUUID(), columnDisplayName, columnDataAdapter, columnRenderer, columnDataValueKey, columnFilterable, columnHeaderClassName, columnSortStrategy));
 
         List<WorkstackType> workstackTypes = Arrays.asList(new WorkstackType(10L, systemName, workstackType, workstackColumns));
 

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/dto/WorkstackColumnDtoTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/dto/WorkstackColumnDtoTest.java
@@ -4,6 +4,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import uk.gov.digital.ho.hocs.info.domain.model.WorkstackColumn;
 
+import java.util.UUID;
+
 
 public class WorkstackColumnDtoTest {
 
@@ -16,7 +18,7 @@ public class WorkstackColumnDtoTest {
         Boolean filterable = true;
         String headerClassName = "some css header name";
         String sortStrategy = "TestSortStrategy";
-        WorkstackColumn workstackColumn = new WorkstackColumn(10L, displayName, dataAdapter, renderer, dataValueKey, filterable, headerClassName, sortStrategy);
+        WorkstackColumn workstackColumn = new WorkstackColumn(UUID.randomUUID(), displayName, dataAdapter, renderer, dataValueKey, filterable, headerClassName, sortStrategy);
 
         WorkstackColumnDto dto = WorkstackColumnDto.from(workstackColumn);
 

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/dto/WorkstackTypeDtoTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/dto/WorkstackTypeDtoTest.java
@@ -7,6 +7,7 @@ import uk.gov.digital.ho.hocs.info.domain.model.WorkstackType;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 
 public class WorkstackTypeDtoTest {
@@ -22,7 +23,7 @@ public class WorkstackTypeDtoTest {
         String cssClass = "some_css_class";
         String sortStrategy = "TestSortStrategy";
 
-        List<WorkstackColumn> workstackColumns = Arrays.asList(new WorkstackColumn(10L, displayName, dataAdapter, renderer, dataValueKey, isFilterable, cssClass, sortStrategy));
+        List<WorkstackColumn> workstackColumns = Arrays.asList(new WorkstackColumn(UUID.randomUUID(), displayName, dataAdapter, renderer, dataValueKey, isFilterable, cssClass, sortStrategy));
         WorkstackType workstackType = new WorkstackType(10L, "system", "some_type", workstackColumns);
 
 


### PR DESCRIPTION
WorkstackColumn and WorkstackType now link to the new uuid column that
has been reworked into the WorkstackColumn to replace the id primary key.
This has led to a few tests needing to be reworked for this new uuid
column.