### PR TITLE
Ignore aws-java-sdk dependabot patch versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,6 @@ updates:
       separator: "-"
     reviewers:
       - "UKHomeOffice/hocs-core"
+    ignore:
+      - dependency-name: "aws-java-sdk"
+        update-types: [ "version-update:semver-patch" ]


### PR DESCRIPTION
The `aws-java-sdk` is currently updated daily and contains changes to
all of the bundled java aws libraries. As we use a limited number of
these, this becomes a noisy change that is mostly irrelavent. This
change specified to dependabot to ignore patch versions for this library
. This does not stop security package upgrades.