### PR TITLE
HOCS-4312 - remove retry and async annotations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,6 @@ dependencies {
 	implementation('org.springframework.boot:spring-boot-starter-json')
 	implementation('org.springframework.boot:spring-boot-starter-undertow')
 	implementation('org.springframework.boot:spring-boot-starter-validation')
-	implementation('org.springframework.retry:spring-retry')
 
 	implementation('net.logstash.logback:logstash-logback-encoder:5.3')
 	implementation('log4j:log4j:1.2.17')

--- a/src/main/java/uk/gov/digital/ho/hocs/info/HocsInfoServiceApplication.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/HocsInfoServiceApplication.java
@@ -3,13 +3,11 @@ package uk.gov.digital.ho.hocs.info;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.retry.annotation.EnableRetry;
 
 import javax.annotation.PreDestroy;
 
 @Slf4j
 @SpringBootApplication
-@EnableRetry
 public class HocsInfoServiceApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/uk/gov/digital/ho/hocs/info/application/RestHelper.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/application/RestHelper.java
@@ -4,7 +4,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.digital.ho.hocs.info.domain.exception.ApplicationExceptions;
@@ -33,19 +32,16 @@ public class RestHelper {
         this.requestData = requestData;
     }
 
-    @Retryable
     public <T,R> ResponseEntity<R> post(String serviceBaseURL, String url, T request, Class<R> responseType) {
         return restTemplate.exchange(String.format("%s%s", serviceBaseURL, url), HttpMethod.POST, new HttpEntity<>(request, createAuthHeaders()), responseType);
     }
 
-    @Retryable
     public <R> ResponseEntity<R> get(String serviceBaseURL, String url, Class<R> responseType) {
         ResponseEntity<R> response = restTemplate.exchange(String.format("%s%s", serviceBaseURL, url), HttpMethod.GET, new HttpEntity<>(null, createAuthHeaders()), responseType);
         validateResponse(response);
         return response;
     }
 
-    @Retryable
     public <R> ResponseEntity<R> delete(String serviceBaseURL, String url, Class<R> responseType) {
         return restTemplate.exchange(String.format("%s%s", serviceBaseURL, url), HttpMethod.DELETE, new HttpEntity<>(null, createAuthHeaders()), responseType);
     }

--- a/src/main/java/uk/gov/digital/ho/hocs/info/client/notifyclient/NotifyClient.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/client/notifyclient/NotifyClient.java
@@ -7,9 +7,6 @@ import org.apache.camel.CamelExecutionException;
 import org.apache.camel.ProducerTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 import uk.gov.digital.ho.hocs.info.client.notifyclient.dto.TeamActiveCommand;
@@ -44,8 +41,6 @@ public class NotifyClient {
         this.requestData = requestData;
     }
 
-    @Retryable(maxAttemptsExpression = "${retry.maxAttempts}", backoff = @Backoff(delayExpression = "${retry.delay}"))
-    @Async
     public void sendTeamRenameEmail(UUID teamUUID, String oldDisplayName) {
         Assert.notNull(teamUUID, "teamUUID parameter must not be null");
         Assert.notNull(oldDisplayName, "oldDisplayName parameter must not be null");
@@ -53,8 +48,6 @@ public class NotifyClient {
         sendTeamCommand(new TeamRenameCommand(teamUUID, oldDisplayName));
     }
 
-    @Retryable(maxAttemptsExpression = "${retry.maxAttempts}", backoff = @Backoff(delayExpression = "${retry.delay}"))
-    @Async
     public void sendTeamActiveStatusEmail(UUID teamUUID, Boolean currentActiveStatus) {
         Assert.notNull(teamUUID, "teamUUID parameter must not be null");
         Assert.notNull(currentActiveStatus, "currentActiveStatus parameter must not be null");

--- a/src/main/java/uk/gov/digital/ho/hocs/info/security/KeycloakService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/security/KeycloakService.java
@@ -24,8 +24,6 @@ import org.keycloak.representations.idm.GroupRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.util.JsonSerialization;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import uk.gov.digital.ho.hocs.info.api.dto.CreateUserDto;
 import uk.gov.digital.ho.hocs.info.api.dto.CreateUserResponse;
@@ -133,7 +131,6 @@ public class KeycloakService {
         }
     }
 
-    @Retryable(maxAttemptsExpression = "${retry.maxAttempts}", backoff = @Backoff(delayExpression = "${retry.delay}"))
     public Set<UUID> getGroupsForUser(UUID userUUID) {
         try {
             RealmResource hocsRealm = keycloakClient.realm(hocsRealmName);
@@ -150,7 +147,6 @@ public class KeycloakService {
     }
 
 
-    @Retryable(maxAttemptsExpression = "${retry.maxAttempts}", backoff = @Backoff(delayExpression = "${retry.delay}"))
     public List<UserRepresentation> getAllUsers() {
         log.info("Get users from Keycloak realm {}", hocsRealmName);
         UsersResource usersResource = keycloakClient.realm(hocsRealmName).users();
@@ -166,12 +162,10 @@ public class KeycloakService {
         return users;
     }
 
-    @Retryable(maxAttemptsExpression = "${retry.maxAttempts}", backoff = @Backoff(delayExpression = "${retry.delay}"))
     public UserRepresentation getUserFromUUID(UUID userUUID) {
         return keycloakClient.realm(hocsRealmName).users().get(userUUID.toString()).toRepresentation();
     }
 
-    @Retryable(maxAttemptsExpression = "${retry.maxAttempts}", backoff = @Backoff(delayExpression = "${retry.delay}"))
     public Set<UserRepresentation> getUsersForTeam(UUID teamUUID) {
         String encodedTeamPath = "/" + Base64UUID.uuidToBase64String(teamUUID);
         HashSet<UserRepresentation> groupUsers = new HashSet<>();

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -4,9 +4,6 @@ notify.redrive.policy={"maxReceiveCount": "${notify.queue.maximumRedeliveries}",
 notify.queue=aws-sqs://${notify.queue.name}?amazonSQSClient=#notifySqsClient&messageAttributeNames=All&redrivePolicy=${notify.redrive.policy}&waitTimeSeconds=20
 notify.queue.dlq=aws-sqs://${notify.queue.dlq.name}?amazonSQSClient=#notifySqsClient&messageAttributeNames=All
 
-retry.maxAttempts=2
-retry.delay=1000
-
 springdoc.api-docs.enabled=true
 springdoc.swagger-ui.enabled=true
 springdoc.swagger-ui.disable-swagger-default-url=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -33,9 +33,6 @@ hocs.basicauth=UNSET
 aws.region=eu-west-2
 aws.account.id=12345
 
-retry.maxAttempts=3
-retry.delay=2000
-
 camel.springboot.main-run-controller=true
 
 keycloak.server.root=http://localhost:9081

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -21,9 +21,6 @@ api.ni.assembly=http://data.niassembly.gov.uk/members.asmx/GetAllCurrentMembers
 api.european.parliament=http://www.europarl.europa.eu/meps/en/download/advanced/xml?countryCode=GB
 api.welsh.assembly=https://senedd.assembly.wales/mgwebservice.asmx/GetCouncillorsByWard
 
-retry.maxAttempts=3
-retry.delay=2000
-
 audit.queue.name=audit-queue
 audit.queue=seda://${audit.queue.name}
 auditing.deployment.namespace=local


### PR DESCRIPTION
As part of the investigation it was determined that the application was failing to create new threads for the retry code, we have given the pods more memory, but we don't believe we need to use @Retry or @async at all - we prefer to fail fast.