### PR TITLE
HOCS-4532: upgrade keycloak library to 11.0.2 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,19 +50,15 @@ dependencies {
 	implementation 'org.apache.httpcomponents:httpmime:4.5.13'
 	implementation 'javax.xml.bind:jaxb-api:2.3.1'
 	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.9.6'
-	implementation 'org.keycloak:keycloak-admin-client:8.0.2'
-	implementation('org.keycloak:keycloak-services:8.0.2'){
+	implementation 'org.keycloak:keycloak-admin-client:11.0.2'
+	implementation('org.keycloak:keycloak-services:11.0.2'){
 		exclude module: "slf4j-log4j12"
 	}
-	implementation 'org.jboss.resteasy:resteasy-jaxrs:3.9.1.Final'
-	implementation 'org.jboss.resteasy:resteasy-client:3.9.1.Final'
-	implementation 'org.jboss.resteasy:resteasy-jackson2-provider:3.9.1.Final'
 
 	implementation 'org.apache.commons:commons-csv:1.9.0'
 	implementation 'org.springdoc:springdoc-openapi-ui:1.6.4'
 	implementation 'com.jayway.jsonpath:json-path:2.6.0'
 	implementation 'javax.json:javax.json-api:1.1.4'
-
 
 	implementation 'org.flywaydb:flyway-core:8.4.2'
 	runtimeOnly 'org.hsqldb:hsqldb'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.1'
 
 services:
   keycloak:
-    image: jboss/keycloak
+    image: jboss/keycloak:11.0.2
     restart: always
     ports:
     - 9990:9990


### PR DESCRIPTION
Current production Keycloak version is 11.0.2, this change upgrades the
outdated dependency to this version. This change also pegs the version
of Keycloak used in the internal `docker-compose` file to use 11.0.2.