### PR TITLE
HOCS-4839 Prevent NPE on null Members response

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/client/ingest/ListConsumerService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/client/ingest/ListConsumerService.java
@@ -65,13 +65,17 @@ public class ListConsumerService {
             IrishMembers irishMembers =
                     getDataFromAPI(apiNorthernIrishAssembly, MediaType.APPLICATION_XML, IrishMembers.class);
 
-            return irishMembers.getMembers()
-                    .stream().map(m ->
-                            new Member(House.HOUSE_NORTHERN_IRISH_ASSEMBLY.getDisplayValue(),
-                                    m.getFullDisplayName() + " MLA",
-                                    houseAddress.getUuid(),
-                                    "NI" + m.getPersonId()))
-                    .collect(Collectors.toSet());
+            if (irishMembers.getMembers() != null) {
+                return irishMembers.getMembers()
+                        .stream().map(m ->
+                                new Member(House.HOUSE_NORTHERN_IRISH_ASSEMBLY.getDisplayValue(),
+                                        m.getFullDisplayName() + " MLA",
+                                        houseAddress.getUuid(),
+                                        "NI" + m.getPersonId()))
+                        .collect(Collectors.toSet());
+            }
+            return Collections.emptySet();
+
         } catch (ApplicationExceptions.IngestException | ApplicationExceptions.EntityNotFoundException ex) {
             log.warn(ex.getMessage());
             return Collections.emptySet();
@@ -105,13 +109,17 @@ public class ListConsumerService {
 
             UKMembers houseOfCommomsMembers = getDataFromAPI(getFormattedUkEndpoint(HOUSE_COMMONS), MediaType.APPLICATION_XML, UKMembers.class);
 
-            return houseOfCommomsMembers.getMembers()
-                    .stream().map(m ->
-                            new Member(House.HOUSE_COMMONS.getDisplayValue(),
-                                    m.getFullTitle(),
-                                    houseAddress.getUuid(),
-                                    "CO"+m.getMemberId()))
-                    .collect(Collectors.toSet());
+            if (houseOfCommomsMembers.getMembers() != null) {
+                return houseOfCommomsMembers.getMembers()
+                        .stream().map(m ->
+                                new Member(House.HOUSE_COMMONS.getDisplayValue(),
+                                        m.getFullTitle(),
+                                        houseAddress.getUuid(),
+                                        "CO" + m.getMemberId()))
+                        .collect(Collectors.toSet());
+            }
+
+            return Collections.emptySet();
         } catch (ApplicationExceptions.IngestException | ApplicationExceptions.EntityNotFoundException ex) {
             log.warn(ex.getMessage());
             return Collections.emptySet();
@@ -125,13 +133,17 @@ public class ListConsumerService {
 
             UKMembers houseOfLordsMembers = getDataFromAPI(getFormattedUkEndpoint(HOUSE_LORDS), MediaType.APPLICATION_XML, UKMembers.class);
 
-            return houseOfLordsMembers.getMembers()
-                    .stream().map(m ->
-                            new Member(House.HOUSE_LORDS.getDisplayValue(),
-                                    m.getFullTitle(),
-                                    houseAddress.getUuid(),
-                                    "LO"+m.getMemberId()))
-                    .collect(Collectors.toSet());
+            if (houseOfLordsMembers.getMembers() != null) {
+                return houseOfLordsMembers.getMembers()
+                        .stream().map(m ->
+                                new Member(House.HOUSE_LORDS.getDisplayValue(),
+                                        m.getFullTitle(),
+                                        houseAddress.getUuid(),
+                                        "LO" + m.getMemberId()))
+                        .collect(Collectors.toSet());
+            }
+
+            return Collections.emptySet();
         } catch (ApplicationExceptions.IngestException | ApplicationExceptions.EntityNotFoundException ex) {
             log.warn(ex.getMessage());
             return Collections.emptySet();
@@ -145,22 +157,26 @@ public class ListConsumerService {
 
             WelshWards welshWards = getDataFromAPI(apiWelshAssembly, MediaType.APPLICATION_XML, WelshWards.class);
 
-            Set<WelshMembers> welshMembers = welshWards.getWards().stream()
-                    .map(WelshWard::getMembers)
-                    .collect(Collectors.toSet());
+            if (welshWards.getWards() != null) {
+                Set<WelshMembers> welshMembers = welshWards.getWards().stream()
+                        .map(WelshWard::getMembers)
+                        .collect(Collectors.toSet());
 
-            Set<WelshMember> welshMemberSet = welshMembers.stream()
-                    .map(WelshMembers::getMembers)
-                    .flatMap(Collection::stream)
-                    .collect(Collectors.toSet());
+                Set<WelshMember> welshMemberSet = welshMembers.stream()
+                        .map(WelshMembers::getMembers)
+                        .flatMap(Collection::stream)
+                        .collect(Collectors.toSet());
 
-            return welshMemberSet.stream()
-                    .map(m ->
-                            new Member(House.HOUSE_WELSH_ASSEMBLY.getDisplayValue(),
-                                    m.getName(),
-                                    houseAddress.getUuid(),
-                                    "WE"+m.getId()))
-                    .collect(Collectors.toSet());
+                return welshMemberSet.stream()
+                        .map(m ->
+                                new Member(House.HOUSE_WELSH_ASSEMBLY.getDisplayValue(),
+                                        m.getName(),
+                                        houseAddress.getUuid(),
+                                        "WE"+m.getId()))
+                        .collect(Collectors.toSet());
+            }
+
+            return Collections.emptySet();
         } catch (ApplicationExceptions.IngestException | ApplicationExceptions.EntityNotFoundException ex) {
             log.warn(ex.getMessage());
             return Collections.emptySet();
@@ -206,7 +222,6 @@ public class ListConsumerService {
             throw new ApplicationExceptions.IngestException("ListConsumerService exchange exception : " + e.getMessage() + " endpoint : " +
                     apiEndpoint + " headers : " + headers.toString() + " media type : " +  mediaType.toString());
         }
-
         return response.getBody();
     }
 

--- a/src/test/java/uk/gov/digital/ho/hocs/info/client/ingest/ListConsumerServicesTests.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/client/ingest/ListConsumerServicesTests.java
@@ -5,10 +5,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.http.HttpMethod;
+import org.springframework.http.*;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
-import uk.gov.digital.ho.hocs.info.domain.exception.ApplicationExceptions;
 import uk.gov.digital.ho.hocs.info.domain.model.Country;
 import uk.gov.digital.ho.hocs.info.domain.model.HouseAddress;
 import uk.gov.digital.ho.hocs.info.domain.model.Member;
@@ -20,8 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ListConsumerServicesTests {
@@ -66,6 +64,116 @@ public class ListConsumerServicesTests {
         Set<Member> members = listConsumerService.createFromIrishAssemblyAPI();
 
         verify(houseAddressRepository).findByHouseCode(any());
+
+        assertTrue(members.isEmpty());
+    }
+
+    @Test
+    public void whenNiAssemblyApiReturnsNoMembers_shouldReturnEmptyCollection() {
+        HttpHeaders header = new HttpHeaders();
+        header.setContentType(MediaType.APPLICATION_JSON);
+
+        IrishMembers irishMembers = new IrishMembers();
+
+        ResponseEntity<?> responseEntity = new ResponseEntity<>(
+                irishMembers,
+                header,
+                HttpStatus.OK
+        );
+
+        when(houseAddressRepository.findByHouseCode(any())).thenReturn(new HouseAddress());
+        when(restTemplate.exchange(eq("Test3"), eq(HttpMethod.GET), any(), eq(IrishMembers.class)))
+                .thenReturn((ResponseEntity<IrishMembers>) responseEntity);
+
+        Set<Member> members = listConsumerService.createFromIrishAssemblyAPI();
+
+        assertTrue(members.isEmpty());
+    }
+
+    @Test
+    public void whenCommonsApiReturnsNoMembers_shouldReturnEmptyCollection() {
+        HttpHeaders header = new HttpHeaders();
+        header.setContentType(MediaType.APPLICATION_JSON);
+
+        UKMembers ukMembers = new UKMembers();
+
+        ResponseEntity<?> responseEntity = new ResponseEntity<>(
+                ukMembers,
+                header,
+                HttpStatus.OK
+        );
+
+        when(houseAddressRepository.findByHouseCode(any())).thenReturn(new HouseAddress());
+        when(restTemplate.exchange(eq("Test1"), eq(HttpMethod.GET), any(), eq(UKMembers.class)))
+                .thenReturn((ResponseEntity<UKMembers>) responseEntity);
+
+        Set<Member> members = listConsumerService.createCommonsFromUKParliamentAPI();
+
+        assertTrue(members.isEmpty());
+    }
+
+    @Test
+    public void whenLordsApiReturnsNoMembers_shouldReturnEmptyCollection() {
+        HttpHeaders header = new HttpHeaders();
+        header.setContentType(MediaType.APPLICATION_JSON);
+
+        UKMembers ukMembers = new UKMembers();
+
+        ResponseEntity<?> responseEntity = new ResponseEntity<>(
+                ukMembers,
+                header,
+                HttpStatus.OK
+        );
+
+        when(houseAddressRepository.findByHouseCode(any())).thenReturn(new HouseAddress());
+        when(restTemplate.exchange(eq("Test1"), eq(HttpMethod.GET), any(), eq(UKMembers.class)))
+                .thenReturn((ResponseEntity<UKMembers>) responseEntity);
+
+        Set<Member> members = listConsumerService.createLordsFromUKParliamentAPI();
+
+        assertTrue(members.isEmpty());
+    }
+
+    @Test
+    public void whenWelshAssemblyApiReturnsNoMembers_shouldReturnEmptyCollection() {
+        HttpHeaders header = new HttpHeaders();
+        header.setContentType(MediaType.APPLICATION_JSON);
+
+        WelshWards welshWards = new WelshWards();
+
+        ResponseEntity<?> responseEntity = new ResponseEntity<>(
+                welshWards,
+                header,
+                HttpStatus.OK
+        );
+
+        when(houseAddressRepository.findByHouseCode(any())).thenReturn(new HouseAddress());
+        when(restTemplate.exchange(eq("Test4"), eq(HttpMethod.GET), any(), eq(WelshWards.class)))
+                .thenReturn((ResponseEntity<WelshWards>) responseEntity);
+
+        Set<Member> members = listConsumerService.createFromWelshAssemblyAPI();
+
+        assertTrue(members.isEmpty());
+    }
+
+    @Test
+    public void whenScottishParliamentApiReturnsNoMembers_shouldReturnEmptyCollection() {
+        HttpHeaders header = new HttpHeaders();
+        header.setContentType(MediaType.APPLICATION_JSON);
+
+        ScottishMember[] scottishMembers = new ScottishMember[0];
+
+        ResponseEntity<?> responseEntity = new ResponseEntity<>(
+                scottishMembers,
+                header,
+                HttpStatus.OK
+        );
+
+        when(houseAddressRepository.findByHouseCode(any())).thenReturn(new HouseAddress());
+        when(restTemplate.exchange(eq("Test2"), eq(HttpMethod.GET), any(), eq(ScottishMember[].class)))
+                .thenReturn((ResponseEntity<ScottishMember[]>) responseEntity);
+
+        Set<Member> members = listConsumerService.createFromScottishParliamentAPI();
 
         assertTrue(members.isEmpty());
     }


### PR DESCRIPTION
If a call to get members returned a null response,
an NPE was thrown. Stop the NPE and return an empty set.