### PR TITLE
Pipeline: add missing restart script

### DIFF
--- a/kube/restart.sh
+++ b/kube/restart.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+export KUBE_NAMESPACE=${ENVIRONMENT}
+
+if [[ ${KUBE_NAMESPACE} == *prod ]] ; then
+    export KUBE_SERVER="https://kube-api-prod.prod.acp.homeoffice.gov.uk"
+    export KUBE_CERTIFICATE_AUTHORITY="https://raw.githubusercontent.com/UKHomeOffice/acp-ca/master/acp-prod.crt"
+else
+    export KUBE_SERVER="https://kube-api-notprod.notprod.acp.homeoffice.gov.uk"
+    export KUBE_CERTIFICATE_AUTHORITY="https://raw.githubusercontent.com/UKHomeOffice/acp-ca/master/acp-notprod.crt"
+fi
+
+kd run rollout restart deployment hocs-info-service


### PR DESCRIPTION
Upon moving the kube folder into the main repository the restart script
was missed. This has meant that all data only repo changes have not been
triggering this downstream restart pipeline. This change ports over the
restart script from the kube repository.