### PR TITLE
HOCS-4783 Remove redundant log line

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/ConfigurationService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/ConfigurationService.java
@@ -44,7 +44,6 @@ public class ConfigurationService {
             );
         }
         log.info("Got {} Configuration", configuration.getSystemName());
-        log.info(configuration.toString());
         return configuration;
     }
 


### PR DESCRIPTION
Stop logging the configuration. It adds logspam and is of little
practical use.