### PR TITLE
HOCS-4696: support tag on data

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -236,6 +236,8 @@ trigger:
     - tag
   branch:
     - main
+concurrency:
+  limit: 1
 
 environment:
   KEYCLOAK_SERVER_ROOT: http://keycloak:8080

--- a/.github/workflows/semver-data.yml
+++ b/.github/workflows/semver-data.yml
@@ -1,0 +1,22 @@
+name: 'SemVer - Tag on Data Change'
+on:
+  workflow_dispatch:
+    inputs:
+      increment:
+        description: 'SemVer Increment Value'
+        required: true
+        default: 'patch'
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  semver:
+    name: Manual SemVer Tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: UKHomeOffice/semver-tag-action@v1.0.0
+        with:
+          increment: ${{ github.event.inputs.increment }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
When a data PR is closed, this sends a trigger to the `semver-data`
action that allows a tag based on that PRs labels to the info. This then
supports a fresh deploy and drone trigger to dev environments.