### PR TITLE
HOCS-4478: repoint to new column

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/Field.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/Field.java
@@ -64,7 +64,7 @@ public class Field implements Serializable {
 
     @Getter
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "child_field_id")
+    @JoinColumn(name = "child_field", referencedColumnName = "uuid")
     private Field child = null;
 
     public Field(String component, String name, String label, String validation, String props, boolean summary, AccessLevel accessLevel, Field child) {

--- a/src/main/resources/db/postgresql/V1_55__4478_SwapIdForUuid.sql
+++ b/src/main/resources/db/postgresql/V1_55__4478_SwapIdForUuid.sql
@@ -1,0 +1,12 @@
+-- Add child_field column to field
+ALTER TABLE field
+    ADD COLUMN child_field uuid
+        CONSTRAINT fk_field_child_field_uuid REFERENCES field(uuid);
+
+UPDATE field
+SET child_field =
+    (SELECT uuid FROM field f
+    WHERE f.id = field.child_field_id);
+
+ALTER TABLE field
+    DROP COLUMN child_field_id;

--- a/src/test/resources/beforeTest.sql
+++ b/src/test/resources/beforeTest.sql
@@ -73,17 +73,6 @@ INSERT INTO correspondent_type (uuid, display_name, type)
 VALUES ('fe1e8854-72ef-4141-a675-fb06760264fd', 'Test Correspondent Type 1', 'TEST1'),
        ('c2155e6c-7ecd-450d-86e3-884e48c8c6c7', 'Test Correspondent Type 2', 'TEST2');
 
---- schema test
-CREATE OR REPLACE FUNCTION get_field_id_from_uuid(field_uuid UUID)
-    RETURNS INTEGER AS '
-DECLARE
-result INTEGER;
-BEGIN
-    result := (SELECT id FROM info.field WHERE uuid = field_uuid);
-RETURN result;
-END;
-' LANGUAGE plpgsql;
-
 INSERT INTO info.screen_schema(uuid, type, title, action_label, active, props, validation)
 VALUES ('f958f77d-b277-408d-bd6f-4a498d3f217f',
         'TEST_SCREEN_SCHEMA',
@@ -93,7 +82,7 @@ VALUES ('f958f77d-b277-408d-bd6f-4a498d3f217f',
         '{}',
         '{}');
 
-INSERT INTO info.field ("uuid", "component", "name", "label", "validation", "summary", "report_extract", "active", "props", child_field_id)
+INSERT INTO info.field ("uuid", "component", "name", "label", "validation", "summary", "report_extract", "active", "props", child_field)
 VALUES ('782a75de-ce06-4d31-95eb-87e42234f396',
         'text-area',
         'TEST_TEXT_FIELD',
@@ -110,7 +99,7 @@ VALUES ('782a75de-ce06-4d31-95eb-87e42234f396',
         null,
         '[]'::jsonb, true, false, true,
         '{"direction": "TEST_DIRECTION"}'::jsonb,
-        get_field_id_from_uuid('782a75de-ce06-4d31-95eb-87e42234f396'));
+        '782a75de-ce06-4d31-95eb-87e42234f396');
 
 INSERT INTO info.field_screen(schema_uuid, field_uuid) VALUES
     ('f958f77d-b277-408d-bd6f-4a498d3f217f', '782a75de-ce06-4d31-95eb-87e42234f396'),


### PR DESCRIPTION
Repoint the child field from the `child_field_id` to `child_field`.