### PR TITLE
Change drone ordering

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -319,6 +319,8 @@ trigger:
     - tag
   branch:
     - main
+depends_on:
+  - build tag
 
 clone:
   disable: true
@@ -371,7 +373,6 @@ trigger:
   branch:
     - main
 depends_on:
-  - build tag
   - tag data
 
 steps:


### PR DESCRIPTION
For tagged builds we ensure that info service successfully builds its
tag before triggering data. This also allows a edge case whereby the
last build of data fails finishes after the downstream build.