### PR TITLE
Use latest main if tag for SHA not present

### DIFF
--- a/.github/workflows/semver-data.yml
+++ b/.github/workflows/semver-data.yml
@@ -21,3 +21,4 @@ jobs:
         with:
           increment: ${{ github.event.inputs.increment }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_use_head_tag: true


### PR DESCRIPTION
If a tag is not found for the SHA passed into the SemVer tag (if
skip-release moves the head pointer for example) default to use the head
of the branch.