### PR TITLE
HOCS-3836: Add duplicate check for amending entity

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/EntityService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/EntityService.java
@@ -10,9 +10,11 @@ import uk.gov.digital.ho.hocs.info.domain.repository.EntityRepository;
 import uk.gov.digital.ho.hocs.info.domain.exception.ApplicationExceptions;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @Slf4j
@@ -72,6 +74,18 @@ public class EntityService {
         Entity entity = entityRepository.findByUuid(UUID.fromString(entityDto.getUuid()));
 
         if (StringUtils.isNotEmpty(entityListUUID) && entity.getEntityListUUID().equals(UUID.fromString(entityListUUID))) {
+            List<Entity> existingEntities = entityRepository.findByDataAndEntityListUUID(
+                    entityDto.getData(), UUID.fromString(entityListUUID));
+
+            existingEntities = existingEntities
+                    .stream()
+                    .filter(e -> !Objects.equals(e.getUuid(), UUID.fromString(entityDto.getUuid())))
+                    .collect(Collectors.toList());
+
+            if (!existingEntities.isEmpty()) {
+                throw new ApplicationExceptions.EntityAlreadyExistsException("entity with this simple name already exists!");
+            }
+
             entity.update(entityDto);
             entityRepository.save(entity);
         } else {

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/EntityService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/EntityService.java
@@ -83,7 +83,8 @@ public class EntityService {
                     .collect(Collectors.toList());
 
             if (!existingEntities.isEmpty()) {
-                throw new ApplicationExceptions.EntityAlreadyExistsException("entity with this simple name already exists!");
+                throw new ApplicationExceptions.EntityAlreadyExistsException(
+                        String.format("entity with simple name: %s already exists", existingEntities.get(0).getSimpleName()));
             }
 
             entity.update(entityDto);

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/EntityRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/EntityRepository.java
@@ -39,4 +39,7 @@ public interface EntityRepository extends CrudRepository<Entity, Long> {
     Entity findByUuid(UUID uuid);
 
     Optional<Entity> findBySimpleNameAndEntityListUUID(String simpleName, UUID entityListUuid);
+
+    @Query(value = "select e.* from entity e where e.data = ?1 and e.entity_list_uuid = ?2", nativeQuery = true)
+    List<Entity> findByDataAndEntityListUUID(String data, UUID entityListUuid);
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/EntityServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/EntityServiceTest.java
@@ -206,6 +206,7 @@ public class EntityServiceTest {
         verify(entityRepository).save(mockEntity);
         verify(entityRepository).findByUuid(uuid);
         verify(entityRepository).findEntityListUUIDBySimpleName(listName);
+        verify(entityRepository).findByDataAndEntityListUUID(data, listUUID);
         verifyNoMoreInteractions(entityRepository);
 
     }
@@ -227,6 +228,32 @@ public class EntityServiceTest {
 
         entityService.updateEntity(listName, entityDto);
 
+
+    }
+
+    @Test(expected = ApplicationExceptions.EntityAlreadyExistsException.class)
+    public void updateEntity_duplicate() {
+        String listName = "L1";
+        String simpleName1 = "nameOne";
+        String simpleName2 = "nameTwo";
+        UUID uuid1 = UUID.randomUUID();
+        UUID uuid2 = UUID.randomUUID();
+        String data = "{ title: 'Title' }";
+        UUID listUUID = UUID.randomUUID();
+
+        EntityDto entity1Dto = new EntityDto(simpleName1, uuid1.toString(), data);
+        Entity entity2 = new Entity(2L, uuid2, simpleName2, data, listUUID, true, 10);
+
+        List<Entity> entitiesToReturn = List.of(entity2);
+
+        Entity mockEntity = mock(Entity.class);
+
+        when(mockEntity.getEntityListUUID()).thenReturn(listUUID);
+        when(entityRepository.findByUuid(uuid1)).thenReturn(mockEntity);
+        when(entityRepository.findEntityListUUIDBySimpleName(listName)).thenReturn(listUUID.toString());
+        when(entityRepository.findByDataAndEntityListUUID(data, listUUID)).thenReturn(entitiesToReturn);
+
+        entityService.updateEntity(listName, entity1Dto);
 
     }
 


### PR DESCRIPTION
Currently, there is no check for duplicate titles when amending an
entity. This change adds a check and throws an
EnityAlreadyExistsException if a duplicate title is found.