### PR TITLE
Hocs 4696: add the correct dependency name to Sonar

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -317,7 +317,7 @@ steps:
     commands:
       - sonar-scanner -Dsonar.projectVersion="$(git rev-parse --abbrev-ref HEAD)"
     depends_on:
-      - build and test project
+      - test project
 
   - name: build & push latest
     image: plugins/docker


### PR DESCRIPTION
Add the correct dependency name to Sonar as the deploy on tag step is currently failing.