### PR TITLE
Dependabot: ignore keycloak dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,4 @@ updates:
     ignore:
       - dependency-name: "com.amazonaws:aws-java-sdk"
         update-types: [ "version-update:semver-patch" ]
+      - dependancy-name: "org.keycloak:keycloak-*"


### PR DESCRIPTION
As our Keycloak version has to be in line with the version that is in
the production environment provided by ACP. This change marks the
keycloak libraries as one to ignore as we will upgrade it inline with
ACP.