### PR TITLE
HOCS-4696: use GitHub SemVer actions

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,6 +2,12 @@
 kind: pipeline
 type: kubernetes
 name: build
+trigger:
+  event:
+    - push
+  branch:
+    exclude:
+      - main
 
 environment:
   KEYCLOAK_SERVER_ROOT: http://keycloak:8080
@@ -63,6 +69,8 @@ steps:
           -d @keycloak/local-realm.json \
           -H "Authorization: Bearer $${TKN}" \
           -H "Content-Type: application/json"
+    depends_on:
+      - clone
 
   - name: test project
     image: quay.io/ukhomeofficedigital/hocs-base-image-build
@@ -94,58 +102,19 @@ steps:
       repo: quay.io/ukhomeofficedigital/hocs-info-service
       tags:
         - ${DRONE_COMMIT_SHA}
-    when:
-      branch:
-        exclude:
-          - main
-          - "dependabot*"
     depends_on:
       - test project
-
-  - name: build & push latest
-    image: plugins/docker
-    environment:
-      DOCKER_PASSWORD:
-        from_secret: QUAY_ROBOT_TOKEN
-      DOCKER_USERNAME: ukhomeofficedigital+hocs_quay_robot
-    settings:
-      registry: quay.io
-      repo: quay.io/ukhomeofficedigital/hocs-info-service
-      tags:
-        - ${DRONE_COMMIT_SHA}
-        - latest
-    when:
-      branch:
-        include:
-          - main
-    depends_on:
-      - test project
-
-trigger:
-  event:
-    - push
 
 ---
 kind: pipeline
 type: kubernetes
 name: deploy
-depends_on:
-  - build
 trigger:
   event:
-    exclude:
-      - pull_request
-      - tag
+    - promote
   target:
     exclude:
       - restart*
-
-services:
-  - name: docker
-    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
-
-environment:
-  DOCKER_HOST: tcp://docker:2375
 
 steps:
   - name: fetch and checkout
@@ -154,143 +123,6 @@ steps:
       - git fetch --tags
       - git checkout $${VERSION}
 
-  - name: deploy to cs-dev
-    image: quay.io/ukhomeofficedigital/kd
-    commands:
-      - cd kube
-      - ./deploy.sh
-    environment:
-      ENVIRONMENT: cs-dev
-      KUBE_TOKEN:
-        from_secret: hocs_info_service_cs_dev
-      VERSION: "${DRONE_COMMIT_SHA}"
-      HOCS_INFO_SERVICE_DATA_VERSION: latest
-    depends_on:
-      - fetch and checkout
-    when:
-      branch:
-        - main
-      event:
-        - push
-
-  - name: deploy to wcs-dev
-    image: quay.io/ukhomeofficedigital/kd
-    commands:
-      - cd kube
-      - ./deploy.sh
-    environment:
-      ENVIRONMENT: wcs-dev
-      KUBE_TOKEN:
-        from_secret: hocs_info_service_wcs_dev
-      VERSION: "${DRONE_COMMIT_SHA}"
-      HOCS_INFO_SERVICE_DATA_VERSION: latest
-    depends_on:
-      - fetch and checkout
-    when:
-      branch:
-        - main
-      event:
-        - push
-
-  - name: wait for docker
-    image: docker
-    commands:
-      - n=0; until docker stats --no-stream; do echo "Waiting for Docker $n"; n=$((n +1)); sleep 1; done
-    when:
-      event:
-        - promote
-      target:
-        - release
-
-  - name: generate & tag build
-    image: quay.io/ukhomeofficedigital/hocs-version-bot
-    commands:
-      - >
-        /app/hocs-deploy
-        --dockerRepository=quay.io/ukhomeofficedigital
-        --environment=qa
-        --registryPassword=$${DOCKER_PASSWORD}
-        --registryUser=ukhomeofficedigital+hocs_quay_robot
-        --service=hocs-info-service
-        --serviceGitToken=$${GITHUB_TOKEN}
-        --sourceBuild=$${VERSION}
-        --version=$${SEMVER}
-        --versionRepo="https://gitlab.digital.homeoffice.gov.uk/hocs/hocs-versions.git"
-        --versionRepoServiceToken=$${GITLAB_TOKEN}
-    environment:
-      DOCKER_API_VERSION: 1.40
-      DOCKER_PASSWORD:
-        from_secret: QUAY_ROBOT_TOKEN
-      GITLAB_TOKEN:
-        from_secret: GITLAB_TOKEN
-      GITHUB_TOKEN:
-        from_secret: GITHUB_TOKEN
-    depends_on:
-      - wait for docker
-      - fetch and checkout
-    when:
-      event:
-        - promote
-      target:
-        - release
-
-  - name: env-file
-    image: alpine:latest
-    commands:
-      - source version.txt
-      - echo HOCS_INFO_SERVICE_DATA_VERSION=$VERSION > info-service-data-version.env
-    depends_on:
-      - generate & tag build
-    when:
-      event:
-        - promote
-      target:
-        - release
-
-  - name: CS downstream build
-    image: plugins/downstream
-    settings:
-      server: https://drone-gh.acp.homeoffice.gov.uk
-      deploy: cs-qa
-      fork: false
-      last_successful: true
-      token:
-        from_secret: DRONE_TOKEN
-      params:
-        - info-service-data-version.env
-      repositories:
-        - UKHomeOffice/hocs-data@main
-    depends_on:
-      - generate & tag build
-      - env-file
-    when:
-      event:
-        - promote
-      target:
-        - release
-
-  - name: WCS downstream build
-    image: plugins/downstream
-    settings:
-      server: https://drone-gh.acp.homeoffice.gov.uk
-      token:
-        from_secret: DRONE_TOKEN
-      fork: false
-      deploy: wcs-qa
-      last_successful: true
-      params:
-        - info-service-data-version.env
-      repositories:
-        - UKHomeOffice/hocs-data-wcs@main
-    depends_on:
-      - generate & tag build
-      - env-file
-    when:
-      event:
-        - promote
-      target:
-        - release
-
   - name: deploy to cs-qa
     image: quay.io/ukhomeofficedigital/kd
     environment:
@@ -298,15 +130,11 @@ steps:
       KUBE_TOKEN:
         from_secret: hocs_info_service_cs_qa
     commands:
-      - source version.txt
-      - echo $VERSION
       - cd kube
       - ./deploy.sh
     depends_on:
-      - CS downstream build
+      - fetch and checkout
     when:
-      event:
-        - promote
       target:
         - release
 
@@ -317,15 +145,11 @@ steps:
       KUBE_TOKEN:
         from_secret: hocs_info_service_wcs_qa
     commands:
-      - source version.txt
-      - echo $VERSION
       - cd kube
       - ./deploy.sh
     depends_on:
-      - WCS downstream build
+      - fetch and checkout
     when:
-      event:
-        - promote
       target:
         - release
 
@@ -344,10 +168,7 @@ steps:
       target:
         exclude:
           - release
-          - restart
           - "*-prod"
-      event:
-        - promote
 
   - name: deploy to prod
     image: quay.io/ukhomeofficedigital/kd
@@ -361,8 +182,6 @@ steps:
     depends_on:
       - fetch and checkout
     when:
-      event:
-        - promote
       target:
         - "*-prod"
 
@@ -382,7 +201,6 @@ trigger:
 # separately to our main deployment pipeline
 
 steps:
-
   - name: restart cs-dev
     image: quay.io/ukhomeofficedigital/kd
     commands:
@@ -394,7 +212,6 @@ steps:
         from_secret: hocs_info_service_cs_dev
     when:
       target:
-        - restart
         - restart-cs
 
   - name: restart wcs-dev
@@ -408,5 +225,205 @@ steps:
         from_secret: hocs_info_service_wcs_dev
     when:
       target:
-        - restart
         - restart-wcs
+
+---
+kind: pipeline
+type: kubernetes
+name: build tag
+trigger:
+  event:
+    - tag
+  branch:
+    - main
+
+environment:
+  KEYCLOAK_SERVER_ROOT: http://keycloak:8080
+  KEYCLOAK_USER: admin
+  KEYCLOAK_PASSWORD: password1
+
+services:
+  - name: keycloak
+    image: jboss/keycloak
+    environment:
+      DB_VENDOR: h2
+
+  - name: postgres
+    image: postgres:12-alpine
+    environment:
+      POSTGRES_USER: root
+      POSTGRES_PASSWORD: dev
+
+  - name: localstack
+    image: quay.io/ukhomeofficedigital/localstack
+    environment:
+      SERVICES: sqs, sns
+      DEFAULT_REGION: eu-west-2
+
+steps:
+  - name: setup localstack
+    image: quay.io/ukhomeofficedigital/localstack
+    commands:
+      - cd config/localstack
+      - ./1-setup-sqs.sh
+      - ./2-setup-sns.sh
+    depends_on:
+      - clone
+
+  - name: wait for keycloak
+    image: quay.io/ukhomeofficedigital/hocs-docker-tools
+    commands:
+      - >
+        until
+          $(curl \
+          --output /dev/null \
+          --silent --head --fail \
+          $${KEYCLOAK_SERVER_ROOT}/auth/realms/master/.well-known/openid-configuration);
+        do
+          echo "waiting for keycloak"
+          sleep 1
+        done
+      - >
+        export TKN=$(curl -X POST \
+          'http://keycloak:8080/auth/realms/master/protocol/openid-connect/token' \
+          -H "Content-Type: application/x-www-form-urlencoded" \
+          -d username=$${KEYCLOAK_USER} \
+          -d password=$${KEYCLOAK_PASSWORD} \
+          -d grant_type=password \
+          -d client_id=admin-cli \
+          | jq -r '.access_token')
+      - >
+        curl -vX POST http://keycloak:8080/auth/admin/realms \
+          -d @keycloak/local-realm.json \
+          -H "Authorization: Bearer $${TKN}" \
+          -H "Content-Type: application/json"
+    depends_on:
+      - clone
+
+  - name: test project
+    image: quay.io/ukhomeofficedigital/hocs-base-image-build
+    environment:
+      SPRING_PROFILES_ACTIVE: "development, local, test"
+      DB_HOST: postgres
+      AWS_LOCAL_HOST: localstack
+    commands:
+      - ./gradlew clean build --no-daemon
+    depends_on:
+      - wait for keycloak
+      - setup localstack
+
+  - name: sonar scanner
+    image: quay.io/ukhomeofficedigital/sonar-scanner
+    commands:
+      - sonar-scanner -Dsonar.projectVersion="$(git rev-parse --abbrev-ref HEAD)"
+    depends_on:
+      - build and test project
+
+  - name: build & push latest
+    image: plugins/docker
+    settings:
+      registry: quay.io
+      repo: quay.io/ukhomeofficedigital/hocs-info-service
+      tags:
+        - ${DRONE_TAG}
+        - ${DRONE_COMMIT_SHA}
+        - latest
+    environment:
+      DOCKER_PASSWORD:
+        from_secret: QUAY_ROBOT_TOKEN
+      DOCKER_USERNAME: ukhomeofficedigital+hocs_quay_robot
+    depends_on:
+      - test project
+
+---
+kind: pipeline
+type: kubernetes
+name: tag data
+trigger:
+  event:
+    - tag
+  branch:
+    - main
+
+clone:
+  disable: true
+
+steps:
+  - name: env-file
+    image: alpine:latest
+    commands:
+      - echo HOCS_INFO_SERVICE_DATA_VERSION=$${DRONE_TAG} > info-service-data-version.env
+
+  - name: CS downstream build
+    image: plugins/downstream
+    settings:
+      server: https://drone-gh.acp.homeoffice.gov.uk
+      deploy: cs-qa
+      fork: false
+      last_successful: true
+      token:
+        from_secret: DRONE_TOKEN
+      params:
+        - info-service-data-version.env
+      repositories:
+        - UKHomeOffice/hocs-data@main
+    depends_on:
+      - env-file
+
+  - name: WCS downstream build
+    image: plugins/downstream
+    settings:
+      server: https://drone-gh.acp.homeoffice.gov.uk
+      deploy: wcs-qa
+      fork: false
+      last_successful: true
+      token:
+        from_secret: DRONE_TOKEN
+      params:
+        - info-service-data-version.env
+      repositories:
+        - UKHomeOffice/hocs-data-wcs@main
+    depends_on:
+      - env-file
+
+---
+kind: pipeline
+type: kubernetes
+name: deploy tag
+trigger:
+  event:
+    - tag
+  branch:
+    - main
+depends_on:
+  - build tag
+  - tag data
+
+steps:
+  - name: deploy to cs-dev
+    image: quay.io/ukhomeofficedigital/kd
+    commands:
+      - cd kube
+      - ./deploy.sh
+    environment:
+      ENVIRONMENT: cs-dev
+      KUBE_TOKEN:
+        from_secret: hocs_info_service_cs_dev
+      KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
+      VERSION: "${DRONE_TAG}"
+    depends_on:
+      - clone
+
+  - name: deploy to wcs-dev
+    image: quay.io/ukhomeofficedigital/kd
+    commands:
+      - cd kube
+      - ./deploy.sh
+    environment:
+      ENVIRONMENT: wcs-dev
+      KUBE_TOKEN:
+        from_secret: hocs_info_service_wcs_dev
+      KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
+      VERSION: "${DRONE_TAG}"
+    depends_on:
+      - clone

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -1,0 +1,14 @@
+name: 'PR Label Checker'
+on:
+  pull_request:
+    types: [ labeled, unlabeled, opened, reopened, synchronize ]
+
+jobs:
+  build:
+    name: SemVer PR Label Checker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: UKHomeOffice/match-label-action@v1.0.0
+        with:
+          labels: minor,major,patch
+          mode: singular

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -1,0 +1,20 @@
+name: 'SemVer - Tag the Commit'
+on:
+  pull_request:
+    types: [ closed ]
+
+jobs:
+  build:
+    name: SemVer Tag on PR Merge
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && github.base_ref == 'main'
+    steps:
+      - id: label
+        uses: UKHomeOffice/match-label-action@v1.0.0
+        with:
+          labels: minor,major,patch
+          mode: singular
+      - uses: UKHomeOffice/semver-tag-action@v1.0.0
+        with:
+          increment: ${{ steps.label.outputs.matchedLabels }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This change removes the use of the old hocs-version-bot in favour of
new GitHub actions.

When an action happens on a PR an action is run that checks that the PR
is labeled with one of the following: Patch, Minor, or Major.
If one of these isn't present the PR will be blocked till one is added.
This enables us to immediately identify the scale of the change.

On an successful merge, an second action is ran that uses specified
label to update the SemVer version for the service - automatically
creating a Git Tag with that version.

This triggers a drone build that automatically deploys this new version
to the dev environments. This triggers a downstream build to CS-DEV and
WCS-DEV to tag that image in ECR. The deployment to the environment
awaits the success of the build and push and the tagging of data.