### PR TITLE
Update Keycloak and Usages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ plugins.withType(JacocoPlugin) {
 }
 
 test {
+	useJUnitPlatform()
 	finalizedBy jacocoTestReport // report is always generated after tests run
 }
 
@@ -71,8 +72,10 @@ dependencies {
 	annotationProcessor 'org.springframework:spring-context-indexer:5.3.20'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.junit.vintage:junit-vintage-engine:5.9.0-M1'
 	testImplementation 'org.assertj:assertj-core'
-	testImplementation 'junit:junit:4.13.2'
+
+
 	testImplementation 'org.mockito:mockito-inline:4.6.1'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,8 @@ plugins {
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 }
 
+def keycloakVersion = '15.0.2'
+
 group = 'uk.gov.digital.ho.hocs'
 sourceCompatibility = JavaVersion.VERSION_17
 
@@ -51,10 +53,8 @@ dependencies {
 	implementation 'org.apache.httpcomponents:httpmime:4.5.13'
 	implementation 'javax.xml.bind:jaxb-api:2.3.1'
 	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.13.3'
-	implementation 'org.keycloak:keycloak-admin-client:11.0.2'
-	implementation('org.keycloak:keycloak-services:11.0.2'){
-		exclude module: "slf4j-log4j12"
-	}
+	implementation "org.keycloak:keycloak-admin-client:${keycloakVersion}"
+	implementation "org.keycloak:keycloak-services:${keycloakVersion}"
 
 	implementation 'org.apache.commons:commons-csv:1.9.0'
 	implementation 'org.springdoc:springdoc-openapi-ui:1.6.9'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,9 @@ version: '3.8'
 
 services:
   keycloak:
-    image: jboss/keycloak:11.0.2
+    image: jboss/keycloak:15.0.2
     restart: always
     ports:
-    - 9990:9990
     - 9081:8080
     networks:
     - hocs-network

--- a/keycloak/local-realm.json
+++ b/keycloak/local-realm.json
@@ -1,1522 +1,2249 @@
 {
-  "id" : "hocs",
-  "realm" : "hocs",
-  "notBefore" : 0,
-  "revokeRefreshToken" : false,
-  "refreshTokenMaxReuse" : 0,
-  "accessTokenLifespan" : 300,
-  "accessTokenLifespanForImplicitFlow" : 900,
-  "ssoSessionIdleTimeout" : 1800,
-  "ssoSessionMaxLifespan" : 36000,
-  "offlineSessionIdleTimeout" : 2592000,
-  "offlineSessionMaxLifespanEnabled" : false,
-  "offlineSessionMaxLifespan" : 5184000,
-  "accessCodeLifespan" : 60,
-  "accessCodeLifespanUserAction" : 300,
-  "accessCodeLifespanLogin" : 1800,
-  "actionTokenGeneratedByAdminLifespan" : 43200,
-  "actionTokenGeneratedByUserLifespan" : 300,
-  "enabled" : true,
-  "sslRequired" : "none",
-  "registrationAllowed" : false,
-  "registrationEmailAsUsername" : false,
-  "rememberMe" : false,
-  "verifyEmail" : false,
-  "loginWithEmailAllowed" : true,
-  "duplicateEmailsAllowed" : false,
-  "resetPasswordAllowed" : false,
-  "editUsernameAllowed" : false,
-  "bruteForceProtected" : false,
-  "permanentLockout" : false,
-  "maxFailureWaitSeconds" : 900,
-  "minimumQuickLoginWaitSeconds" : 60,
-  "waitIncrementSeconds" : 60,
-  "quickLoginCheckMilliSeconds" : 1000,
-  "maxDeltaTimeSeconds" : 43200,
-  "failureFactor" : 30,
-  "roles" : {
-    "realm" : [ {
-      "id" : "63ca477d-b18b-47f5-b27a-d139c96870d4",
-      "name" : "admin",
-      "composite" : false,
-      "clientRole" : false,
-      "containerId" : "hocs"
-    }, {
-      "id" : "fed9906d-b7b7-42ff-bce3-ae090c67b824",
-      "name" : "offline_access",
-      "description" : "${role_offline-access}",
-      "composite" : false,
-      "clientRole" : false,
-      "containerId" : "hocs"
-    }, {
-      "id" : "2be2b11a-27a4-4320-a7c9-ac623729950f",
-      "name" : "uma_authorization",
-      "description" : "${role_uma_authorization}",
-      "composite" : false,
-      "clientRole" : false,
-      "containerId" : "hocs"
-    } ],
-    "client" : {
-      "realm-management" : [ {
-        "id" : "e9e9b910-7624-4a2e-970d-3ff21df0fb7d",
-        "name" : "view-clients",
-        "description" : "${role_view-clients}",
-        "composite" : true,
-        "composites" : {
-          "client" : {
-            "realm-management" : [ "query-clients" ]
+  "id": "hocs",
+  "realm": "hocs",
+  "notBefore": 0,
+  "defaultSignatureAlgorithm": "RS256",
+  "revokeRefreshToken": false,
+  "refreshTokenMaxReuse": 0,
+  "accessTokenLifespan": 300,
+  "accessTokenLifespanForImplicitFlow": 900,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "ssoSessionIdleTimeoutRememberMe": 0,
+  "ssoSessionMaxLifespanRememberMe": 0,
+  "offlineSessionIdleTimeout": 2592000,
+  "offlineSessionMaxLifespanEnabled": false,
+  "offlineSessionMaxLifespan": 5184000,
+  "clientSessionIdleTimeout": 0,
+  "clientSessionMaxLifespan": 0,
+  "clientOfflineSessionIdleTimeout": 0,
+  "clientOfflineSessionMaxLifespan": 0,
+  "accessCodeLifespan": 60,
+  "accessCodeLifespanUserAction": 300,
+  "accessCodeLifespanLogin": 1800,
+  "actionTokenGeneratedByAdminLifespan": 43200,
+  "actionTokenGeneratedByUserLifespan": 300,
+  "oauth2DeviceCodeLifespan": 600,
+  "oauth2DevicePollingInterval": 5,
+  "enabled": true,
+  "sslRequired": "external",
+  "registrationAllowed": false,
+  "registrationEmailAsUsername": false,
+  "rememberMe": false,
+  "verifyEmail": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "permanentLockout": false,
+  "maxFailureWaitSeconds": 900,
+  "minimumQuickLoginWaitSeconds": 60,
+  "waitIncrementSeconds": 60,
+  "quickLoginCheckMilliSeconds": 1000,
+  "maxDeltaTimeSeconds": 43200,
+  "failureFactor": 30,
+  "roles": {
+    "realm": [
+      {
+        "id": "4ac62127-336f-4b5b-8cb7-0891f31ca45a",
+        "name": "uma_authorization",
+        "description": "${role_uma_authorization}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "hocs",
+        "attributes": {}
+      },
+      {
+        "id": "63c0e6ca-ab9f-4972-afcc-41f83758ee38",
+        "name": "default-roles-hocs",
+        "description": "${role_default-roles}",
+        "composite": true,
+        "composites": {
+          "realm": [
+            "offline_access",
+            "uma_authorization"
+          ],
+          "client": {
+            "account": [
+              "view-profile",
+              "manage-account"
+            ]
           }
         },
-        "clientRole" : true,
-        "containerId" : "ae432542-d7e5-4aef-ad30-bc3f1a112432"
-      }, {
-        "id" : "b2384ab0-b553-4938-9ce6-f5f4079ad968",
-        "name" : "view-identity-providers",
-        "description" : "${role_view-identity-providers}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "ae432542-d7e5-4aef-ad30-bc3f1a112432"
-      }, {
-        "id" : "1291e97c-84c9-4def-8536-4037a72db8b4",
-        "name" : "manage-identity-providers",
-        "description" : "${role_manage-identity-providers}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "ae432542-d7e5-4aef-ad30-bc3f1a112432"
-      }, {
-        "id" : "f99e96a4-d86d-4751-bd30-3e0917f98193",
-        "name" : "impersonation",
-        "description" : "${role_impersonation}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "ae432542-d7e5-4aef-ad30-bc3f1a112432"
-      }, {
-        "id" : "de6d529f-573a-46e7-9b29-fadd8974578c",
-        "name" : "query-users",
-        "description" : "${role_query-users}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "ae432542-d7e5-4aef-ad30-bc3f1a112432"
-      }, {
-        "id" : "2dd39803-53cd-43e4-bba9-5fbd46608bfa",
-        "name" : "create-client",
-        "description" : "${role_create-client}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "ae432542-d7e5-4aef-ad30-bc3f1a112432"
-      }, {
-        "id" : "db554093-aa54-45fc-80b2-540249ae3d68",
-        "name" : "view-users",
-        "description" : "${role_view-users}",
-        "composite" : true,
-        "composites" : {
-          "client" : {
-            "realm-management" : [ "query-users", "query-groups" ]
+        "clientRole": false,
+        "containerId": "hocs",
+        "attributes": {}
+      },
+      {
+        "id": "551c1e6d-1ea2-4a5c-8eaf-077491581a75",
+        "name": "offline_access",
+        "description": "${role_offline-access}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "hocs",
+        "attributes": {}
+      },
+      {
+        "id": "396f8fc6-51d7-4390-95f5-d49d2ae91c99",
+        "name": "default-roles-integration",
+        "description": "${role_default-roles}",
+        "composite": true,
+        "composites": {
+          "realm": [
+            "offline_access",
+            "uma_authorization"
+          ],
+          "client": {
+            "account": [
+              "view-profile",
+              "manage-account"
+            ]
           }
         },
-        "clientRole" : true,
-        "containerId" : "ae432542-d7e5-4aef-ad30-bc3f1a112432"
-      }, {
-        "id" : "cbf9df88-40b7-4a5d-9673-f28fe8027f7f",
-        "name" : "manage-clients",
-        "description" : "${role_manage-clients}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "ae432542-d7e5-4aef-ad30-bc3f1a112432"
-      }, {
-        "id" : "fb66b26c-c7a1-403e-b088-6a091ad3c578",
-        "name" : "query-groups",
-        "description" : "${role_query-groups}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "ae432542-d7e5-4aef-ad30-bc3f1a112432"
-      }, {
-        "id" : "3bd3d644-1b47-451c-b02d-41ba7949b55a",
-        "name" : "view-realm",
-        "description" : "${role_view-realm}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "ae432542-d7e5-4aef-ad30-bc3f1a112432"
-      }, {
-        "id" : "01755e1d-de9f-4675-bba2-131a300ac64f",
-        "name" : "query-realms",
-        "description" : "${role_query-realms}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "ae432542-d7e5-4aef-ad30-bc3f1a112432"
-      }, {
-        "id" : "59218cb3-b391-4ba3-82c5-5ec3bbf6b8d3",
-        "name" : "view-events",
-        "description" : "${role_view-events}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "ae432542-d7e5-4aef-ad30-bc3f1a112432"
-      }, {
-        "id" : "562c64d7-8a9e-40b3-926f-0274ade0dbd3",
-        "name" : "manage-users",
-        "description" : "${role_manage-users}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "ae432542-d7e5-4aef-ad30-bc3f1a112432"
-      }, {
-        "id" : "190dd276-015e-4895-9eca-8438d9c0dcdf",
-        "name" : "query-clients",
-        "description" : "${role_query-clients}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "ae432542-d7e5-4aef-ad30-bc3f1a112432"
-      }, {
-        "id" : "d0e0fd43-4d7f-4eec-838b-b1091b7dd56b",
-        "name" : "realm-admin",
-        "description" : "${role_realm-admin}",
-        "composite" : true,
-        "composites" : {
-          "client" : {
-            "realm-management" : [ "manage-identity-providers", "view-identity-providers", "view-clients", "impersonation", "query-users", "create-client", "view-users", "manage-clients", "query-groups", "view-realm", "query-realms", "query-clients", "manage-users", "view-events", "manage-realm", "manage-events", "manage-authorization", "view-authorization" ]
-          }
+        "clientRole": false,
+        "containerId": "hocs",
+        "attributes": {}
+      }
+    ],
+    "client": {
+      "info-service-client": [],
+      "realm-management": [
+        {
+          "id": "71896e98-2bde-4674-b2e1-51f9c5042898",
+          "name": "view-authorization",
+          "description": "${role_view-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c2cbb986-0958-44ec-8645-39b648755ee1",
+          "attributes": {}
         },
-        "clientRole" : true,
-        "containerId" : "ae432542-d7e5-4aef-ad30-bc3f1a112432"
-      }, {
-        "id" : "87772c75-aeea-44a4-a892-68268c71476e",
-        "name" : "manage-realm",
-        "description" : "${role_manage-realm}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "ae432542-d7e5-4aef-ad30-bc3f1a112432"
-      }, {
-        "id" : "32e5c7d8-a5b6-49ad-b135-664857d1fa9d",
-        "name" : "manage-events",
-        "description" : "${role_manage-events}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "ae432542-d7e5-4aef-ad30-bc3f1a112432"
-      }, {
-        "id" : "94095d60-fd1c-46ca-9378-25db12649a88",
-        "name" : "manage-authorization",
-        "description" : "${role_manage-authorization}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "ae432542-d7e5-4aef-ad30-bc3f1a112432"
-      }, {
-        "id" : "c5fb8b85-25ba-47ef-8ba0-fe9a4d6fdfdb",
-        "name" : "view-authorization",
-        "description" : "${role_view-authorization}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "ae432542-d7e5-4aef-ad30-bc3f1a112432"
-      } ],
-      "security-admin-console" : [ ],
-      "admin-cli" : [ ],
-      "broker" : [ {
-        "id" : "58b6381f-2706-4f5d-a30e-5d235c3d87de",
-        "name" : "read-token",
-        "description" : "${role_read-token}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "a60defb6-1806-4d8d-be2b-c3ae909856fe"
-      } ],
-      "account" : [ {
-        "id" : "27d2ef3d-51c2-4752-9bc0-14d08b0af9be",
-        "name" : "view-profile",
-        "description" : "${role_view-profile}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "4a4ca7c0-48d7-47c6-9c90-e0ae052b8d7a"
-      }, {
-        "id" : "2734839b-9c6f-45e2-91f3-d2edb8efa461",
-        "name" : "manage-account-links",
-        "description" : "${role_manage-account-links}",
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "4a4ca7c0-48d7-47c6-9c90-e0ae052b8d7a"
-      }, {
-        "id" : "55125d39-1799-4f70-a134-4a75ac9fa3b8",
-        "name" : "manage-account",
-        "description" : "${role_manage-account}",
-        "composite" : true,
-        "composites" : {
-          "client" : {
-            "account" : [ "manage-account-links" ]
-          }
+        {
+          "id": "430cf161-65da-4237-b5e4-b1ecaaa3755c",
+          "name": "view-realm",
+          "description": "${role_view-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c2cbb986-0958-44ec-8645-39b648755ee1",
+          "attributes": {}
         },
-        "clientRole" : true,
-        "containerId" : "4a4ca7c0-48d7-47c6-9c90-e0ae052b8d7a"
-      } ]
+        {
+          "id": "4e7086c8-cea5-4bf2-a07c-ec330dac3507",
+          "name": "manage-users",
+          "description": "${role_manage-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c2cbb986-0958-44ec-8645-39b648755ee1",
+          "attributes": {}
+        },
+        {
+          "id": "f5669947-63bf-4264-944c-882d5780483f",
+          "name": "realm-admin",
+          "description": "${role_realm-admin}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "view-realm",
+                "view-authorization",
+                "manage-users",
+                "manage-events",
+                "manage-realm",
+                "query-clients",
+                "impersonation",
+                "manage-clients",
+                "create-client",
+                "query-users",
+                "manage-authorization",
+                "query-realms",
+                "manage-identity-providers",
+                "view-users",
+                "view-identity-providers",
+                "query-groups",
+                "view-events",
+                "view-clients"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "c2cbb986-0958-44ec-8645-39b648755ee1",
+          "attributes": {}
+        },
+        {
+          "id": "0213db61-9bd1-42f3-b78f-66ed676c4766",
+          "name": "manage-events",
+          "description": "${role_manage-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c2cbb986-0958-44ec-8645-39b648755ee1",
+          "attributes": {}
+        },
+        {
+          "id": "3245a7eb-22cc-4284-90ca-aeada189941f",
+          "name": "manage-realm",
+          "description": "${role_manage-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c2cbb986-0958-44ec-8645-39b648755ee1",
+          "attributes": {}
+        },
+        {
+          "id": "9d2aa0ff-8ec1-4397-8e7a-7953443fb794",
+          "name": "impersonation",
+          "description": "${role_impersonation}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c2cbb986-0958-44ec-8645-39b648755ee1",
+          "attributes": {}
+        },
+        {
+          "id": "3148ea47-06dc-4311-9a37-cd782363ac1b",
+          "name": "query-clients",
+          "description": "${role_query-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c2cbb986-0958-44ec-8645-39b648755ee1",
+          "attributes": {}
+        },
+        {
+          "id": "73e3d8ed-d6ba-4e02-b2ac-ae44368c9a77",
+          "name": "manage-clients",
+          "description": "${role_manage-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c2cbb986-0958-44ec-8645-39b648755ee1",
+          "attributes": {}
+        },
+        {
+          "id": "770afa3b-2a94-491c-a8a7-b6c154b20697",
+          "name": "create-client",
+          "description": "${role_create-client}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c2cbb986-0958-44ec-8645-39b648755ee1",
+          "attributes": {}
+        },
+        {
+          "id": "8a183d13-14df-43b2-9556-ee35abbfd2e9",
+          "name": "query-users",
+          "description": "${role_query-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c2cbb986-0958-44ec-8645-39b648755ee1",
+          "attributes": {}
+        },
+        {
+          "id": "56d16a59-8e12-4e0c-925c-a2b680463210",
+          "name": "manage-authorization",
+          "description": "${role_manage-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c2cbb986-0958-44ec-8645-39b648755ee1",
+          "attributes": {}
+        },
+        {
+          "id": "1dc26895-f531-45dc-a775-e0702b06fdf6",
+          "name": "query-realms",
+          "description": "${role_query-realms}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c2cbb986-0958-44ec-8645-39b648755ee1",
+          "attributes": {}
+        },
+        {
+          "id": "a3de8577-3c96-49fa-9488-5b87a3d22eaa",
+          "name": "manage-identity-providers",
+          "description": "${role_manage-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c2cbb986-0958-44ec-8645-39b648755ee1",
+          "attributes": {}
+        },
+        {
+          "id": "dceffe63-cd0c-4d71-9d25-9326d2fa1430",
+          "name": "view-users",
+          "description": "${role_view-users}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-groups",
+                "query-users"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "c2cbb986-0958-44ec-8645-39b648755ee1",
+          "attributes": {}
+        },
+        {
+          "id": "80682073-a5a7-4e74-80ce-2ff2ac41bfc0",
+          "name": "view-identity-providers",
+          "description": "${role_view-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c2cbb986-0958-44ec-8645-39b648755ee1",
+          "attributes": {}
+        },
+        {
+          "id": "084138c5-bad3-4034-a305-71067c2a0772",
+          "name": "query-groups",
+          "description": "${role_query-groups}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c2cbb986-0958-44ec-8645-39b648755ee1",
+          "attributes": {}
+        },
+        {
+          "id": "339d0c79-9bcc-4659-9b64-0784e40d1859",
+          "name": "view-events",
+          "description": "${role_view-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c2cbb986-0958-44ec-8645-39b648755ee1",
+          "attributes": {}
+        },
+        {
+          "id": "c84f21da-104e-4d76-a4b5-beea75136d4a",
+          "name": "view-clients",
+          "description": "${role_view-clients}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-clients"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "c2cbb986-0958-44ec-8645-39b648755ee1",
+          "attributes": {}
+        }
+      ],
+      "security-admin-console": [],
+      "admin-cli": [],
+      "account-console": [],
+      "broker": [
+        {
+          "id": "967ef94e-7813-4989-9eb7-f66ab9fcddc7",
+          "name": "read-token",
+          "description": "${role_read-token}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "f4894a3e-3946-4464-a991-034721d65e4b",
+          "attributes": {}
+        }
+      ],
+      "account": [
+        {
+          "id": "f8b2c858-30cb-4293-8485-295374c0fc21",
+          "name": "view-consent",
+          "description": "${role_view-consent}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d2c8ac4e-5dfb-4511-8af5-7638f874522c",
+          "attributes": {}
+        },
+        {
+          "id": "5d7f7dd0-3bf5-4751-9ff9-62a90887295e",
+          "name": "manage-consent",
+          "description": "${role_manage-consent}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": [
+                "view-consent"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "d2c8ac4e-5dfb-4511-8af5-7638f874522c",
+          "attributes": {}
+        },
+        {
+          "id": "488e78c4-b47c-4033-a95b-da6088adb18a",
+          "name": "view-profile",
+          "description": "${role_view-profile}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d2c8ac4e-5dfb-4511-8af5-7638f874522c",
+          "attributes": {}
+        },
+        {
+          "id": "9908e883-124c-4be8-ba4b-fd00d704b5ca",
+          "name": "manage-account-links",
+          "description": "${role_manage-account-links}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d2c8ac4e-5dfb-4511-8af5-7638f874522c",
+          "attributes": {}
+        },
+        {
+          "id": "e7260349-29a9-4152-8031-933f2f7c3342",
+          "name": "view-applications",
+          "description": "${role_view-applications}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d2c8ac4e-5dfb-4511-8af5-7638f874522c",
+          "attributes": {}
+        },
+        {
+          "id": "33814011-97d7-4171-8268-da7d6adcd0e9",
+          "name": "delete-account",
+          "description": "${role_delete-account}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d2c8ac4e-5dfb-4511-8af5-7638f874522c",
+          "attributes": {}
+        },
+        {
+          "id": "5b5626a8-652e-48f5-a199-8c3b4fcd26a2",
+          "name": "manage-account",
+          "description": "${role_manage-account}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": [
+                "manage-account-links"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "d2c8ac4e-5dfb-4511-8af5-7638f874522c",
+          "attributes": {}
+        }
+      ]
     }
   },
-  "groups": [
-    {
-      "id": "59d92ab1-82f4-44b4-9c44-3f4e904bef8b",
-      "name": "RERERCIiIiIiIiIiIiIiIg",
-      "path": "/RERERCIiIiIiIiIiIiIiIg",
-      "attributes": {},
-      "realmRoles": [],
-      "clientRoles": {},
-      "subGroups": []
-    },
-    {
-      "id": "3a195c4d-6be8-420b-9f60-06003e3b575a",
-      "name": "MzMzMzMzMzMzMzMzMzMzMw",
-      "path": "/MzMzMzMzMzMzMzMzMzMzMw",
-      "attributes": {},
-      "realmRoles": [],
-      "clientRoles": {},
-      "subGroups": []
-    },
-    {
-      "id": "abf7617c-058c-4287-9f41-b95384fdbc7d",
-      "name": "Q0pOM0N_Tm2PBBTqQP2_og",
-      "path": "/Q0pOM0N_Tm2PBBTqQP2_og",
-      "attributes": {},
-      "realmRoles": [],
-      "clientRoles": {},
-      "subGroups": []
-    },
-    {
-      "id": "abf7617c-058c-4287-9f41-b95384fdbc7e",
-      "name": "iztDZqN8SLaydExQ-Ag4Qw",
-      "path": "/iztDZqN8SLaydExQ-Ag4Qw",
-      "attributes": {},
-      "realmRoles": [],
-      "clientRoles": {},
-      "subGroups": []
-    },
-    {
-      "id": "abf7617c-058c-4287-9f41-b95384fdbc7f",
-      "name": "EREREREREREREREREREREQ",
-      "path": "/EREREREREREREREREREREQ",
-      "attributes": {},
-      "realmRoles": [],
-      "clientRoles": {},
-      "subGroups": []
-    }
-
+  "groups": [],
+  "defaultRole": {
+    "id": "63c0e6ca-ab9f-4972-afcc-41f83758ee38",
+    "name": "default-roles-hocs",
+    "description": "${role_default-roles}",
+    "composite": true,
+    "clientRole": false,
+    "containerId": "hocs"
+  },
+  "requiredCredentials": [
+    "password"
   ],
-  "defaultRoles" : [ "uma_authorization", "offline_access" ],
-  "requiredCredentials" : [ "password" ],
-  "otpPolicyType" : "totp",
-  "otpPolicyAlgorithm" : "HmacSHA1",
-  "otpPolicyInitialCounter" : 0,
-  "otpPolicyDigits" : 6,
-  "otpPolicyLookAheadWindow" : 1,
-  "otpPolicyPeriod" : 30,
-  "otpSupportedApplications" : [ "FreeOTP", "Google Authenticator" ],
-  "users" : [ {
-    "id" : "ed00bf4a-1a74-4d0b-a3d0-379c12c5e3ff",
-    "createdTimestamp" : 1541622074757,
-    "username" : "admin",
-    "enabled" : true,
-    "totp" : false,
-    "emailVerified" : true,
-    "credentials" : [ {
-      "type" : "password",
-      "hashedSaltedValue" : "K4oQart6CT7BdeQyZgkgcDc0d+jEIHVqpxVqjq7H1UkAM1kcXQkJtM/kiBw3J6LyT3MkX/IbO86rUL7mSlDJqw==",
-      "salt" : "rhZ0BnXWH2ZqEE/2gASL6Q==",
-      "hashIterations" : 27500,
-      "counter" : 0,
-      "algorithm" : "pbkdf2-sha256",
-      "digits" : 0,
-      "period" : 0,
-      "createdDate" : 1541624862203,
-      "config" : { }
-    } ],
-    "disableableCredentialTypes" : [ "password" ],
-    "requiredActions" : [ ],
-    "realmRoles" : [ "admin", "offline_access", "uma_authorization" ],
-    "clientRoles" : {
-      "realm-management" : [ "realm-admin", "query-users", "query-groups", "query-realms", "manage-users" ],
-      "account" : [ "view-profile", "manage-account" ]
-    },
-    "notBefore" : 0,
-    "groups" : [ "/Q0pOM0N_Tm2PBBTqQP2_og", "/iztDZqN8SLaydExQ-Ag4Qw"]
-  },
-
+  "otpPolicyType": "totp",
+  "otpPolicyAlgorithm": "HmacSHA1",
+  "otpPolicyInitialCounter": 0,
+  "otpPolicyDigits": 6,
+  "otpPolicyLookAheadWindow": 1,
+  "otpPolicyPeriod": 30,
+  "otpSupportedApplications": [
+    "FreeOTP",
+    "Google Authenticator"
+  ],
+  "webAuthnPolicyRpEntityName": "keycloak",
+  "webAuthnPolicySignatureAlgorithms": [
+    "ES256"
+  ],
+  "webAuthnPolicyRpId": "",
+  "webAuthnPolicyAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyRequireResidentKey": "not specified",
+  "webAuthnPolicyUserVerificationRequirement": "not specified",
+  "webAuthnPolicyCreateTimeout": 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyAcceptableAaguids": [],
+  "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms": [
+    "ES256"
+  ],
+  "webAuthnPolicyPasswordlessRpId": "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout": 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+  "users": [
     {
-      "id" : "04167856-f772-4bca-87b9-f8b6739853b7",
-      "createdTimestamp" : 1544174581362,
-      "username" : "caseworker1",
-      "enabled" : true,
-      "totp" : false,
-      "emailVerified" : false,
-      "credentials" : [ ],
-      "disableableCredentialTypes" : [ ],
-      "requiredActions" : [ ],
-      "realmRoles" : [ "offline_access", "uma_authorization" ],
-      "clientRoles" : {
-        "account" : [ "view-profile", "manage-account" ]
+      "id": "3dd53a05-d87c-4051-9239-d00a7c9defbe",
+      "createdTimestamp": 1655204051927,
+      "username": "service-account-info-service-client",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "serviceAccountClientId": "info-service-client",
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "default-roles-integration"
+      ],
+      "clientRoles": {
+        "realm-management": [
+          "realm-admin"
+        ]
       },
-      "notBefore" : 0,
-      "groups" : [
-        "/EREREREREREREREREREREQ",
-        "/MzMzMzMzMzMzMzMzMzMzMw",
-        "/RERERCIiIiIiIiIiIiIiIg"]
-    },
-    {
-      "id" : "968672ca-9fc1-491c-b2b9-d13c58b12d7a",
-      "createdTimestamp" : 1544174663425,
-      "username" : "minowner",
-      "enabled" : true,
-      "totp" : false,
-      "emailVerified" : false,
-      "credentials" : [ {
-        "type" : "password",
-        "hashedSaltedValue" : "K4oQart6CT7BdeQyZgkgcDc0d+jEIHVqpxVqjq7H1UkAM1kcXQkJtM/kiBw3J6LyT3MkX/IbO86rUL7mSlDJqw==",
-        "salt" : "rhZ0BnXWH2ZqEE/2gASL6Q==",
-        "hashIterations" : 27500,
-        "counter" : 0,
-        "algorithm" : "pbkdf2-sha256",
-        "digits" : 0,
-        "period" : 0,
-        "createdDate" : 1541624862203,
-        "config" : { }
-      } ],
-      "disableableCredentialTypes" : [ ],
-      "requiredActions" : [ ],
-      "realmRoles" : [ "offline_access", "uma_authorization" ],
-      "clientRoles" : {
-        "account" : [ "view-profile", "manage-account" ]
-      },
-      "notBefore" : 0,
-      "groups" : [ "/EREREREREREREREREREREQ", "/MzMzMzMzMzMzMzMzMzMzMw" ]
-    }, {
-      "id" : "fc72ee08-7972-40df-a801-501d3a271fa3",
-      "createdTimestamp" : 1544174692718,
-      "username" : "minreader",
-      "enabled" : true,
-      "totp" : false,
-      "emailVerified" : false,
-      "credentials" : [ {
-        "type" : "password",
-        "hashedSaltedValue" : "K4oQart6CT7BdeQyZgkgcDc0d+jEIHVqpxVqjq7H1UkAM1kcXQkJtM/kiBw3J6LyT3MkX/IbO86rUL7mSlDJqw==",
-        "salt" : "rhZ0BnXWH2ZqEE/2gASL6Q==",
-        "hashIterations" : 27500,
-        "counter" : 0,
-        "algorithm" : "pbkdf2-sha256",
-        "digits" : 0,
-        "period" : 0,
-        "createdDate" : 1541624862203,
-        "config" : { }
-      } ],
-      "disableableCredentialTypes" : [ ],
-      "requiredActions" : [ ],
-      "realmRoles" : [ "offline_access", "uma_authorization" ],
-      "clientRoles" : {
-        "account" : [ "view-profile", "manage-account" ]
-      },
-      "notBefore" : 0,
-      "groups" : [ "/EREREREREREREREREREREQ" ]
+      "notBefore": 0,
+      "groups": []
     }
   ],
-  "scopeMappings" : [ {
-    "clientScope" : "offline_access",
-    "roles" : [ "offline_access" ]
-  } ],
-  "clients" : [ {
-    "id" : "4a4ca7c0-48d7-47c6-9c90-e0ae052b8d7a",
-    "clientId" : "account",
-    "name" : "${client_account}",
-    "baseUrl" : "/auth/realms/hocs/account",
-    "surrogateAuthRequired" : false,
-    "enabled" : true,
-    "clientAuthenticatorType" : "client-secret",
-    "secret" : "fd233dd2-6d3a-4d88-b725-3e7e622c3726",
-    "defaultRoles" : [ "view-profile", "manage-account" ],
-    "redirectUris" : [ "/auth/realms/hocs/account/*" ],
-    "webOrigins" : [ ],
-    "notBefore" : 0,
-    "bearerOnly" : false,
-    "consentRequired" : false,
-    "standardFlowEnabled" : true,
-    "implicitFlowEnabled" : false,
-    "directAccessGrantsEnabled" : false,
-    "serviceAccountsEnabled" : false,
-    "publicClient" : false,
-    "frontchannelLogout" : false,
-    "protocol" : "openid-connect",
-    "attributes" : { },
-    "authenticationFlowBindingOverrides" : { },
-    "fullScopeAllowed" : false,
-    "nodeReRegistrationTimeout" : 0,
-    "defaultClientScopes" : [ "role_list", "profile", "email" ],
-    "optionalClientScopes" : [ "address", "phone", "offline_access" ]
-  }, {
-    "id" : "2565b525-f4eb-4e73-82b2-a9462dce303c",
-    "clientId" : "admin-cli",
-    "name" : "${client_admin-cli}",
-    "surrogateAuthRequired" : false,
-    "enabled" : true,
-    "clientAuthenticatorType" : "client-secret",
-    "secret" : "a8b2fb48-e435-4a6a-a40b-a831a8d600c2",
-    "redirectUris" : [ ],
-    "webOrigins" : [ ],
-    "notBefore" : 0,
-    "bearerOnly" : false,
-    "consentRequired" : false,
-    "standardFlowEnabled" : false,
-    "implicitFlowEnabled" : false,
-    "directAccessGrantsEnabled" : true,
-    "serviceAccountsEnabled" : false,
-    "publicClient" : true,
-    "frontchannelLogout" : false,
-    "protocol" : "openid-connect",
-    "attributes" : { },
-    "authenticationFlowBindingOverrides" : { },
-    "fullScopeAllowed" : false,
-    "nodeReRegistrationTimeout" : 0,
-    "defaultClientScopes" : [ "role_list", "profile", "email" ],
-    "optionalClientScopes" : [ "address", "phone", "offline_access" ]
-  }, {
-    "id" : "a60defb6-1806-4d8d-be2b-c3ae909856fe",
-    "clientId" : "broker",
-    "name" : "${client_broker}",
-    "surrogateAuthRequired" : false,
-    "enabled" : true,
-    "clientAuthenticatorType" : "client-secret",
-    "secret" : "4ae58b52-f0ea-4f5a-87a5-dc0a2f834776",
-    "redirectUris" : [ ],
-    "webOrigins" : [ ],
-    "notBefore" : 0,
-    "bearerOnly" : false,
-    "consentRequired" : false,
-    "standardFlowEnabled" : true,
-    "implicitFlowEnabled" : false,
-    "directAccessGrantsEnabled" : false,
-    "serviceAccountsEnabled" : false,
-    "publicClient" : false,
-    "frontchannelLogout" : false,
-    "protocol" : "openid-connect",
-    "attributes" : { },
-    "authenticationFlowBindingOverrides" : { },
-    "fullScopeAllowed" : false,
-    "nodeReRegistrationTimeout" : 0,
-    "defaultClientScopes" : [ "role_list", "profile", "email" ],
-    "optionalClientScopes" : [ "address", "phone", "offline_access" ]
-  }, {
-    "id" : "ae432542-d7e5-4aef-ad30-bc3f1a112432",
-    "clientId" : "realm-management",
-    "name" : "${client_realm-management}",
-    "surrogateAuthRequired" : false,
-    "enabled" : true,
-    "clientAuthenticatorType" : "client-secret",
-    "secret" : "c996fc43-cd2a-452b-8a5e-237b42dc8bea",
-    "redirectUris" : [ ],
-    "webOrigins" : [ ],
-    "notBefore" : 0,
-    "bearerOnly" : true,
-    "consentRequired" : false,
-    "standardFlowEnabled" : true,
-    "implicitFlowEnabled" : false,
-    "directAccessGrantsEnabled" : false,
-    "serviceAccountsEnabled" : false,
-    "authorizationServicesEnabled" : true,
-    "publicClient" : false,
-    "frontchannelLogout" : false,
-    "protocol" : "openid-connect",
-    "attributes" : { },
-    "authenticationFlowBindingOverrides" : { },
-    "fullScopeAllowed" : false,
-    "nodeReRegistrationTimeout" : 0,
-    "defaultClientScopes" : [ "role_list", "profile", "email" ],
-    "optionalClientScopes" : [ "address", "phone", "offline_access" ],
-    "authorizationSettings" : {
-      "allowRemoteResourceManagement" : false,
-      "policyEnforcementMode" : "ENFORCING",
-      "resources" : [ {
-        "name" : "role.resource.63ca477d-b18b-47f5-b27a-d139c96870d4",
-        "type" : "Role",
-        "ownerManagedAccess" : false,
-        "attributes" : { },
-        "_id" : "10ab5045-3a90-40cd-819e-cbd3989993d7",
-        "uris" : [ ],
-        "scopes" : [ {
-          "name" : "map-role-composite"
-        }, {
-          "name" : "map-role-client-scope"
-        }, {
-          "name" : "map-role"
-        } ]
-      } ],
-      "policies" : [ {
-        "id" : "6729b6b0-44fe-4553-bf10-8a11da6ac508",
-        "name" : "map-role.permission.63ca477d-b18b-47f5-b27a-d139c96870d4",
-        "type" : "scope",
-        "logic" : "POSITIVE",
-        "decisionStrategy" : "AFFIRMATIVE",
-        "config" : {
-          "resources" : "[\"role.resource.63ca477d-b18b-47f5-b27a-d139c96870d4\"]",
-          "scopes" : "[\"map-role\",\"map-role-client-scope\"]"
-        }
-      }, {
-        "id" : "f5b00d79-0f16-45ce-8138-b88d62751689",
-        "name" : "map-role-client-scope.permission.63ca477d-b18b-47f5-b27a-d139c96870d4",
-        "type" : "scope",
-        "logic" : "POSITIVE",
-        "decisionStrategy" : "AFFIRMATIVE",
-        "config" : {
-          "resources" : "[\"role.resource.63ca477d-b18b-47f5-b27a-d139c96870d4\"]",
-          "scopes" : "[\"map-role-client-scope\"]"
-        }
-      }, {
-        "id" : "3aecc046-e5fa-402c-a0a1-9e6332c26d2d",
-        "name" : "map-role-composite.permission.63ca477d-b18b-47f5-b27a-d139c96870d4",
-        "type" : "scope",
-        "logic" : "POSITIVE",
-        "decisionStrategy" : "AFFIRMATIVE",
-        "config" : {
-          "resources" : "[\"role.resource.63ca477d-b18b-47f5-b27a-d139c96870d4\"]",
-          "scopes" : "[\"map-role-composite\"]"
-        }
-      } ],
-      "scopes" : [ {
-        "id" : "95882d59-c9b6-4ad7-ba61-5aca9d85772c",
-        "name" : "manage"
-      }, {
-        "id" : "6bea4a29-77ca-4bc8-b74c-57a9a1ceb6c4",
-        "name" : "view"
-      }, {
-        "id" : "c1649e92-fe41-4286-bdf8-25e05ea21d07",
-        "name" : "manage-members"
-      }, {
-        "id" : "d3cbf83c-935a-447b-b275-69c3bbe0081a",
-        "name" : "view-members"
-      }, {
-        "id" : "136b1985-d163-419e-8117-9e34d2a68aa0",
-        "name" : "manage-membership"
-      }, {
-        "id" : "5145b8dd-e10c-4329-ba66-28154105c180",
-        "name" : "map-role"
-      }, {
-        "id" : "26cf3009-1dd6-4305-9376-d430a5d9eaba",
-        "name" : "map-role-client-scope"
-      }, {
-        "id" : "c38e10d6-7370-4658-a85e-f040b1aef0bb",
-        "name" : "map-role-composite"
-      }, {
-        "id" : "d7a291cb-8cbc-4c45-bf3e-44824d1beb78",
-        "name" : "map-roles"
-      }, {
-        "id" : "607ede5d-254e-4ce3-b861-7fd57e1e0404",
-        "name" : "map-roles-client-scope"
-      }, {
-        "id" : "ead7cc44-5805-4d1b-aa0d-f21fe8c90c8d",
-        "name" : "map-roles-composite"
-      }, {
-        "id" : "4925e822-1179-473d-ab80-0f1e4c58450a",
-        "name" : "configure"
-      }, {
-        "id" : "15b91ade-c6e7-4a13-bf91-4dd339bc72c4",
-        "name" : "token-exchange"
-      } ]
+  "scopeMappings": [
+    {
+      "clientScope": "offline_access",
+      "roles": [
+        "offline_access"
+      ]
     }
-  }, {
-    "id" : "0f33b8ab-28e4-43f5-b5a6-6cee9530529e",
-    "clientId" : "security-admin-console",
-    "name" : "${client_security-admin-console}",
-    "baseUrl" : "/auth/admin/hocs/console/index.html",
-    "surrogateAuthRequired" : false,
-    "enabled" : true,
-    "clientAuthenticatorType" : "client-secret",
-    "secret" : "ce2d5cf2-f920-4f3b-9b5b-1c741110bf30",
-    "redirectUris" : [ "/auth/admin/hocs/console/*" ],
-    "webOrigins" : [ ],
-    "notBefore" : 0,
-    "bearerOnly" : false,
-    "consentRequired" : false,
-    "standardFlowEnabled" : true,
-    "implicitFlowEnabled" : false,
-    "directAccessGrantsEnabled" : false,
-    "serviceAccountsEnabled" : false,
-    "publicClient" : true,
-    "frontchannelLogout" : false,
-    "protocol" : "openid-connect",
-    "attributes" : { },
-    "authenticationFlowBindingOverrides" : { },
-    "fullScopeAllowed" : false,
-    "nodeReRegistrationTimeout" : 0,
-    "protocolMappers" : [ {
-      "id" : "23641d83-e9b0-43b1-9585-d6fae6d79bec",
-      "name" : "locale",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "locale",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "locale",
-        "jsonType.label" : "String"
+  ],
+  "clientScopeMappings": {
+    "account": [
+      {
+        "client": "account-console",
+        "roles": [
+          "manage-account"
+        ]
       }
-    } ],
-    "defaultClientScopes" : [ "role_list", "profile", "email" ],
-    "optionalClientScopes" : [ "address", "phone", "offline_access" ]
-  } ],
-  "clientScopes" : [ {
-    "id" : "297b921a-3f78-40a1-b29c-1a2025d1e000",
-    "name" : "address",
-    "description" : "OpenID Connect built-in scope: address",
-    "protocol" : "openid-connect",
-    "attributes" : {
-      "consent.screen.text" : "${addressScopeConsentText}",
-      "display.on.consent.screen" : "true"
-    },
-    "protocolMappers" : [ {
-      "id" : "e2c82876-880b-4ac4-af82-10d9887d2494",
-      "name" : "address",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-address-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "user.attribute.formatted" : "formatted",
-        "user.attribute.country" : "country",
-        "user.attribute.postal_code" : "postal_code",
-        "userinfo.token.claim" : "true",
-        "user.attribute.street" : "street",
-        "id.token.claim" : "true",
-        "user.attribute.region" : "region",
-        "access.token.claim" : "true",
-        "user.attribute.locality" : "locality"
-      }
-    } ]
-  }, {
-    "id" : "7dc18f35-31d0-4dca-bda3-2607dd501caa",
-    "name" : "email",
-    "description" : "OpenID Connect built-in scope: email",
-    "protocol" : "openid-connect",
-    "attributes" : {
-      "consent.screen.text" : "${emailScopeConsentText}",
-      "display.on.consent.screen" : "true"
-    },
-    "protocolMappers" : [ {
-      "id" : "8efefcd5-ca47-4bf1-a3c4-621f5709a5c0",
-      "name" : "email verified",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-property-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "emailVerified",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "email_verified",
-        "jsonType.label" : "boolean"
-      }
-    }, {
-      "id" : "5c047220-f87c-4c99-b346-c269666366ec",
-      "name" : "email",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-property-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "email",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "email",
-        "jsonType.label" : "String"
-      }
-    } ]
-  }, {
-    "id" : "a622df9b-e1d7-489b-b652-5a3f84f832f0",
-    "name" : "offline_access",
-    "description" : "OpenID Connect built-in scope: offline_access",
-    "protocol" : "openid-connect",
-    "attributes" : {
-      "consent.screen.text" : "${offlineAccessScopeConsentText}",
-      "display.on.consent.screen" : "true"
-    }
-  }, {
-    "id" : "56076151-1e72-4f05-a491-cd7acef2152b",
-    "name" : "phone",
-    "description" : "OpenID Connect built-in scope: phone",
-    "protocol" : "openid-connect",
-    "attributes" : {
-      "consent.screen.text" : "${phoneScopeConsentText}",
-      "display.on.consent.screen" : "true"
-    },
-    "protocolMappers" : [ {
-      "id" : "095034b0-d97f-4a14-8664-ee1391348d0f",
-      "name" : "phone number verified",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "phoneNumberVerified",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "phone_number_verified",
-        "jsonType.label" : "boolean"
-      }
-    }, {
-      "id" : "4a8d8ba6-c27e-4f95-b279-86af55593ed9",
-      "name" : "phone number",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "phoneNumber",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "phone_number",
-        "jsonType.label" : "String"
-      }
-    } ]
-  }, {
-    "id" : "9b4d4f85-306a-47c9-95c8-e82c8e393a55",
-    "name" : "profile",
-    "description" : "OpenID Connect built-in scope: profile",
-    "protocol" : "openid-connect",
-    "attributes" : {
-      "consent.screen.text" : "${profileScopeConsentText}",
-      "display.on.consent.screen" : "true"
-    },
-    "protocolMappers" : [ {
-      "id" : "e44f5037-3ce9-4a6b-bdc1-44791088966a",
-      "name" : "username",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-property-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "username",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "preferred_username",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "d70dd4b9-5446-4880-a2dc-22a3192c8bdf",
-      "name" : "full name",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-full-name-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "userinfo.token.claim" : "true"
-      }
-    }, {
-      "id" : "361baa6f-cbbe-4354-8814-810a33b9d54c",
-      "name" : "given name",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-property-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "firstName",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "given_name",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "bac48a79-d7e4-47c5-b420-3e337c241f49",
-      "name" : "locale",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "locale",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "locale",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "4c9947c9-3416-4fd2-b74e-3c54185708c3",
-      "name" : "profile",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "profile",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "profile",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "41b24907-b260-4334-a9c1-543586487860",
-      "name" : "updated at",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "updatedAt",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "updated_at",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "9f8531c7-5307-4b50-968c-fc98bc6d8716",
-      "name" : "birthdate",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "birthdate",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "birthdate",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "4c96949b-d7f6-4061-bce3-9217d3a93932",
-      "name" : "website",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "website",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "website",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "09e1e34b-5b8b-4a33-9796-353ef033db90",
-      "name" : "nickname",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "nickname",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "nickname",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "f0a180cc-2998-4581-8866-732c0d33ed2a",
-      "name" : "family name",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-property-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "lastName",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "family_name",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "c649cec7-93ed-402a-a60a-809225aa3e42",
-      "name" : "middle name",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "middleName",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "middle_name",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "21d8b4dd-dcee-4076-bee5-808f8b76abd2",
-      "name" : "picture",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "picture",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "picture",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "4be3e32b-3735-4c4d-8c56-c36e485ecc75",
-      "name" : "gender",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "gender",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "gender",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "913a9b24-e833-4079-b324-fb4ffd13bc5c",
-      "name" : "zoneinfo",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-attribute-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "zoneinfo",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "zoneinfo",
-        "jsonType.label" : "String"
-      }
-    } ]
-  }, {
-    "id" : "c81fc283-7030-4307-b8ae-45b208252c55",
-    "name" : "role_list",
-    "description" : "SAML role list",
-    "protocol" : "saml",
-    "attributes" : {
-      "consent.screen.text" : "${samlRoleListScopeConsentText}",
-      "display.on.consent.screen" : "true"
-    },
-    "protocolMappers" : [ {
-      "id" : "60d2fdc1-02bf-438e-a7fe-67c191c0a66c",
-      "name" : "role list",
-      "protocol" : "saml",
-      "protocolMapper" : "saml-role-list-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "single" : "false",
-        "attribute.nameformat" : "Basic",
-        "attribute.name" : "Role"
-      }
-    } ]
-  } ],
-  "defaultDefaultClientScopes" : [ "role_list", "profile", "email" ],
-  "defaultOptionalClientScopes" : [ "offline_access", "address", "phone" ],
-  "browserSecurityHeaders" : {
-    "contentSecurityPolicyReportOnly" : "",
-    "xContentTypeOptions" : "nosniff",
-    "xRobotsTag" : "none",
-    "xFrameOptions" : "SAMEORIGIN",
-    "xXSSProtection" : "1; mode=block",
-    "contentSecurityPolicy" : "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
-    "strictTransportSecurity" : "max-age=31536000; includeSubDomains"
+    ]
   },
-  "smtpServer" : { },
-  "eventsEnabled" : false,
-  "eventsListeners" : [ "jboss-logging" ],
-  "enabledEventTypes" : [ ],
-  "adminEventsEnabled" : false,
-  "adminEventsDetailsEnabled" : false,
-  "components" : {
-    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy" : [ {
-      "id" : "454e9108-c508-4d8e-aacc-111e8f8952be",
-      "name" : "Consent Required",
-      "providerId" : "consent-required",
-      "subType" : "anonymous",
-      "subComponents" : { },
-      "config" : { }
-    }, {
-      "id" : "2663e73a-f023-4002-a8a4-ef8bc7bfebe8",
-      "name" : "Full Scope Disabled",
-      "providerId" : "scope",
-      "subType" : "anonymous",
-      "subComponents" : { },
-      "config" : { }
-    }, {
-      "id" : "8b3c76c7-8c9e-4a9b-a766-0f87328391cf",
-      "name" : "Allowed Client Scopes",
-      "providerId" : "allowed-client-templates",
-      "subType" : "anonymous",
-      "subComponents" : { },
-      "config" : {
-        "allow-default-scopes" : [ "true" ]
-      }
-    }, {
-      "id" : "a37d35e6-92e6-4360-8ddc-67ff498bb331",
-      "name" : "Allowed Client Scopes",
-      "providerId" : "allowed-client-templates",
-      "subType" : "authenticated",
-      "subComponents" : { },
-      "config" : {
-        "allow-default-scopes" : [ "true" ]
-      }
-    }, {
-      "id" : "b50e5d7d-2995-4c56-8339-a1f9b5ad4995",
-      "name" : "Allowed Protocol Mapper Types",
-      "providerId" : "allowed-protocol-mappers",
-      "subType" : "anonymous",
-      "subComponents" : { },
-      "config" : {
-        "allowed-protocol-mapper-types" : [ "saml-role-list-mapper", "saml-user-property-mapper", "oidc-usermodel-property-mapper", "oidc-usermodel-attribute-mapper", "oidc-address-mapper", "saml-user-attribute-mapper", "oidc-full-name-mapper", "oidc-sha256-pairwise-sub-mapper" ]
-      }
-    }, {
-      "id" : "68bdd5ea-600c-45f1-9005-60766f670189",
-      "name" : "Trusted Hosts",
-      "providerId" : "trusted-hosts",
-      "subType" : "anonymous",
-      "subComponents" : { },
-      "config" : {
-        "host-sending-registration-request-must-match" : [ "true" ],
-        "client-uris-must-match" : [ "true" ]
-      }
-    }, {
-      "id" : "103d59ac-3a95-4325-9c33-a930cf143b46",
-      "name" : "Allowed Protocol Mapper Types",
-      "providerId" : "allowed-protocol-mappers",
-      "subType" : "authenticated",
-      "subComponents" : { },
-      "config" : {
-        "allowed-protocol-mapper-types" : [ "saml-user-property-mapper", "saml-role-list-mapper", "oidc-usermodel-attribute-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-address-mapper", "oidc-full-name-mapper", "saml-user-attribute-mapper", "oidc-usermodel-property-mapper" ]
-      }
-    }, {
-      "id" : "c119ccc7-a322-4ede-ba4e-fa7928b6eb2f",
-      "name" : "Max Clients Limit",
-      "providerId" : "max-clients",
-      "subType" : "anonymous",
-      "subComponents" : { },
-      "config" : {
-        "max-clients" : [ "200" ]
-      }
-    } ],
-    "org.keycloak.keys.KeyProvider" : [ {
-      "id" : "0b485991-e1f5-4ec0-994d-8122d1c55263",
-      "name" : "aes-generated",
-      "providerId" : "aes-generated",
-      "subComponents" : { },
-      "config" : {
-        "kid" : [ "ab2b16cb-f96d-46cf-aa4e-b3384ca05e0c" ],
-        "secret" : [ "yVqCNqBP1qSKSJy2eIzerA" ],
-        "priority" : [ "100" ]
-      }
-    }, {
-      "id" : "dacd2261-d8bf-4407-a56a-b4ae8bd4dcf1",
-      "name" : "rsa-generated",
-      "providerId" : "rsa-generated",
-      "subComponents" : { },
-      "config" : {
-        "privateKey" : [ "MIIEowIBAAKCAQEAvd9Y4kWgiRLjAM1OYWACei51P8ludtgMOXDkiFuOFU07/S1qq3VfHWX24ZvYQgOpFERHTNHoUPPb+WK1p5mxiSjC4hPwEtJU9maPVzt8PBMPffjPfHKhIvrWBgtA0P6Br2aq01OajTkI7ZnqS/KrpG8qqRI52BLoMUfJVLAUuviFmWPmDDifWW4QUPTyyzhBq6VhhouGVAqZ3Vwm+xyn+kErrduhDJcA53Om4/tBmIbELs3/wj/5xtLR1mOVtzCJS+IKV6XglmELVuoEhZEmzbH2iDFZZxErX8cnQeJ6oQTpc/lMq8lK3lo/+6YLgdSeg0x5X8wvepmRMdgaBVNWfQIDAQABAoIBAArIhnnDToy6X94JyuvI0hsyTEJlJDrnpjoU6UW9PWKEUmXckHRQZCh9Q/ooKa4GGzIldo8sVK9USiftrTdpiSWrBPZl/3pyK5Ua2gUwQav/wR98Y/xDXldoO4N4XCQCcEcP45/A3cQrexBTb3UEwS7DiX60pEhbOoih9RM0NNkxbubDsh7BWGdYXE4QoBlPe29sNGrJRLdrrnqEGAkC60XWGgoFlBnY1q4QGAEvNKglXtDEv718JUFL6EBdubxJmDJj0xkj0cJgsJQatNR7xV4kCkopTVMNpoYxHRlCIoTjfcnqcs3+PGW1wGw3EkUTdYFCd/J0TAPy8M9x52uGphkCgYEA9N1yyaFBfZi9IxUecpCoKDkuXhacE3ijF86i7SD2scY+4wxzzXKfZ4b6Z2qwkvAIu85Bqc4eTgvdT1mk+/Jl3BDeZD0wD8nYP3XaEeiNVlaXaMXJrrG3Oe9hT0wuXX20XpCz2yT99bjuywK7xv0sbJreiZ+6lBFtmg6gVz7klzsCgYEAxoG2cwzF8WvmvKVIY8IWuERoKvyLM4gnIv1Z/wmttt+W/sCFQY0/O1xuYENI56cdZi8ObtYDfoLkWIM2IjpQfVxNapxkSJm+YRPfDKsBNf2ttr0Rc6jnYmMUUazZaHNfw+DqmqByTdvzxSwfVScicjyeRlmRx/an2ulBd9gJHacCgYBbjsYSAHrVdJwcFxR4cACAcckVo0yetzf8eeZP1kiH9oGjMg/G3TofYsgUjT8S4i/R0XCaBpksQ6FvvyxCjMNrgt81CfADp0x1hiKRGaxngR9CLNqZuJezUP/Iv8qCaLNdvKuToIRZMdoQDKib4iSPQ2U8fn4sSUv7E8b+eGTO6wKBgGnXv/CYXvLbFayAdJi8ZGDcGK7S+WYAst11OQdDodxgW6J6BJNvPMfqAPBS8AyUjphtfsSaWEKciCSp0bNuZHxzOtQdj1smntwkPEoE5CBlorpNFYEWDknnim4CO+n1mppW0sCfzFK3dMMtQ4ej1joTGFFqcNCuM9IFjWLZTgMBAoGBAIeQFHcOvgWK+hRtnnukCIdNRKx6erajQrP7ojJR9HW8AyCIdp2NiuuvNWyMl0YC3u7CEVnRjv7gTbAd151KdOqFzmqE2cDZooTalsVknEh+bX/rJSXmAKVDjjfBGVagAyCiYLvDVtpM4k8grz9KCBZ/1ynhGuJ0+ZE2Uauur7fk" ],
-        "certificate" : [ "MIIClzCCAX8CBgFm79WnXjANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDDARob2NzMB4XDTE4MTEwNzIwMTkwOFoXDTI4MTEwNzIwMjA0OFowDzENMAsGA1UEAwwEaG9jczCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL3fWOJFoIkS4wDNTmFgAnoudT/JbnbYDDlw5IhbjhVNO/0taqt1Xx1l9uGb2EIDqRRER0zR6FDz2/litaeZsYkowuIT8BLSVPZmj1c7fDwTD334z3xyoSL61gYLQND+ga9mqtNTmo05CO2Z6kvyq6RvKqkSOdgS6DFHyVSwFLr4hZlj5gw4n1luEFD08ss4QaulYYaLhlQKmd1cJvscp/pBK63boQyXAOdzpuP7QZiGxC7N/8I/+cbS0dZjlbcwiUviClel4JZhC1bqBIWRJs2x9ogxWWcRK1/HJ0HieqEE6XP5TKvJSt5aP/umC4HUnoNMeV/ML3qZkTHYGgVTVn0CAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAQNJyAa0knEl3ZNndBstHzwQd7wMri7Ky6gKN5pJuK4K7cddbqUzcCbeQBmbi3xOhexHwUTK9jPAd0lxvVZNB5y73JhZ+Xq3X6m1C/GDA+in3K7wwmZYouxpniGXiOSZ8ACQf6KMg9GA8H4JnWrNCONSSOOcNDjdAvLdnh8GVdBZLuGMXFIg+rpXop/wJ0qdNscwZrFso2KNl9FuJmyWm1/drGPD5s5Z7S23fZTJTzb2j8z1GXDXoyycqclO33LhfFwy2APH3beJBp91GONAbC7x+FOc9tRl0MmCc3CEYVYst9kXfgOgT6y/MivOtI25PiI9lMN017hywSw5gjP36oA==" ],
-        "priority" : [ "100" ]
-      }
-    }, {
-      "id" : "ee5de1ba-8622-40bc-abed-609274591af5",
-      "name" : "hmac-generated",
-      "providerId" : "hmac-generated",
-      "subComponents" : { },
-      "config" : {
-        "kid" : [ "bac430f3-f4c3-4743-958e-8d9726767d9f" ],
-        "secret" : [ "aA9Qau1YuaLOQl7ipULLQLqZuqMkoFAlzLo2Ac0DFcYspTo86LEPjFsNPedWJOBhfjDjyL3OHmz-Yeiy4o1Itw" ],
-        "priority" : [ "100" ],
-        "algorithm" : [ "HS256" ]
-      }
-    } ]
-  },
-  "internationalizationEnabled" : false,
-  "supportedLocales" : [ ],
-  "authenticationFlows" : [ {
-    "id" : "bcab1d1f-b8d2-4c40-88b0-c97851b3b805",
-    "alias" : "Handle Existing Account",
-    "description" : "Handle what to do if there is existing account with same email/username like authenticated identity provider",
-    "providerId" : "basic-flow",
-    "topLevel" : false,
-    "builtIn" : true,
-    "authenticationExecutions" : [ {
-      "authenticator" : "idp-confirm-link",
-      "requirement" : "REQUIRED",
-      "priority" : 10,
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : false
-    }, {
-      "authenticator" : "idp-email-verification",
-      "requirement" : "ALTERNATIVE",
-      "priority" : 20,
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : false
-    }, {
-      "requirement" : "ALTERNATIVE",
-      "priority" : 30,
-      "flowAlias" : "Verify Existing Account by Re-authentication",
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : true
-    } ]
-  }, {
-    "id" : "f5c8fdb7-9d81-48dc-b0cd-d077ee1a1703",
-    "alias" : "Verify Existing Account by Re-authentication",
-    "description" : "Reauthentication of existing account",
-    "providerId" : "basic-flow",
-    "topLevel" : false,
-    "builtIn" : true,
-    "authenticationExecutions" : [ {
-      "authenticator" : "idp-username-password-form",
-      "requirement" : "REQUIRED",
-      "priority" : 10,
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : false
-    }, {
-      "authenticator" : "auth-otp-form",
-      "requirement" : "OPTIONAL",
-      "priority" : 20,
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : false
-    } ]
-  }, {
-    "id" : "dd0a9955-f819-4414-84b7-7fd94308f922",
-    "alias" : "browser",
-    "description" : "browser based authentication",
-    "providerId" : "basic-flow",
-    "topLevel" : true,
-    "builtIn" : true,
-    "authenticationExecutions" : [ {
-      "authenticator" : "auth-cookie",
-      "requirement" : "ALTERNATIVE",
-      "priority" : 10,
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : false
-    }, {
-      "authenticator" : "auth-spnego",
-      "requirement" : "DISABLED",
-      "priority" : 20,
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : false
-    }, {
-      "authenticator" : "identity-provider-redirector",
-      "requirement" : "ALTERNATIVE",
-      "priority" : 25,
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : false
-    }, {
-      "requirement" : "ALTERNATIVE",
-      "priority" : 30,
-      "flowAlias" : "forms",
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : true
-    } ]
-  }, {
-    "id" : "be8113b5-b147-4b2e-bcf4-7f7792e87458",
-    "alias" : "clients",
-    "description" : "Base authentication for clients",
-    "providerId" : "client-flow",
-    "topLevel" : true,
-    "builtIn" : true,
-    "authenticationExecutions" : [ {
-      "authenticator" : "client-secret",
-      "requirement" : "ALTERNATIVE",
-      "priority" : 10,
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : false
-    }, {
-      "authenticator" : "client-jwt",
-      "requirement" : "ALTERNATIVE",
-      "priority" : 20,
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : false
-    }, {
-      "authenticator" : "client-secret-jwt",
-      "requirement" : "ALTERNATIVE",
-      "priority" : 30,
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : false
-    }, {
-      "authenticator" : "client-x509",
-      "requirement" : "ALTERNATIVE",
-      "priority" : 40,
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : false
-    } ]
-  }, {
-    "id" : "176c247c-0223-430c-bd9d-4f25e988fec4",
-    "alias" : "direct grant",
-    "description" : "OpenID Connect Resource Owner Grant",
-    "providerId" : "basic-flow",
-    "topLevel" : true,
-    "builtIn" : true,
-    "authenticationExecutions" : [ {
-      "authenticator" : "direct-grant-validate-username",
-      "requirement" : "REQUIRED",
-      "priority" : 10,
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : false
-    }, {
-      "authenticator" : "direct-grant-validate-password",
-      "requirement" : "REQUIRED",
-      "priority" : 20,
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : false
-    }, {
-      "authenticator" : "direct-grant-validate-otp",
-      "requirement" : "OPTIONAL",
-      "priority" : 30,
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : false
-    } ]
-  }, {
-    "id" : "260225c9-770b-4f5b-a7dc-02774df55bbe",
-    "alias" : "docker auth",
-    "description" : "Used by Docker clients to authenticate against the IDP",
-    "providerId" : "basic-flow",
-    "topLevel" : true,
-    "builtIn" : true,
-    "authenticationExecutions" : [ {
-      "authenticator" : "docker-http-basic-authenticator",
-      "requirement" : "REQUIRED",
-      "priority" : 10,
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : false
-    } ]
-  }, {
-    "id" : "0820104e-ff1c-47a9-817b-be8fe38addcc",
-    "alias" : "first broker login",
-    "description" : "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
-    "providerId" : "basic-flow",
-    "topLevel" : true,
-    "builtIn" : true,
-    "authenticationExecutions" : [ {
-      "authenticatorConfig" : "review profile config",
-      "authenticator" : "idp-review-profile",
-      "requirement" : "REQUIRED",
-      "priority" : 10,
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : false
-    }, {
-      "authenticatorConfig" : "create unique user config",
-      "authenticator" : "idp-create-user-if-unique",
-      "requirement" : "ALTERNATIVE",
-      "priority" : 20,
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : false
-    }, {
-      "requirement" : "ALTERNATIVE",
-      "priority" : 30,
-      "flowAlias" : "Handle Existing Account",
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : true
-    } ]
-  }, {
-    "id" : "d528b181-31fd-489e-993f-2fa3a973dcc4",
-    "alias" : "forms",
-    "description" : "Username, password, otp and other auth forms.",
-    "providerId" : "basic-flow",
-    "topLevel" : false,
-    "builtIn" : true,
-    "authenticationExecutions" : [ {
-      "authenticator" : "auth-username-password-form",
-      "requirement" : "REQUIRED",
-      "priority" : 10,
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : false
-    }, {
-      "authenticator" : "auth-otp-form",
-      "requirement" : "OPTIONAL",
-      "priority" : 20,
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : false
-    } ]
-  }, {
-    "id" : "d60c07ed-7f34-47fd-9872-f9d1af73a665",
-    "alias" : "http challenge",
-    "description" : "An authentication flow based on challenge-response HTTP Authentication Schemes",
-    "providerId" : "basic-flow",
-    "topLevel" : true,
-    "builtIn" : true,
-    "authenticationExecutions" : [ {
-      "authenticator" : "no-cookie-redirect",
-      "requirement" : "REQUIRED",
-      "priority" : 10,
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : false
-    }, {
-      "authenticator" : "basic-auth",
-      "requirement" : "REQUIRED",
-      "priority" : 20,
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : false
-    }, {
-      "authenticator" : "basic-auth-otp",
-      "requirement" : "DISABLED",
-      "priority" : 30,
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : false
-    }, {
-      "authenticator" : "auth-spnego",
-      "requirement" : "DISABLED",
-      "priority" : 40,
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : false
-    } ]
-  }, {
-    "id" : "31d8f0ed-960e-4956-b03c-be0a6a3abecf",
-    "alias" : "registration",
-    "description" : "registration flow",
-    "providerId" : "basic-flow",
-    "topLevel" : true,
-    "builtIn" : true,
-    "authenticationExecutions" : [ {
-      "authenticator" : "registration-page-form",
-      "requirement" : "REQUIRED",
-      "priority" : 10,
-      "flowAlias" : "registration form",
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : true
-    } ]
-  }, {
-    "id" : "556452f8-5c74-466e-86a5-b16b098c655b",
-    "alias" : "registration form",
-    "description" : "registration form",
-    "providerId" : "form-flow",
-    "topLevel" : false,
-    "builtIn" : true,
-    "authenticationExecutions" : [ {
-      "authenticator" : "registration-user-creation",
-      "requirement" : "REQUIRED",
-      "priority" : 20,
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : false
-    }, {
-      "authenticator" : "registration-profile-action",
-      "requirement" : "REQUIRED",
-      "priority" : 40,
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : false
-    }, {
-      "authenticator" : "registration-password-action",
-      "requirement" : "REQUIRED",
-      "priority" : 50,
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : false
-    }, {
-      "authenticator" : "registration-recaptcha-action",
-      "requirement" : "DISABLED",
-      "priority" : 60,
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : false
-    } ]
-  }, {
-    "id" : "8313be26-f755-469c-8f0f-596a005b30f3",
-    "alias" : "reset credentials",
-    "description" : "Reset credentials for a user if they forgot their password or something",
-    "providerId" : "basic-flow",
-    "topLevel" : true,
-    "builtIn" : true,
-    "authenticationExecutions" : [ {
-      "authenticator" : "reset-credentials-choose-user",
-      "requirement" : "REQUIRED",
-      "priority" : 10,
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : false
-    }, {
-      "authenticator" : "reset-credential-email",
-      "requirement" : "REQUIRED",
-      "priority" : 20,
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : false
-    }, {
-      "authenticator" : "reset-password",
-      "requirement" : "REQUIRED",
-      "priority" : 30,
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : false
-    }, {
-      "authenticator" : "reset-otp",
-      "requirement" : "OPTIONAL",
-      "priority" : 40,
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : false
-    } ]
-  }, {
-    "id" : "f6dfb420-c9ab-4d57-8c05-51356e2a521b",
-    "alias" : "saml ecp",
-    "description" : "SAML ECP Profile Authentication Flow",
-    "providerId" : "basic-flow",
-    "topLevel" : true,
-    "builtIn" : true,
-    "authenticationExecutions" : [ {
-      "authenticator" : "http-basic-authenticator",
-      "requirement" : "REQUIRED",
-      "priority" : 10,
-      "userSetupAllowed" : false,
-      "autheticatorFlow" : false
-    } ]
-  } ],
-  "authenticatorConfig" : [ {
-    "id" : "6342a744-0729-495a-960d-13b7589e99fd",
-    "alias" : "create unique user config",
-    "config" : {
-      "require.password.update.after.registration" : "false"
+  "clients": [
+    {
+      "id": "d2c8ac4e-5dfb-4511-8af5-7638f874522c",
+      "clientId": "account",
+      "name": "${client_account}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/hocs/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/realms/hocs/account/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {},
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "roles",
+        "profile",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "bb7f93fe-758f-4a25-ac14-315f341ed56a",
+      "clientId": "account-console",
+      "name": "${client_account-console}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/hocs/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/realms/hocs/account/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "8e83b27a-5f6c-42cf-b3e6-e2b024e17b8a",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "roles",
+        "profile",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "8042bd01-55d4-4724-bedd-9babc1c2d110",
+      "clientId": "admin-cli",
+      "name": "${client_admin-cli}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {},
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "roles",
+        "profile",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "f4894a3e-3946-4464-a991-034721d65e4b",
+      "clientId": "broker",
+      "name": "${client_broker}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {},
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "roles",
+        "profile",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "232f7fba-aeea-4d01-877d-cede6c0abf0d",
+      "clientId": "info-service-client",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "id.token.as.detached.signature": "false",
+        "saml.assertion.signature": "false",
+        "saml.force.post.binding": "false",
+        "saml.multivalued.roles": "false",
+        "saml.encrypt": "false",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "backchannel.logout.revoke.offline.tokens": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "use.refresh.tokens": "true",
+        "exclude.session.state.from.auth.response": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "saml.artifact.binding": "false",
+        "backchannel.logout.session.required": "true",
+        "client_credentials.use_refresh_token": "false",
+        "saml_force_name_id_format": "false",
+        "require.pushed.authorization.requests": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "2ea4b783-7e07-47c4-b8be-3f3d5525c658",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "7c406eb8-aff3-4a15-8630-f766e7630fdc",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "7f9d0f1c-d64e-4d15-94b0-6b945463d5f2",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "roles",
+        "profile",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "c2cbb986-0958-44ec-8645-39b648755ee1",
+      "clientId": "realm-management",
+      "name": "${client_realm-management}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {},
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "roles",
+        "profile",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "0bf9c6ff-164d-450b-aa8a-06000b282d68",
+      "clientId": "security-admin-console",
+      "name": "${client_security-admin-console}",
+      "rootUrl": "${authAdminUrl}",
+      "baseUrl": "/admin/hocs/console/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/admin/hocs/console/*"
+      ],
+      "webOrigins": [
+        "+"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "20d6299a-0833-4442-b8f5-9c78bda98c4a",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "roles",
+        "profile",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
     }
-  }, {
-    "id" : "368296e9-fb72-48de-ad4d-55075278f4b0",
-    "alias" : "review profile config",
-    "config" : {
-      "update.profile.on.first.login" : "missing"
+  ],
+  "clientScopes": [
+    {
+      "id": "799c35cb-bd43-4649-840e-506d31aebfea",
+      "name": "phone",
+      "description": "OpenID Connect built-in scope: phone",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${phoneScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "089f2482-c877-4fac-8de5-74aece9a667a",
+          "name": "phone number",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumber",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "d9f1aa14-05c6-4b78-83f4-94e2f747ce06",
+          "name": "phone number verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumberVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number_verified",
+            "jsonType.label": "boolean"
+          }
+        }
+      ]
+    },
+    {
+      "id": "32b13799-4257-4c7c-9b67-184e855e2378",
+      "name": "role_list",
+      "description": "SAML role list",
+      "protocol": "saml",
+      "attributes": {
+        "consent.screen.text": "${samlRoleListScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "9730ee08-dfc2-402b-b81b-c11ac151d160",
+          "name": "role list",
+          "protocol": "saml",
+          "protocolMapper": "saml-role-list-mapper",
+          "consentRequired": false,
+          "config": {
+            "single": "false",
+            "attribute.nameformat": "Basic",
+            "attribute.name": "Role"
+          }
+        }
+      ]
+    },
+    {
+      "id": "175977db-a275-4650-a66f-eca9ee3f5300",
+      "name": "email",
+      "description": "OpenID Connect built-in scope: email",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${emailScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "86e93de7-70cb-4150-a97c-258c2dd3d460",
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "02f50a8b-cf3b-44c4-95b7-8eb6cd8677f0",
+          "name": "email verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "emailVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email_verified",
+            "jsonType.label": "boolean"
+          }
+        }
+      ]
+    },
+    {
+      "id": "159c86da-8f30-4d42-ade1-d1f080b2c7a5",
+      "name": "microprofile-jwt",
+      "description": "Microprofile - JWT built-in scope",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "d3db8581-21fc-4064-a0b6-e82d025a26b8",
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "multivalued": "true",
+            "user.attribute": "foo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "2d2ef065-7c64-4d0a-85f1-02203301e0f0",
+          "name": "upn",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "upn",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "8959640c-8d9f-4132-ac85-f7d057609626",
+      "name": "offline_access",
+      "description": "OpenID Connect built-in scope: offline_access",
+      "protocol": "openid-connect",
+      "attributes": {
+        "consent.screen.text": "${offlineAccessScopeConsentText}",
+        "display.on.consent.screen": "true"
+      }
+    },
+    {
+      "id": "fdd977b0-6b10-4624-928b-ef8cd00b5c5c",
+      "name": "web-origins",
+      "description": "OpenID Connect scope for add allowed web origins to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false",
+        "consent.screen.text": ""
+      },
+      "protocolMappers": [
+        {
+          "id": "aef96164-8e2d-4a52-916b-2b9cbfdc57ec",
+          "name": "allowed web origins",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-allowed-origins-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ]
+    },
+    {
+      "id": "bc9c5a88-d4fd-42c9-82ce-f2e7381889af",
+      "name": "roles",
+      "description": "OpenID Connect scope for add user roles to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${rolesScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "9378a01c-84fa-41eb-9138-fe5d0d27675c",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {}
+        },
+        {
+          "id": "b172ebae-30d6-4ec7-bf91-72c43abadcb9",
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "access.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        },
+        {
+          "id": "140862fc-9df3-4a84-96bc-c658718dc298",
+          "name": "client roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-client-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "access.token.claim": "true",
+            "claim.name": "resource_access.${client_id}.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "1351a082-adc5-4240-8ab7-429729a17792",
+      "name": "address",
+      "description": "OpenID Connect built-in scope: address",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${addressScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "90a5165b-5dce-4a59-bca8-001c49731c03",
+          "name": "address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-address-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute.formatted": "formatted",
+            "user.attribute.country": "country",
+            "user.attribute.postal_code": "postal_code",
+            "userinfo.token.claim": "true",
+            "user.attribute.street": "street",
+            "id.token.claim": "true",
+            "user.attribute.region": "region",
+            "access.token.claim": "true",
+            "user.attribute.locality": "locality"
+          }
+        }
+      ]
+    },
+    {
+      "id": "26d836cd-d352-4889-ae77-c165ba588f5d",
+      "name": "profile",
+      "description": "OpenID Connect built-in scope: profile",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${profileScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "f35519d0-4352-49ef-a9af-4e2b212e49e8",
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "lastName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "family_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "54da734c-9a14-4339-932b-206aef323c8d",
+          "name": "birthdate",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "birthdate",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "birthdate",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "b2682c0f-07a6-4ac1-b3b9-582f332eea9b",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "a00237c3-4e91-4c55-a7db-c6c6fd67f9df",
+          "name": "picture",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "picture",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "picture",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "2d65f6f1-6a74-4701-9867-63d3be52fd13",
+          "name": "gender",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "gender",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "gender",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "d14e8487-2f1c-4259-9369-e713a504e5d6",
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "firstName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "given_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "eece65c4-56e4-449d-b06c-9e2796840c1d",
+          "name": "profile",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "profile",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "profile",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "cd77a97a-e75c-465d-9d2b-90050b2aff7c",
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "30615626-03d0-4f74-aad1-1fe9534827ea",
+          "name": "nickname",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "nickname",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "nickname",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "4c8a2705-7c61-45c8-a8a9-4b473cda1f0e",
+          "name": "middle name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "middleName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "middle_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "eecf50d2-b33f-44bf-a6c4-7ac2d9aadc29",
+          "name": "updated at",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "updatedAt",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "updated_at",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "e2612213-7555-4640-b832-d9e14f7caadd",
+          "name": "website",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "website",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "website",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "d3c48674-64de-4fdb-bdb0-e5ad82d5f829",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "fe30c562-540e-4465-a8a1-3274ad980319",
+          "name": "zoneinfo",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "zoneinfo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "zoneinfo",
+            "jsonType.label": "String"
+          }
+        }
+      ]
     }
-  } ],
-  "requiredActions" : [ {
-    "alias" : "CONFIGURE_TOTP",
-    "name" : "Configure OTP",
-    "providerId" : "CONFIGURE_TOTP",
-    "enabled" : true,
-    "defaultAction" : false,
-    "priority" : 10,
-    "config" : { }
-  }, {
-    "alias" : "terms_and_conditions",
-    "name" : "Terms and Conditions",
-    "providerId" : "terms_and_conditions",
-    "enabled" : false,
-    "defaultAction" : false,
-    "priority" : 20,
-    "config" : { }
-  }, {
-    "alias" : "UPDATE_PASSWORD",
-    "name" : "Update Password",
-    "providerId" : "UPDATE_PASSWORD",
-    "enabled" : true,
-    "defaultAction" : false,
-    "priority" : 30,
-    "config" : { }
-  }, {
-    "alias" : "UPDATE_PROFILE",
-    "name" : "Update Profile",
-    "providerId" : "UPDATE_PROFILE",
-    "enabled" : true,
-    "defaultAction" : false,
-    "priority" : 40,
-    "config" : { }
-  }, {
-    "alias" : "VERIFY_EMAIL",
-    "name" : "Verify Email",
-    "providerId" : "VERIFY_EMAIL",
-    "enabled" : true,
-    "defaultAction" : false,
-    "priority" : 50,
-    "config" : { }
-  } ],
-  "browserFlow" : "browser",
-  "registrationFlow" : "registration",
-  "directGrantFlow" : "direct grant",
-  "resetCredentialsFlow" : "reset credentials",
-  "clientAuthenticationFlow" : "clients",
-  "dockerAuthenticationFlow" : "docker auth",
-  "attributes" : {
-    "_browser_header.xXSSProtection" : "1; mode=block",
-    "_browser_header.xFrameOptions" : "SAMEORIGIN",
-    "_browser_header.strictTransportSecurity" : "max-age=31536000; includeSubDomains",
-    "permanentLockout" : "false",
-    "quickLoginCheckMilliSeconds" : "1000",
-    "_browser_header.xRobotsTag" : "none",
-    "maxFailureWaitSeconds" : "900",
-    "minimumQuickLoginWaitSeconds" : "60",
-    "failureFactor" : "30",
-    "actionTokenGeneratedByUserLifespan" : "300",
-    "maxDeltaTimeSeconds" : "43200",
-    "_browser_header.xContentTypeOptions" : "nosniff",
-    "offlineSessionMaxLifespan" : "5184000",
-    "actionTokenGeneratedByAdminLifespan" : "43200",
-    "_browser_header.contentSecurityPolicyReportOnly" : "",
-    "bruteForceProtected" : "false",
-    "_browser_header.contentSecurityPolicy" : "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
-    "waitIncrementSeconds" : "60",
-    "offlineSessionMaxLifespanEnabled" : "false"
+  ],
+  "defaultDefaultClientScopes": [
+    "role_list",
+    "profile",
+    "email",
+    "roles",
+    "web-origins"
+  ],
+  "defaultOptionalClientScopes": [
+    "offline_access",
+    "address",
+    "phone",
+    "microprofile-jwt"
+  ],
+  "browserSecurityHeaders": {
+    "contentSecurityPolicyReportOnly": "",
+    "xContentTypeOptions": "nosniff",
+    "xRobotsTag": "none",
+    "xFrameOptions": "SAMEORIGIN",
+    "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "xXSSProtection": "1; mode=block",
+    "strictTransportSecurity": "max-age=31536000; includeSubDomains"
   },
-  "keycloakVersion" : "4.5.0.Final",
-  "userManagedAccessAllowed" : true
+  "smtpServer": {},
+  "eventsEnabled": false,
+  "eventsListeners": [
+    "jboss-logging"
+  ],
+  "enabledEventTypes": [],
+  "adminEventsEnabled": false,
+  "adminEventsDetailsEnabled": false,
+  "identityProviders": [],
+  "identityProviderMappers": [],
+  "components": {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
+      {
+        "id": "e68221a4-05ee-4872-bf10-23ecf1f940d6",
+        "name": "Max Clients Limit",
+        "providerId": "max-clients",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "max-clients": [
+            "200"
+          ]
+        }
+      },
+      {
+        "id": "53a7e975-b315-41af-b6ec-6cc75b57c387",
+        "name": "Trusted Hosts",
+        "providerId": "trusted-hosts",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "host-sending-registration-request-must-match": [
+            "true"
+          ],
+          "client-uris-must-match": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "85ca501e-2965-43fb-8901-8bf315cd5e9d",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "c1ee7293-b973-49ad-8433-2992873b79bd",
+        "name": "Consent Required",
+        "providerId": "consent-required",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "26bb2358-6b67-44d0-8e83-d9d966e1d314",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "19b99f49-4cc4-46a3-bda2-0eb5ddf63165",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "saml-user-attribute-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "saml-user-property-mapper",
+            "oidc-address-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "saml-role-list-mapper",
+            "oidc-usermodel-property-mapper",
+            "oidc-full-name-mapper"
+          ]
+        }
+      },
+      {
+        "id": "9f42a24b-577b-436e-a3f8-c21327976e87",
+        "name": "Full Scope Disabled",
+        "providerId": "scope",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "e7832b25-5c66-4786-b165-d85822f1d654",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "oidc-usermodel-property-mapper",
+            "saml-user-attribute-mapper",
+            "oidc-address-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "saml-user-property-mapper",
+            "oidc-full-name-mapper",
+            "saml-role-list-mapper"
+          ]
+        }
+      }
+    ],
+    "org.keycloak.keys.KeyProvider": [
+      {
+        "id": "5a7f145e-452a-439d-8c1c-094b6192f54c",
+        "name": "rsa-enc-generated",
+        "providerId": "rsa-generated",
+        "subComponents": {},
+        "config": {
+          "keyUse": [
+            "enc"
+          ],
+          "priority": [
+            "100"
+          ]
+        }
+      },
+      {
+        "id": "91f39504-0315-419c-90d1-246a32735be8",
+        "name": "rsa-generated",
+        "providerId": "rsa-generated",
+        "subComponents": {},
+        "config": {
+          "keyUse": [
+            "sig"
+          ],
+          "priority": [
+            "100"
+          ]
+        }
+      },
+      {
+        "id": "140af1b0-6e52-48f6-9ec3-24d9e69fd889",
+        "name": "aes-generated",
+        "providerId": "aes-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ]
+        }
+      },
+      {
+        "id": "7aa7d10e-3f51-42a7-bf6a-4b8700f51e84",
+        "name": "hmac-generated",
+        "providerId": "hmac-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ],
+          "algorithm": [
+            "HS256"
+          ]
+        }
+      }
+    ]
+  },
+  "internationalizationEnabled": false,
+  "supportedLocales": [],
+  "authenticationFlows": [
+    {
+      "id": "a7818cc6-970c-4d92-817a-ed5a831701bf",
+      "alias": "Account verification options",
+      "description": "Method with which to verity the existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-email-verification",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "flowAlias": "Verify Existing Account by Re-authentication",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "8e7bc325-11f4-4503-ba36-ff8c353f3434",
+      "alias": "Authentication Options",
+      "description": "Authentication options.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "basic-auth",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "basic-auth-otp",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-spnego",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 30,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "d94888af-87e2-47eb-8f6d-49a7f159f59f",
+      "alias": "Browser - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "65b87246-5727-41a2-a923-9168ac7b6733",
+      "alias": "Direct Grant - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "direct-grant-validate-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "1667ba58-3aaa-407f-babd-667ec4772cb5",
+      "alias": "First broker login - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "38da0962-b796-4160-9bb9-63377a7bfdc6",
+      "alias": "Handle Existing Account",
+      "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-confirm-link",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "flowAlias": "Account verification options",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "6a1034f2-b4ec-4cc5-bc25-e7c8573396c9",
+      "alias": "Reset - Conditional OTP",
+      "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "reset-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "09f4e458-50da-4b7c-b18d-bac5fba39682",
+      "alias": "User creation or linking",
+      "description": "Flow for the existing/non-existing user alternatives",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "create unique user config",
+          "authenticator": "idp-create-user-if-unique",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "flowAlias": "Handle Existing Account",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "e85d18ff-81d2-47ca-9204-1ce55371ddcc",
+      "alias": "Verify Existing Account by Re-authentication",
+      "description": "Reauthentication of existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "flowAlias": "First broker login - Conditional OTP",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "da06d265-5be2-40df-81fb-c772df60b891",
+      "alias": "browser",
+      "description": "browser based authentication",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-cookie",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-spnego",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "identity-provider-redirector",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 25,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "flowAlias": "forms",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "830c54a1-9bfa-4bfa-8432-33e820161960",
+      "alias": "clients",
+      "description": "Base authentication for clients",
+      "providerId": "client-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "client-secret",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "client-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "client-secret-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "client-x509",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 40,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "110e40f9-7f05-4a08-b3cc-99cf77e58972",
+      "alias": "direct grant",
+      "description": "OpenID Connect Resource Owner Grant",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "direct-grant-validate-username",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "direct-grant-validate-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 30,
+          "flowAlias": "Direct Grant - Conditional OTP",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "d6b0b50a-c97d-4737-8eca-0a5dcb09acc9",
+      "alias": "docker auth",
+      "description": "Used by Docker clients to authenticate against the IDP",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "docker-http-basic-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "2bcad3fd-3887-4753-b665-181d77106369",
+      "alias": "first broker login",
+      "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "review profile config",
+          "authenticator": "idp-review-profile",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "flowAlias": "User creation or linking",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "f43432d8-557e-4073-ae01-34e0b49bfc29",
+      "alias": "forms",
+      "description": "Username, password, otp and other auth forms.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "flowAlias": "Browser - Conditional OTP",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "9dbba9e0-3920-4d1e-918d-3ba5ae153447",
+      "alias": "http challenge",
+      "description": "An authentication flow based on challenge-response HTTP Authentication Schemes",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "no-cookie-redirect",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "flowAlias": "Authentication Options",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "4a4c50b9-57cc-4db4-ab95-0e6134f87ed7",
+      "alias": "registration",
+      "description": "registration flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-page-form",
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "flowAlias": "registration form",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "88face81-1fa1-4ca7-a165-92f3a9cf2d2a",
+      "alias": "registration form",
+      "description": "registration form",
+      "providerId": "form-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-user-creation",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "registration-profile-action",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 40,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "registration-password-action",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 50,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "registration-recaptcha-action",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 60,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "7845ce81-7388-42eb-a4f4-5deb6c769cf1",
+      "alias": "reset credentials",
+      "description": "Reset credentials for a user if they forgot their password or something",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "reset-credentials-choose-user",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "reset-credential-email",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "reset-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 30,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 40,
+          "flowAlias": "Reset - Conditional OTP",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "a449aab0-af56-429e-9900-f67e7a9644e7",
+      "alias": "saml ecp",
+      "description": "SAML ECP Profile Authentication Flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "http-basic-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    }
+  ],
+  "authenticatorConfig": [
+    {
+      "id": "7f9cd41e-4bc4-4002-b3a2-0c275e7c02f2",
+      "alias": "create unique user config",
+      "config": {
+        "require.password.update.after.registration": "false"
+      }
+    },
+    {
+      "id": "be786f0a-16c2-48f0-84b2-97c2a1454a00",
+      "alias": "review profile config",
+      "config": {
+        "update.profile.on.first.login": "missing"
+      }
+    }
+  ],
+  "requiredActions": [
+    {
+      "alias": "CONFIGURE_TOTP",
+      "name": "Configure OTP",
+      "providerId": "CONFIGURE_TOTP",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 10,
+      "config": {}
+    },
+    {
+      "alias": "terms_and_conditions",
+      "name": "Terms and Conditions",
+      "providerId": "terms_and_conditions",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 20,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PASSWORD",
+      "name": "Update Password",
+      "providerId": "UPDATE_PASSWORD",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 30,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PROFILE",
+      "name": "Update Profile",
+      "providerId": "UPDATE_PROFILE",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 40,
+      "config": {}
+    },
+    {
+      "alias": "VERIFY_EMAIL",
+      "name": "Verify Email",
+      "providerId": "VERIFY_EMAIL",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 50,
+      "config": {}
+    },
+    {
+      "alias": "delete_account",
+      "name": "Delete Account",
+      "providerId": "delete_account",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 60,
+      "config": {}
+    },
+    {
+      "alias": "update_user_locale",
+      "name": "Update User Locale",
+      "providerId": "update_user_locale",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 1000,
+      "config": {}
+    }
+  ],
+  "browserFlow": "browser",
+  "registrationFlow": "registration",
+  "directGrantFlow": "direct grant",
+  "resetCredentialsFlow": "reset credentials",
+  "clientAuthenticationFlow": "clients",
+  "dockerAuthenticationFlow": "docker auth",
+  "attributes": {
+    "cibaBackchannelTokenDeliveryMode": "poll",
+    "cibaExpiresIn": "120",
+    "cibaAuthRequestedUserHint": "login_hint",
+    "oauth2DeviceCodeLifespan": "600",
+    "oauth2DevicePollingInterval": "5",
+    "parRequestUriLifespan": "60",
+    "cibaInterval": "5"
+  },
+  "keycloakVersion": "15.0.2",
+  "userManagedAccessAllowed": false,
+  "clientProfiles": {
+    "profiles": []
+  },
+  "clientPolicies": {
+    "policies": []
+  }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/TeamService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/TeamService.java
@@ -157,7 +157,8 @@ public class TeamService {
     @Transactional
     public Team createTeam(TeamDto newTeam, UUID unitUUID) {
         log.debug("Creating Team {}", newTeam.getDisplayName());
-        Team team = teamRepository.findByUuidOrDisplayName(newTeam.getUuid(), newTeam.getDisplayName());
+
+        Team team = teamRepository.findByDisplayName(newTeam.getDisplayName());
         Unit unit = unitRepository.findByUuid(unitUUID);
         if (team == null) {
             log.debug("Team {} doesn't exist, creating.", newTeam.getDisplayName());

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/UserResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/UserResource.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @Slf4j
 @RestController
@@ -52,16 +53,15 @@ public class UserResource {
         return ResponseEntity.ok(users);
     }
 
-    @PostMapping(value = "/user", produces = APPLICATION_JSON_UTF8_VALUE)
+    @PostMapping(value = "/user", produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<CreateUserResponse> createUser(@Valid @RequestBody CreateUserDto createUserDto) {
         CreateUserResponse createUserResponse = userService.createUser(createUserDto);
         return ResponseEntity.ok().body(createUserResponse);
     }
 
-    @PutMapping(value = "/user/{userUUID}", produces = APPLICATION_JSON_UTF8_VALUE)
+    @PutMapping(value = "/user/{userUUID}", produces = APPLICATION_JSON_VALUE)
     public ResponseEntity updateUser(@PathVariable UUID userUUID, @Valid @RequestBody UpdateUserDto updateUserDto) {
         userService.updateUser(userUUID, updateUserDto);
         return ResponseEntity.ok().build();
     }
 }
-

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/CaseActionIntegrationTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/CaseActionIntegrationTest.java
@@ -1,85 +1,53 @@
 package uk.gov.digital.ho.hocs.info.api;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.entity.ContentType;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.keycloak.admin.client.Keycloak;
-import org.keycloak.admin.client.resource.RealmResource;
-import org.keycloak.representations.idm.PartialImportRepresentation;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.*;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlConfig;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.digital.ho.hocs.info.api.dto.CaseTypeActionDto;
 import uk.gov.digital.ho.hocs.info.api.dto.CaseTypeDto;
-import uk.gov.digital.ho.hocs.info.security.KeycloakService;
-
-import java.io.File;
 import java.io.IOException;
 import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 import static org.springframework.test.context.jdbc.SqlConfig.TransactionMode.ISOLATED;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(properties = {"user.email.whitelist=homeoffice.gov.uk"},
-        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Sql(scripts = "classpath:beforeTest.sql", config = @SqlConfig(transactionMode = ISOLATED))
 @Sql(scripts = "classpath:afterTest.sql", config = @SqlConfig(transactionMode = ISOLATED), executionPhase = AFTER_TEST_METHOD)
+@DirtiesContext(classMode = AFTER_EACH_TEST_METHOD)
 @ActiveProfiles({"local", "integration"})
 public class CaseActionIntegrationTest {
-
-    @Autowired
-    KeycloakService keycloakService;
-
-    Keycloak keycloakClient;
-
-    @Value("${keycloak.server.url}")
-    String serverUrl;
-    @Value("${keycloak.username}")
-    String username;
-    @Value("${keycloak.password}")
-    String password;
-    @Value("${keycloak.client.id}")
-    String clientId;
-    @Value("${keycloak.realm}")
-    String HOCS_REALM;
 
     TestRestTemplate restTemplate = new TestRestTemplate();
     @LocalServerPort
     int port;
-    @Autowired
-    ObjectMapper mapper;
-    private HttpHeaders headers;
 
-    private String userId;
+    private HttpHeaders headers;
 
     @Before
     public void setup() throws IOException {
         headers = new HttpHeaders();
         headers.add(HttpHeaders.ACCEPT, ContentType.APPLICATION_JSON.toString());
-        keycloakClient = Keycloak.getInstance(
-                serverUrl, "master", username, password, clientId, clientId);
-        setupKeycloakRealm();
-
-        userId = keycloakClient.realm(HOCS_REALM).users().search("admin").get(0).getId();
     }
 
     @Test
     public void shouldRetrieveAllInitialCaseTypes() {
-
         // given
         // setup done in before.sql
         HttpEntity httpEntity = new HttpEntity(headers);
@@ -100,12 +68,10 @@ public class CaseActionIntegrationTest {
                 .filter(caseTypeDto -> caseTypeDto.getPreviousCaseType() == null)
                 .count())
                 .isEqualTo(3);
-
     }
 
     @Test
     public void shouldRetrieveAllCaseTypes() {
-
         // given
         // setup done in before.sql
         HttpEntity httpEntity = new HttpEntity(headers);
@@ -127,9 +93,6 @@ public class CaseActionIntegrationTest {
 
     @Test
     public void shouldReturnRequestedActionById() {
-
-        String caseTypeString = "CT1";
-
         String actionID = "f2b625c9-7250-4293-9e68-c8f515e3043d";
 
         ParameterizedTypeReference<CaseTypeActionDto> typeReference = new ParameterizedTypeReference<>() {};
@@ -145,15 +108,11 @@ public class CaseActionIntegrationTest {
         assertNotNull(response);
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals("APPEAL 1", Objects.requireNonNull(response.getBody()).getActionLabel());
-
     }
 
 
     @Test
     public void shouldReturnRequestedActionLabelById() {
-
-        String caseTypeString = "CT1";
-
         String actionID = "f2b625c9-7250-4293-9e68-c8f515e3043d";
 
         HttpEntity httpEntity = new HttpEntity(headers);
@@ -174,12 +133,4 @@ public class CaseActionIntegrationTest {
         return "http://localhost:" + port;
     }
 
-    private void setupKeycloakRealm() throws IOException {
-        RealmResource hocsRealm = keycloakClient.realm(HOCS_REALM);
-
-        PartialImportRepresentation importRealm = mapper.readValue(new File("./keycloak/local-realm.json"), PartialImportRepresentation.class);
-        hocsRealm.groups().groups().stream().forEach(e -> hocsRealm.groups().group(e.getId()).remove());
-        importRealm.setIfResourceExists(PartialImportRepresentation.Policy.OVERWRITE.toString());
-        keycloakClient.realm(HOCS_REALM).partialImport(importRealm);
-    }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/TeamIntegrationTests.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/TeamIntegrationTests.java
@@ -3,25 +3,21 @@ package uk.gov.digital.ho.hocs.info.api;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.entity.ContentType;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.keycloak.admin.client.Keycloak;
-import org.keycloak.admin.client.resource.RealmResource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.keycloak.representations.idm.GroupRepresentation;
-import org.keycloak.representations.idm.PartialImportRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.*;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlConfig;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
@@ -30,8 +26,8 @@ import uk.gov.digital.ho.hocs.info.domain.repository.TeamRepository;
 import uk.gov.digital.ho.hocs.info.security.AccessLevel;
 import uk.gov.digital.ho.hocs.info.security.Base64UUID;
 import uk.gov.digital.ho.hocs.info.security.KeycloakService;
+import uk.gov.digital.ho.hocs.info.utils.BaseKeycloakTest;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
@@ -39,7 +35,6 @@ import java.util.Set;
 import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpMethod.GET;
-import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 import static org.springframework.test.context.jdbc.SqlConfig.TransactionMode.ISOLATED;
 import static org.springframework.test.web.client.MockRestServiceServer.bindTo;
@@ -47,94 +42,72 @@ import static org.springframework.test.web.client.match.MockRestRequestMatchers.
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Sql(scripts = "classpath:beforeTest.sql", config = @SqlConfig(transactionMode = ISOLATED))
 @Sql(scripts = "classpath:afterTest.sql", config = @SqlConfig(transactionMode = ISOLATED), executionPhase = AFTER_TEST_METHOD)
-@DirtiesContext(classMode = AFTER_EACH_TEST_METHOD)
 @ActiveProfiles({"local", "integration"})
-public class TeamIntegrationTests {
-
-    TestRestTemplate testRestTemplate = new TestRestTemplate();
+public class TeamIntegrationTests extends BaseKeycloakTest {
 
     @Autowired
     private RestTemplate restTemplate;
 
     @Autowired
-    TeamRepository teamRepository;
+    private TeamRepository teamRepository;
 
     @Autowired
-    KeycloakService keycloakService;
-
-    Keycloak keycloakClient;
-
-    private MockRestServiceServer mockCaseworkService;
-
-    private HttpHeaders headers;
+    private ObjectMapper mapper;
 
     @LocalServerPort
-    int port;
+    private int port;
 
-    @Autowired
-    ObjectMapper mapper;
-
-    @Value("${keycloak.server.url}")
-    String serverUrl;
-    @Value("${keycloak.username}")
-    String username;
-    @Value("${keycloak.password}")
-    String password;
-    @Value("${keycloak.client.id}")
-    String clientId;
-    @Value("${keycloak.realm}")
-    String HOCS_REALM;
-
+    private TestRestTemplate testRestTemplate = new TestRestTemplate();
+    private MockRestServiceServer mockCaseworkService;
+    private HttpHeaders headers;
     private String userId;
     private final UUID unitUUID = UUID.fromString("09221c48-b916-47df-9aa0-a0194f86f6dd");
 
+    @BeforeEach
+    public void setup() {
+        service = new KeycloakService(teamRepository, keycloakClient, REALM);
 
-    @Before
-    public void setup() throws IOException {
         headers = new HttpHeaders();
         headers.add(HttpHeaders.ACCEPT, ContentType.APPLICATION_JSON.toString());
-        keycloakClient = Keycloak.getInstance(
-                serverUrl, "master", username, password, clientId, clientId);
-        setupKeycloakRealm();
 
         mockCaseworkService = buildMockService(restTemplate);
-        userId = keycloakClient.realm(HOCS_REALM).users().search("admin").get(0).getId();
-    }
 
+        userId = keycloakClient.realm(REALM).users().search("integration-test@example.com")
+                .stream().findFirst()
+                .map(UserRepresentation::getId)
+                .orElseThrow();
+    }
 
     @Test
     public void shouldGetAllTeamsForUnit() {
-        HttpEntity httpEntity = new HttpEntity(headers);
+        HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
         ResponseEntity<Set<TeamDto>> result = testRestTemplate.exchange(
-                getBasePath() + "/unit/" + unitUUID.toString() + "/teams"
-                , HttpMethod.GET, httpEntity, new ParameterizedTypeReference<Set<TeamDto>>() {
+                getBasePath() + "/unit/" + unitUUID + "/teams"
+                , HttpMethod.GET, httpEntity, new ParameterizedTypeReference<>() {
                 });
         assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(result.getBody().size()).isEqualTo(6);
+        assertThat(result.getBody()).hasSize(6);
     }
 
     @Test
     public void shouldAddTeamToDatabaseAndKeyCloak() {
-
-        Set<PermissionDto> permissions = new HashSet<PermissionDto>() {{
-            add(new PermissionDto("CT1", AccessLevel.OWNER));
-        }};
+        Set<PermissionDto> permissions = Set.of(new PermissionDto("CT1", AccessLevel.OWNER));
         TeamDto team = new TeamDto("Team 3000", permissions);
 
         HttpEntity<TeamDto> httpEntity = new HttpEntity<>(team, headers);
 
         ResponseEntity<TeamDto> result = testRestTemplate.exchange(
-                getBasePath() + "/unit/" + unitUUID.toString() + "/teams"
+                getBasePath() + "/unit/" + unitUUID + "/teams"
                 , HttpMethod.POST, httpEntity, TeamDto.class);
 
         assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(teamRepository.findByUuid(result.getBody().getUuid())).isNotNull();
 
-        GroupRepresentation group = keycloakClient.realm("hocs")
+        GroupRepresentation group = keycloakClient.realm(REALM)
                 .getGroupByPath("/" + Base64UUID.uuidToBase64String(result.getBody().getUuid()));
 
         assertThat(group).isNotNull();
@@ -142,10 +115,9 @@ public class TeamIntegrationTests {
 
     @Test
     public void shouldAddUserToGroup() {
-
         String teamId = "434a4e33-437f-4e6d-8f04-14ea40fdbfa2";
         String base64TeamUUID = Base64UUID.uuidToBase64String(UUID.fromString(teamId));
-        HttpEntity httpEntity = new HttpEntity(List.of(userId),headers);
+        HttpEntity<List<String>> httpEntity = new HttpEntity<>(List.of(userId), headers);
 
         ResponseEntity<String> result = testRestTemplate.exchange(
                 getBasePath() + "/users/team/" + teamId
@@ -153,10 +125,10 @@ public class TeamIntegrationTests {
 
         assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
 
-        GroupRepresentation group = keycloakClient.realm(HOCS_REALM)
+        GroupRepresentation group = keycloakClient.realm(REALM)
                 .getGroupByPath("/" + base64TeamUUID);
 
-        assertThat(keycloakClient.realm(HOCS_REALM)
+        assertThat(keycloakClient.realm(REALM)
                 .users().get(userId).groups().stream()
                 .anyMatch(g -> g.getId().equals(group.getId()))).isTrue();
 
@@ -175,10 +147,10 @@ public class TeamIntegrationTests {
 
         setupCaseworkServiceWithNoCases();
 
-        GroupRepresentation group = keycloakClient.realm(HOCS_REALM)
+        GroupRepresentation group = keycloakClient.realm(REALM)
                 .getGroupByPath("/" + base64TeamUUID);
 
-        assertThat(keycloakClient.realm(HOCS_REALM)
+        assertThat(keycloakClient.realm(REALM)
                 .users().get(userId).groups().stream()
                 .anyMatch(g -> g.getId().equals(group.getId()))).isTrue();
 
@@ -188,7 +160,7 @@ public class TeamIntegrationTests {
 
         assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
 
-        assertThat(keycloakClient.realm(HOCS_REALM)
+        assertThat(keycloakClient.realm(REALM)
                 .users().get(userId).groups().stream()
                 .anyMatch(g -> g.getId().equals(group.getId()))).isFalse();
     }
@@ -206,10 +178,10 @@ public class TeamIntegrationTests {
 
         setupCaseworkServiceWithCases();
 
-        GroupRepresentation group = keycloakClient.realm(HOCS_REALM)
+        GroupRepresentation group = keycloakClient.realm(REALM)
                 .getGroupByPath("/" + base64TeamUUID);
 
-        assertThat(keycloakClient.realm(HOCS_REALM)
+        assertThat(keycloakClient.realm(REALM)
                 .users().get(userId).groups().stream()
                 .anyMatch(g -> g.getId().equals(group.getId()))).isTrue();
 
@@ -219,7 +191,7 @@ public class TeamIntegrationTests {
 
         assertThat(result.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
 
-        assertThat(keycloakClient.realm(HOCS_REALM)
+        assertThat(keycloakClient.realm(REALM)
                 .users().get(userId).groups().stream()
                 .anyMatch(g -> g.getId().equals(group.getId()))).isTrue();
     }
@@ -229,7 +201,7 @@ public class TeamIntegrationTests {
     @Transactional
     public void shouldDeleteTeamPermission() {
         String teamId = "434a4e33-437f-4e6d-8f04-14ea40fdbfa2";
-        Set<PermissionDto> permissions = new HashSet<PermissionDto>() {{
+        Set<PermissionDto> permissions = new HashSet<>() {{
             add(new PermissionDto("CT2", AccessLevel.WRITE));
         }};
 
@@ -249,7 +221,7 @@ public class TeamIntegrationTests {
     @Transactional
     public void shouldDeleteOnePermissionForTeam() {
         String teamId = "8b3b4366-a37c-48b6-b274-4c50f8083843";
-        Set<PermissionDto> permissions = new HashSet<PermissionDto>() {{
+        Set<PermissionDto> permissions = new HashSet<>() {{
             add(new PermissionDto("CT3", AccessLevel.WRITE));
         }};
 
@@ -270,7 +242,7 @@ public class TeamIntegrationTests {
         String teamId = "08612f06-bae2-4d2f-90d2-2254a68414b8";
 
         UpdateTeamNameRequest request = new UpdateTeamNameRequest("New Team Name");
-        HttpEntity<UpdateTeamNameRequest> httpEntity = new HttpEntity(request);
+        HttpEntity<UpdateTeamNameRequest> httpEntity = new HttpEntity<>(request);
 
         ResponseEntity<String> result = testRestTemplate.exchange(
                 getBasePath() + "/team/" + teamId
@@ -328,12 +300,13 @@ public class TeamIntegrationTests {
                 getBasePath() + "/teams?unit=" + unitShortCode,
                 HttpMethod.GET,
                 httpEntity,
-                new ParameterizedTypeReference<Set<TeamDto>>() {}
+                new ParameterizedTypeReference<>() {
+                }
         );
 
         Set<TeamDto> teamDtos = result.getBody();
 
-        assertThat(teamDtos.size()).isEqualTo(2);
+        assertThat(teamDtos).hasSize(2);
         assertThat(teamDtos.stream().map(TeamDto::getDisplayName)).noneMatch(el -> el.equals("TEAM_103")
                         || el.equals("TEAM_104")
                         || el.equals("TEAM_102")
@@ -349,15 +322,6 @@ public class TeamIntegrationTests {
 
     private String getBasePath() {
         return "http://localhost:" + port;
-    }
-
-    private void setupKeycloakRealm() throws IOException {
-        RealmResource hocsRealm = keycloakClient.realm(HOCS_REALM);
-
-        PartialImportRepresentation importRealm = mapper.readValue(new File("./keycloak/local-realm.json"), PartialImportRepresentation.class);
-        hocsRealm.groups().groups().stream().forEach(e -> hocsRealm.groups().group(e.getId()).remove());
-        importRealm.setIfResourceExists(PartialImportRepresentation.Policy.OVERWRITE.toString());
-        keycloakClient.realm(HOCS_REALM).partialImport(importRealm);
     }
 
     private MockRestServiceServer buildMockService(RestTemplate restTemplate) {

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/TeamServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/TeamServiceTest.java
@@ -164,36 +164,36 @@ public class TeamServiceTest {
 
         TeamDto teamDto = new TeamDto("Team1", new HashSet<>());
 
-        when(teamRepository.findByUuidOrDisplayName(any(), any())).thenReturn(null);
+        when(teamRepository.findByDisplayName(any())).thenReturn(null);
         when(unitRepository.findByUuid(unit.getUuid())).thenReturn(unit);
 
         Team result = teamService.createTeam(teamDto, unit.getUuid());
 
-        verify(teamRepository, times(1)).findByUuidOrDisplayName(any(), any());
-        verify(unitRepository, times(1)).findByUuid(unit.getUuid());
-        verify(keycloakService, times(1)).createTeamGroupIfNotExists(result.getUuid());
+        verify(teamRepository).findByDisplayName(any());
+        verify(unitRepository).findByUuid(unit.getUuid());
+        verify(keycloakService).createTeamGroupIfNotExists(result.getUuid());
         verifyNoMoreInteractions(teamRepository);
         verifyNoMoreInteractions(keycloakService);
     }
 
     @Test
     public void shouldAddTeamToKeycloakIfTeamExists() {
-
-        Team team = new Team("Team1", true);
+        Team team = new Team("TEAM 4", true);
         Unit unit = new Unit("UNIT1", "UNIT1", true);
         unit.addTeam(team);
 
-        TeamDto teamDto = new TeamDto("Team1", null, team1UUID, true, new HashSet<>(), null);
-        when(teamRepository.findByUuidOrDisplayName(team1UUID, team.getDisplayName())).thenReturn(team);
+        TeamDto teamDto = new TeamDto("TEAM 1", null,
+                UUID.randomUUID(), true, new HashSet<>(), null);
+        when(unitRepository.findByUuid(unit.getUuid())).thenReturn(unit);
 
         try {
             teamService.createTeam(teamDto, unit.getUuid());
         } catch (ApplicationExceptions.EntityAlreadyExistsException e) {
-            assertThat(e.getMessage()).isEqualTo("Team: Team1 already exists.");
+            assertThat(e.getMessage()).isEqualTo("Team: TEAM 4 already exists.");
         }
-        verify(unitRepository, times(1)).findByUuid(unit.getUuid());
+        verify(unitRepository).findByUuid(unit.getUuid());
         verify(unitRepository, never()).save(unit);
-        verify(keycloakService, times(1)).createTeamGroupIfNotExists(team.getUuid());
+        verify(keycloakService).createTeamGroupIfNotExists(any());
         verifyNoMoreInteractions(keycloakService);
     }
 

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/UserServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/UserServiceTest.java
@@ -79,7 +79,7 @@ public class UserServiceTest {
         Team team = new Team("Team1", Boolean.TRUE);
         team.setUnit(unit);
 
-        Set<UserRepresentation> userRepresentations = new HashSet<>();
+        List<UserRepresentation> userRepresentations = new ArrayList<>();
         UserRepresentation user = generateUserRepresentation(1);
         userRepresentations.add(user);
         UserRepresentation user2 = generateUserRepresentation(2);
@@ -99,7 +99,7 @@ public class UserServiceTest {
         Unit unit = new Unit("UNIT ONE", "UNIT1", Boolean.TRUE);
         Team team = new Team("Team1", Boolean.TRUE);
         team.setUnit(unit);
-        Set<UserRepresentation> userRepresentations = new HashSet<>();
+        List<UserRepresentation> userRepresentations = new ArrayList<>();
         UserRepresentation user1 = generateUserRepresentation(1);
         userRepresentations.add(user1);
         UserRepresentation user2 = generateUserRepresentation(2);
@@ -122,7 +122,7 @@ public class UserServiceTest {
         Unit unit = new Unit("UNIT ONE", "UNIT1", Boolean.TRUE);
         Team team = new Team("Team1", Boolean.TRUE);
         team.setUnit(unit);
-        Set<UserRepresentation> userRepresentations = new HashSet<>();
+        List<UserRepresentation> userRepresentations = new ArrayList<>();
         UserRepresentation user1 = generateUserRepresentation(1);
         userRepresentations.add(user1);
         UserRepresentation user2 = generateUserRepresentation(2);
@@ -143,7 +143,7 @@ public class UserServiceTest {
         UUID teamUUID = UUID.randomUUID();
         String stageType = "some-stage-type";
 
-        Set<UserRepresentation> userRepresentations = new HashSet<>();
+        List<UserRepresentation> userRepresentations = new ArrayList<>();
         UserRepresentation user1 = generateUserRepresentation(1);
         userRepresentations.add(user1);
         UserRepresentation user2 = generateUserRepresentation(2);

--- a/src/test/java/uk/gov/digital/ho/hocs/info/security/keycloak/KeycloakServiceIntegrationTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/security/keycloak/KeycloakServiceIntegrationTest.java
@@ -1,0 +1,35 @@
+package uk.gov.digital.ho.hocs.info.security.keycloak;
+
+import org.junit.jupiter.api.Test;
+import org.keycloak.representations.idm.UserRepresentation;
+import uk.gov.digital.ho.hocs.info.domain.model.Team;
+import uk.gov.digital.ho.hocs.info.utils.BaseKeycloakTest;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+public class KeycloakServiceIntegrationTest extends BaseKeycloakTest {
+
+    @Test
+    public void shouldGetAllUsers() {
+        List<UserRepresentation> result = service.getAllUsers();
+
+        assertThat(result).hasSize(110);
+    }
+
+    @Test
+    public void shouldGetAllUsersInTeam() {
+        when(teamRepository.findByUuid(UUID.fromString("00000000-0000-0000-0000-000000000000")))
+                .thenReturn(new Team("", Collections.emptySet()));
+
+        List<UserRepresentation> result = service.getUsersForTeam(
+                UUID.fromString("00000000-0000-0000-0000-000000000000"));
+
+        assertThat(result).hasSize(110);
+    }
+
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/info/utils/BaseKeycloakTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/utils/BaseKeycloakTest.java
@@ -1,0 +1,120 @@
+package uk.gov.digital.ho.hocs.info.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.KeycloakBuilder;
+import org.keycloak.representations.idm.PartialImportRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import uk.gov.digital.ho.hocs.info.domain.repository.TeamRepository;
+import uk.gov.digital.ho.hocs.info.security.KeycloakService;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.keycloak.OAuth2Constants.CLIENT_CREDENTIALS;
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles({"local", "integration"})
+@ContextConfiguration(classes = { BaseKeycloakTest.KeycloakIntegration.class })
+@DirtiesContext(classMode = AFTER_EACH_TEST_METHOD)
+public class BaseKeycloakTest {
+
+    @TestConfiguration
+    static class KeycloakIntegration {
+
+        @Bean("masterKeycloakClient")
+        public Keycloak masterKeycloakClient(@Value("${keycloak.server.url}") String serverUrl,
+                                             @Value("${keycloak.master.realm}") String realm,
+                                             @Value("${keycloak.username}") String username,
+                                             @Value("${keycloak.password}") String password,
+                                             @Value("${keycloak.client.id}") String clientId) {
+            return KeycloakBuilder.builder()
+                    .serverUrl(serverUrl)
+                    .realm(realm)
+                    .clientId(clientId)
+                    .username(username)
+                    .password(password)
+                    .build();
+        }
+
+        @Primary
+        @Bean
+        public Keycloak testKeycloakClient(@Value("${keycloak.server.url}") String serverUrl,
+                                           @Value("${keycloak.integration.realm}") String realm,
+                                           @Value("${keycloak.integration.resource}") String clientId,
+                                           @Value("${keycloak.integration.secret}") String secretKey) {
+            return KeycloakBuilder.builder()
+                    .grantType(CLIENT_CREDENTIALS)
+                    .serverUrl(serverUrl)
+                    .realm(realm)
+                    .clientId(clientId)
+                    .clientSecret(secretKey)
+                    .build();
+        }
+
+    }
+
+    @Autowired
+    @Qualifier("masterKeycloakClient")
+    private Keycloak masterKeycloakClient;
+
+    @Autowired
+    protected Keycloak keycloakClient;
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    @Value("${keycloak.integration.realm}")
+    protected String REALM;
+
+    protected KeycloakService service;
+
+    @Mock
+    protected TeamRepository teamRepository;
+
+    @BeforeEach
+    public void createKeycloakRealm() throws IOException {
+        var realmRep = new RealmRepresentation();
+        realmRep.setId(REALM);
+        realmRep.setRealm(REALM);
+        realmRep.setEnabled(true);
+
+        masterKeycloakClient.realms().create(realmRep);
+
+        loadRealmInformation();
+
+        service = new KeycloakService(teamRepository, keycloakClient, REALM);
+    }
+
+    @AfterEach
+    public void cleardownKeycloakRealm() {
+        masterKeycloakClient.realm(REALM).remove();
+    }
+
+    private void loadRealmInformation() throws IOException {
+        var resourceFile = getClass().getResource("/local-realm-integration.json");
+
+        assert resourceFile != null;
+
+        var file = new File(resourceFile.getFile());
+        var partialImportRep =
+                mapper.readValue(file, PartialImportRepresentation.class);
+        partialImportRep.setIfResourceExists(PartialImportRepresentation.Policy.SKIP.name());
+        masterKeycloakClient.realm(REALM).partialImport(partialImportRep);
+    }
+
+}

--- a/src/test/resources/afterTest.sql
+++ b/src/test/resources/afterTest.sql
@@ -33,7 +33,8 @@ delete from team where unit_uuid in ('09221c48-b916-47df-9aa0-a0194f86f6dd',
                                  '5d153f3b-865d-49d9-a493-baedd241db19',
                                  '5d153f3b-865d-49d9-a493-baedd241db19',
                                  'a95a4e2b-102b-4300-939b-1bb6c69e9989',
-                                 'a95a4e2b-102b-4300-939b-1bb6c69e9989');
+                                 'a95a4e2b-102b-4300-939b-1bb6c69e9989',
+                                 '00000000-0000-0000-0000-000000000000');
 
 delete from case_type where type in ('CT1', 'CT2', 'CT3', 'CT4' );
 
@@ -43,7 +44,8 @@ delete from unit where display_name in ('UNIT 2',
                                         'UNIT 5',
                                         'UNIT 6',
                                         'UNIT_101',
-                                        'UNIT_100'
+                                        'UNIT_100',
+                                        'Integration Unit'
                                        );
 
 delete from correspondent_type where type in ('TEST', 'TEST1', 'TEST2');

--- a/src/test/resources/application-integration.properties
+++ b/src/test/resources/application-integration.properties
@@ -1,1 +1,0 @@
-spring.flyway.enabled=true

--- a/src/test/resources/application-integration.yaml
+++ b/src/test/resources/application-integration.yaml
@@ -1,0 +1,16 @@
+keycloak:
+  master:
+    realm: master
+  integration:
+    realm: integration
+    resource: info-service-client
+    secret: 3cafe5b6-805e-4bcd-a8ef-633fa6a5287f
+  realm: ${keycloak.integration.realm}
+
+spring:
+  flyway:
+    enabled: true
+
+user:
+  email:
+    whitelist: example.com

--- a/src/test/resources/beforeTest.sql
+++ b/src/test/resources/beforeTest.sql
@@ -3,7 +3,8 @@ VALUES ('UNIT 2', '09221c48-b916-47df-9aa0-a0194f86f6dd', 'UNIT2', TRUE),
        ('UNIT 3', '65996106-91a5-44bf-bc92-a6c2f691f062', 'UNIT3', TRUE),
        ('UNIT 4', '10d5b353-a8ed-4530-bcc0-3edab0397d2f', 'UNIT4', TRUE),
        ('UNIT 5', 'c875dca8-8679-47e7-a589-7cea64b2e13c', 'UNIT5', TRUE),
-       ('UNIT 6', '66547972-56c6-4a8c-9bf5-b3debec1344a', 'UNIT6', TRUE);
+       ('UNIT 6', '66547972-56c6-4a8c-9bf5-b3debec1344a', 'UNIT6', TRUE),
+       ('Integration Unit', '00000000-0000-0000-0000-000000000000', 'INT_UNIT', TRUE);
 
 Insert INTO case_type (uuid, display_name, short_code, type, owning_unit_uuid, deadline_stage, active, bulk, previous_case_type, initial_case)
 VALUES ('f62834a0-d231-44c9-bfa1-55dd93fc0aa0','Test Case Type 1', 'z9', 'CT1', '09221c48-b916-47df-9aa0-a0194f86f6dd', 'DISPATCH', true, true, null, true),
@@ -18,7 +19,8 @@ VALUES ('TEAM 4', null, '08612f06-bae2-4d2f-90d2-2254a68414b8', '09221c48-b916-4
        ('TEAM 7', null, '8b3b4366-a37c-48b6-b274-4c50f8083843', '09221c48-b916-47df-9aa0-a0194f86f6dd', TRUE),
        ('TEAM 8', null, '5d584129-66ea-4e97-9277-7576ab1d32c0', '09221c48-b916-47df-9aa0-a0194f86f6dd', TRUE),
        ('TEAM 9', null, '7c33c878-9404-4f67-9bbc-ca52dff285ca', '09221c48-b916-47df-9aa0-a0194f86f6dd', TRUE),
-       ('TEAM 10', null, 'd09f1444-87ec-4197-8ec5-f28f548d11be', '10d5b353-a8ed-4530-bcc0-3edab0397d2f', FALSE);
+       ('TEAM 10', null, 'd09f1444-87ec-4197-8ec5-f28f548d11be', '10d5b353-a8ed-4530-bcc0-3edab0397d2f', FALSE),
+       ('Integration Team', null, '00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000', TRUE);
 
 INSERT INTO stage_type (uuid, display_name, short_code, type, case_type_uuid, acting_team_uuid, deadline,
                         display_stage_order, active)

--- a/src/test/resources/local-realm-integration.json
+++ b/src/test/resources/local-realm-integration.json
@@ -1,0 +1,4658 @@
+{
+  "id": "integration",
+  "realm": "integration",
+  "notBefore": 0,
+  "defaultSignatureAlgorithm": "RS256",
+  "revokeRefreshToken": false,
+  "refreshTokenMaxReuse": 0,
+  "accessTokenLifespan": 300,
+  "accessTokenLifespanForImplicitFlow": 900,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "ssoSessionIdleTimeoutRememberMe": 0,
+  "ssoSessionMaxLifespanRememberMe": 0,
+  "offlineSessionIdleTimeout": 2592000,
+  "offlineSessionMaxLifespanEnabled": false,
+  "offlineSessionMaxLifespan": 5184000,
+  "clientSessionIdleTimeout": 0,
+  "clientSessionMaxLifespan": 0,
+  "clientOfflineSessionIdleTimeout": 0,
+  "clientOfflineSessionMaxLifespan": 0,
+  "accessCodeLifespan": 60,
+  "accessCodeLifespanUserAction": 300,
+  "accessCodeLifespanLogin": 1800,
+  "actionTokenGeneratedByAdminLifespan": 43200,
+  "actionTokenGeneratedByUserLifespan": 300,
+  "oauth2DeviceCodeLifespan": 600,
+  "oauth2DevicePollingInterval": 5,
+  "enabled": true,
+  "sslRequired": "external",
+  "registrationAllowed": false,
+  "registrationEmailAsUsername": false,
+  "rememberMe": false,
+  "verifyEmail": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "permanentLockout": false,
+  "maxFailureWaitSeconds": 900,
+  "minimumQuickLoginWaitSeconds": 60,
+  "waitIncrementSeconds": 60,
+  "quickLoginCheckMilliSeconds": 1000,
+  "maxDeltaTimeSeconds": 43200,
+  "failureFactor": 30,
+  "roles": {
+    "realm": [
+      {
+        "id": "1bf07aee-155c-4c80-b59f-ad20feae46b0",
+        "name": "offline_access",
+        "description": "${role_offline-access}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "integration",
+        "attributes": {}
+      },
+      {
+        "id": "caf01562-f5ca-42d4-9f72-24d194e98e74",
+        "name": "uma_authorization",
+        "description": "${role_uma_authorization}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "integration",
+        "attributes": {}
+      },
+      {
+        "id": "8138f2e0-e408-4ba4-a460-1daa2be94bc6",
+        "name": "default-roles-integration",
+        "description": "${role_default-roles}",
+        "composite": true,
+        "composites": {
+          "realm": [
+            "offline_access",
+            "uma_authorization"
+          ],
+          "client": {
+            "account": [
+              "manage-account",
+              "view-profile"
+            ]
+          }
+        },
+        "clientRole": false,
+        "containerId": "integration",
+        "attributes": {}
+      }
+    ],
+    "client": {
+      "info-service-client": [],
+      "realm-management": [
+        {
+          "id": "9d169213-f398-4e3e-b22d-47c300fa8b62",
+          "name": "query-users",
+          "description": "${role_query-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8d716a4a-2a37-4bb4-88d5-d55aa0f7c46f",
+          "attributes": {}
+        },
+        {
+          "id": "398704b5-9957-4311-bf03-5909153aab5b",
+          "name": "realm-admin",
+          "description": "${role_realm-admin}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-users",
+                "view-clients",
+                "manage-realm",
+                "view-realm",
+                "manage-identity-providers",
+                "view-identity-providers",
+                "manage-clients",
+                "query-realms",
+                "manage-authorization",
+                "query-groups",
+                "view-authorization",
+                "view-users",
+                "impersonation",
+                "manage-events",
+                "view-events",
+                "query-clients",
+                "create-client",
+                "manage-users"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "8d716a4a-2a37-4bb4-88d5-d55aa0f7c46f",
+          "attributes": {}
+        },
+        {
+          "id": "ed1a62e5-269b-4154-aae0-afc90142360c",
+          "name": "view-clients",
+          "description": "${role_view-clients}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-clients"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "8d716a4a-2a37-4bb4-88d5-d55aa0f7c46f",
+          "attributes": {}
+        },
+        {
+          "id": "225c35e3-0425-40d3-89fa-f1554b949d04",
+          "name": "manage-realm",
+          "description": "${role_manage-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8d716a4a-2a37-4bb4-88d5-d55aa0f7c46f",
+          "attributes": {}
+        },
+        {
+          "id": "d6532984-68ac-4d81-9c2e-a95ab8e28b25",
+          "name": "view-realm",
+          "description": "${role_view-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8d716a4a-2a37-4bb4-88d5-d55aa0f7c46f",
+          "attributes": {}
+        },
+        {
+          "id": "2bc26133-8716-4591-b209-02417685609d",
+          "name": "manage-identity-providers",
+          "description": "${role_manage-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8d716a4a-2a37-4bb4-88d5-d55aa0f7c46f",
+          "attributes": {}
+        },
+        {
+          "id": "75ccca60-e3e7-4e94-9720-f029220a3cd1",
+          "name": "view-identity-providers",
+          "description": "${role_view-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8d716a4a-2a37-4bb4-88d5-d55aa0f7c46f",
+          "attributes": {}
+        },
+        {
+          "id": "2b0365d8-26b8-4cd9-b352-33bdbc33b94a",
+          "name": "manage-clients",
+          "description": "${role_manage-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8d716a4a-2a37-4bb4-88d5-d55aa0f7c46f",
+          "attributes": {}
+        },
+        {
+          "id": "1609a093-67c9-44f0-8738-6fcdb944a553",
+          "name": "query-realms",
+          "description": "${role_query-realms}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8d716a4a-2a37-4bb4-88d5-d55aa0f7c46f",
+          "attributes": {}
+        },
+        {
+          "id": "407ca358-bf74-4c8b-9343-ec171f674d41",
+          "name": "manage-authorization",
+          "description": "${role_manage-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8d716a4a-2a37-4bb4-88d5-d55aa0f7c46f",
+          "attributes": {}
+        },
+        {
+          "id": "d31a4a7f-74ed-4e6d-ad34-535702a1f21f",
+          "name": "query-groups",
+          "description": "${role_query-groups}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8d716a4a-2a37-4bb4-88d5-d55aa0f7c46f",
+          "attributes": {}
+        },
+        {
+          "id": "33ebc30b-e71f-4faa-805a-2536a813ab99",
+          "name": "view-authorization",
+          "description": "${role_view-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8d716a4a-2a37-4bb4-88d5-d55aa0f7c46f",
+          "attributes": {}
+        },
+        {
+          "id": "4201a2cb-08a2-4cf7-adc0-b0067e762188",
+          "name": "view-users",
+          "description": "${role_view-users}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-users",
+                "query-groups"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "8d716a4a-2a37-4bb4-88d5-d55aa0f7c46f",
+          "attributes": {}
+        },
+        {
+          "id": "46df8a5a-0fb6-461e-9700-4dc6504c4817",
+          "name": "impersonation",
+          "description": "${role_impersonation}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8d716a4a-2a37-4bb4-88d5-d55aa0f7c46f",
+          "attributes": {}
+        },
+        {
+          "id": "18ad4ab0-e74f-4566-929e-721e713462b4",
+          "name": "manage-events",
+          "description": "${role_manage-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8d716a4a-2a37-4bb4-88d5-d55aa0f7c46f",
+          "attributes": {}
+        },
+        {
+          "id": "63780219-4b44-4f65-a453-ebdbe1abd4da",
+          "name": "view-events",
+          "description": "${role_view-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8d716a4a-2a37-4bb4-88d5-d55aa0f7c46f",
+          "attributes": {}
+        },
+        {
+          "id": "51382c95-3539-4fe1-adbc-de2f1f51fdcc",
+          "name": "query-clients",
+          "description": "${role_query-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8d716a4a-2a37-4bb4-88d5-d55aa0f7c46f",
+          "attributes": {}
+        },
+        {
+          "id": "c1b361b9-8d69-4cc3-9db5-cbf2b872e05e",
+          "name": "create-client",
+          "description": "${role_create-client}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8d716a4a-2a37-4bb4-88d5-d55aa0f7c46f",
+          "attributes": {}
+        },
+        {
+          "id": "dafd6fdd-45b4-41e1-a036-aac392c88029",
+          "name": "manage-users",
+          "description": "${role_manage-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8d716a4a-2a37-4bb4-88d5-d55aa0f7c46f",
+          "attributes": {}
+        }
+      ],
+      "security-admin-console": [],
+      "admin-cli": [],
+      "account-console": [],
+      "broker": [
+        {
+          "id": "00c20970-9a1b-4ad4-81f2-16e290e6d81d",
+          "name": "read-token",
+          "description": "${role_read-token}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5467d9a7-2468-4d11-82b2-219e35c50882",
+          "attributes": {}
+        }
+      ],
+      "account": [
+        {
+          "id": "77eedd7c-5238-4787-b699-9e334993128b",
+          "name": "manage-account-links",
+          "description": "${role_manage-account-links}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "b8ec1d55-d94d-4628-afdc-a2fccfae6d78",
+          "attributes": {}
+        },
+        {
+          "id": "2394e72f-5ee8-4fc8-83ce-0a86c969dbf9",
+          "name": "view-consent",
+          "description": "${role_view-consent}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "b8ec1d55-d94d-4628-afdc-a2fccfae6d78",
+          "attributes": {}
+        },
+        {
+          "id": "ae84006d-36ae-4723-b962-59e0e7a02e8b",
+          "name": "delete-account",
+          "description": "${role_delete-account}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "b8ec1d55-d94d-4628-afdc-a2fccfae6d78",
+          "attributes": {}
+        },
+        {
+          "id": "c2797380-967f-46bb-8e7e-871eb6930bd4",
+          "name": "manage-account",
+          "description": "${role_manage-account}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": [
+                "manage-account-links"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "b8ec1d55-d94d-4628-afdc-a2fccfae6d78",
+          "attributes": {}
+        },
+        {
+          "id": "dbac947c-480e-4351-badf-5c2b05ad1857",
+          "name": "manage-consent",
+          "description": "${role_manage-consent}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": [
+                "view-consent"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "b8ec1d55-d94d-4628-afdc-a2fccfae6d78",
+          "attributes": {}
+        },
+        {
+          "id": "0136b789-5aeb-471c-8306-8482b513ec33",
+          "name": "view-applications",
+          "description": "${role_view-applications}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "b8ec1d55-d94d-4628-afdc-a2fccfae6d78",
+          "attributes": {}
+        },
+        {
+          "id": "ce81a580-bd0b-4a91-9c36-249cfaa21ba0",
+          "name": "view-profile",
+          "description": "${role_view-profile}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "b8ec1d55-d94d-4628-afdc-a2fccfae6d78",
+          "attributes": {}
+        }
+      ]
+    }
+  },
+  "groups" : [
+    {
+      "id": "f359ecd6-9690-44cb-ab93-20c53e5d606c",
+      "name": "AAAAAAAAAAAAAAAAAAAAAA",
+      "path": "/AAAAAAAAAAAAAAAAAAAAAA",
+      "attributes": {},
+      "realmRoles": [],
+      "clientRoles": {},
+      "subGroups": []
+    }
+  ],
+  "defaultRole": {
+    "id": "8138f2e0-e408-4ba4-a460-1daa2be94bc6",
+    "name": "default-roles-integration",
+    "description": "${role_default-roles}",
+    "composite": true,
+    "clientRole": false,
+    "containerId": "integration"
+  },
+  "requiredCredentials": [
+    "password"
+  ],
+  "otpPolicyType": "totp",
+  "otpPolicyAlgorithm": "HmacSHA1",
+  "otpPolicyInitialCounter": 0,
+  "otpPolicyDigits": 6,
+  "otpPolicyLookAheadWindow": 1,
+  "otpPolicyPeriod": 30,
+  "otpSupportedApplications": [
+    "FreeOTP",
+    "Google Authenticator"
+  ],
+  "webAuthnPolicyRpEntityName": "keycloak",
+  "webAuthnPolicySignatureAlgorithms": [
+    "ES256"
+  ],
+  "webAuthnPolicyRpId": "",
+  "webAuthnPolicyAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyRequireResidentKey": "not specified",
+  "webAuthnPolicyUserVerificationRequirement": "not specified",
+  "webAuthnPolicyCreateTimeout": 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyAcceptableAaguids": [],
+  "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms": [
+    "ES256"
+  ],
+  "webAuthnPolicyPasswordlessRpId": "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout": 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+  "users": [
+    {
+      "id": "7f764aeb-5cf7-49a1-9a66-b013ee4c17da",
+      "createdTimestamp": 1655204051927,
+      "username": "service-account-info-service-client",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "serviceAccountClientId": "info-service-client",
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "default-roles-integration"
+      ],
+      "clientRoles": {
+        "info-service-client": [
+          "uma_protection"
+        ],
+        "realm-management": [
+          "realm-admin"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ ]
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000000",
+      "createdTimestamp": 1655204051927,
+      "username": "integration-test@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "dfceee74-120e-e421-6f1e-1d49c687dca4",
+      "createdTimestamp": 1655204051927,
+      "username": "nFEjWvywVQN@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "45303e0f-8c9f-ef84-75ec-a1307e19ddc4",
+      "createdTimestamp": 1655204051927,
+      "username": "YbgTDiXfw@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "ae9fafbd-8da8-04c9-5e83-5bd02317208b",
+      "createdTimestamp": 1655204051927,
+      "username": "lN@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "22af2fef-a69d-1006-fdd7-37720dc2a4a2",
+      "createdTimestamp": 1655204051927,
+      "username": "FnEzFQTtBgv@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "13450ff5-1ba8-afe3-546e-9bba77c60ba4",
+      "createdTimestamp": 1655204051927,
+      "username": "LH@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "6bdaf9b3-337b-2eee-66b9-d145224dd379",
+      "createdTimestamp": 1655204051927,
+      "username": "lEB@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "60061fa4-406a-b179-7dbb-fa9a6ac54f41",
+      "createdTimestamp": 1655204051927,
+      "username": "uLfXsS@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "ba6cf3b3-4a70-016e-ceae-d65712953151",
+      "createdTimestamp": 1655204051927,
+      "username": "rWTL@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "4bb99899-2b73-d045-7fbb-f8bc98b0847e",
+      "createdTimestamp": 1655204051927,
+      "username": "zZ@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "6c0a4c4d-395f-5996-70db-3e90ce8aa896",
+      "createdTimestamp": 1655204051927,
+      "username": "cWJq@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "ac614314-8186-8d39-67b7-ecc3555a4c65",
+      "createdTimestamp": 1655204051927,
+      "username": "wsEEBbzhb@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "d1707e9a-f3f5-48cb-726e-75b5cf15fccc",
+      "createdTimestamp": 1655204051927,
+      "username": "T@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "3a88fd8d-9958-26c3-5596-930e07f166c9",
+      "createdTimestamp": 1655204051927,
+      "username": "CPKKGP@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "90e62687-8fc7-2ecb-1ae7-88fd287e40e5",
+      "createdTimestamp": 1655204051927,
+      "username": "HJmqBFpVRH@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "cb774c33-ed49-7903-d051-d5aef4c0133e",
+      "createdTimestamp": 1655204051927,
+      "username": "K@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "2da37d87-bb6a-fe67-eba1-175a31222e17",
+      "createdTimestamp": 1655204051927,
+      "username": "snyg@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "5ba9fc23-64c8-e43b-ce19-f6153b2da1af",
+      "createdTimestamp": 1655204051927,
+      "username": "BdCIHy@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "396758e8-9c27-0932-7bde-b87ae743eedd",
+      "createdTimestamp": 1655204051927,
+      "username": "jR@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "92234f0d-b9c2-c555-4d39-6f93e7ffe779",
+      "createdTimestamp": 1655204051927,
+      "username": "TjwpdHdBIYF@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "4376af1c-44a8-3c56-3a92-77aa43a59c59",
+      "createdTimestamp": 1655204051927,
+      "username": "VRswD@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "c0ba8ea5-6744-49e7-0714-b302012e28d7",
+      "createdTimestamp": 1655204051927,
+      "username": "CxfFnWCb@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "1e7be73b-4e40-8717-eee7-097e797382c3",
+      "createdTimestamp": 1655204051927,
+      "username": "gvOz@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "7ae43a27-f19c-f2b3-9073-fb8af5aaf150",
+      "createdTimestamp": 1655204051927,
+      "username": "BbyJSj@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "ba3982a9-ad08-366f-7512-3d162b4e3038",
+      "createdTimestamp": 1655204051927,
+      "username": "JeK@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "6a05cfda-02c6-956b-405e-21de76245638",
+      "createdTimestamp": 1655204051927,
+      "username": "cEec@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "0d1bda8e-0c5f-830f-e2ea-803e3ce20544",
+      "createdTimestamp": 1655204051927,
+      "username": "jibtbfNGLr@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "ab6155cc-8f72-4ff7-a34f-3b6f88407c7c",
+      "createdTimestamp": 1655204051927,
+      "username": "qroBeXVWho@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "9a503ec7-22e9-b65c-4eb4-d31122344b35",
+      "createdTimestamp": 1655204051927,
+      "username": "ast@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "73c2ec2e-6bc4-8989-af67-f7ce8fae1783",
+      "createdTimestamp": 1655204051927,
+      "username": "keUXRh@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "ec79516e-579e-0ecf-feca-4fdf47d10816",
+      "createdTimestamp": 1655204051927,
+      "username": "HXY@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "f67868cd-46d8-a611-9059-c16e5dc92be0",
+      "createdTimestamp": 1655204051927,
+      "username": "shaTBZX@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "13c2e497-ff94-1770-45a8-dcbca5db0c7d",
+      "createdTimestamp": 1655204051927,
+      "username": "sE@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "e1463f34-d8ca-e12b-c041-9d8e7a3788a8",
+      "createdTimestamp": 1655204051927,
+      "username": "ZWFjpfeh@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "36ea849d-f765-e867-6e93-8efee3e0b863",
+      "createdTimestamp": 1655204051927,
+      "username": "xaog@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "b0aa88a9-38ab-7a71-4f9b-bcaaddccf24c",
+      "createdTimestamp": 1655204051927,
+      "username": "ulxpRobC@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "85e22cc6-f0db-dffc-0628-77739b5c7342",
+      "createdTimestamp": 1655204051927,
+      "username": "QSXqoqh@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "8d4384be-a661-1ea6-1812-76f1a8621e13",
+      "createdTimestamp": 1655204051927,
+      "username": "eOeaZ@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "9e2825b4-6d05-2763-5c11-59ad64e58942",
+      "createdTimestamp": 1655204051927,
+      "username": "NIT@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "7568eeaa-cf1e-4f9f-cfcc-b53eb6ce51db",
+      "createdTimestamp": 1655204051927,
+      "username": "hsHOBKTrKvc@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "31a88159-f6f4-c66b-ade8-bba88fa2ccdc",
+      "createdTimestamp": 1655204051927,
+      "username": "S@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "888ce776-5faa-985b-9223-3ec148867f63",
+      "createdTimestamp": 1655204051927,
+      "username": "FqwBVnQoN@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "ed23b08f-046d-7939-bff5-718ef4c4f88f",
+      "createdTimestamp": 1655204051927,
+      "username": "uG@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "a2157100-1c5b-700e-2d78-3b12ab2545cf",
+      "createdTimestamp": 1655204051927,
+      "username": "hAhnRuIZ@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "ea138475-f8b4-76b5-c46f-96886c54b735",
+      "createdTimestamp": 1655204051927,
+      "username": "Tea@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "5bc652b9-b62f-ff2c-dbcd-f57c42eecf37",
+      "createdTimestamp": 1655204051927,
+      "username": "HelNPkEY@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "efe61f7f-12d6-bd1e-a417-f033cc714ebe",
+      "createdTimestamp": 1655204051927,
+      "username": "dQdqASfCTcd@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "3e79914b-3b39-45b8-5300-73b7b72fda96",
+      "createdTimestamp": 1655204051927,
+      "username": "nvSYqOjhKc@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "6ab213bd-5db3-379c-5385-c3994662e51e",
+      "createdTimestamp": 1655204051927,
+      "username": "nJaDy@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "85b0e479-e8a2-0504-051c-9a9cb89b69e1",
+      "createdTimestamp": 1655204051927,
+      "username": "loKvP@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "b48085b0-06cc-bb6f-6fcf-7ec486977be6",
+      "createdTimestamp": 1655204051927,
+      "username": "jxvAl@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "7edff883-4b62-2ae6-1fbe-71e62763ff69",
+      "createdTimestamp": 1655204051927,
+      "username": "VUCYV@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "f5d79f35-7d1a-29c3-98f4-f6fa7a7926f4",
+      "createdTimestamp": 1655204051927,
+      "username": "mVzZ@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "646189d8-a186-f781-9eda-657a0886ef55",
+      "createdTimestamp": 1655204051927,
+      "username": "U@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "c2b7ad42-bfb1-eb2a-1ab9-0c17b04960b0",
+      "createdTimestamp": 1655204051927,
+      "username": "UWbBKRPsl@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "e1c4c809-6a62-e55d-5f77-dc46f7fe56e1",
+      "createdTimestamp": 1655204051927,
+      "username": "swQKTVeDbvD@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "1ecb8c0d-eb65-ebd0-60fc-3a71ea4f296f",
+      "createdTimestamp": 1655204051927,
+      "username": "nSKcmOVVm@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "b34b41ab-3a5f-703f-2f0c-56bd23fe8506",
+      "createdTimestamp": 1655204051927,
+      "username": "HyGBGcA@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "7811709f-3869-211d-7703-536300500eae",
+      "createdTimestamp": 1655204051927,
+      "username": "vao@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "5b39b228-c67d-2f4d-b542-b0c1689db2d9",
+      "createdTimestamp": 1655204051927,
+      "username": "lPNzXIp@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "ec744b76-04cb-7de8-bb9b-9e1cf0d9b430",
+      "createdTimestamp": 1655204051927,
+      "username": "DloI@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "21c45994-ea71-c551-3c13-928aa75f5024",
+      "createdTimestamp": 1655204051927,
+      "username": "VOTIxHGGXn@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "415696d5-fd67-706b-ff75-8785505e898a",
+      "createdTimestamp": 1655204051927,
+      "username": "pnZaq@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "b6715eb1-3cea-8697-f7d9-fe1babaae0d7",
+      "createdTimestamp": 1655204051927,
+      "username": "BVK@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "b536f373-74c4-9646-d35f-e3d1509a01d2",
+      "createdTimestamp": 1655204051927,
+      "username": "eXiGFWnRWBe@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "5a0d271a-0fc0-4ba7-2d57-be012f8a4ff5",
+      "createdTimestamp": 1655204051927,
+      "username": "M@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "847577e3-0c7a-9058-2d48-7dcc23167bf2",
+      "createdTimestamp": 1655204051927,
+      "username": "nZr@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "626e1765-80ca-f294-2d11-f83e5d2aa257",
+      "createdTimestamp": 1655204051927,
+      "username": "bGKvnH@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "2bfc21d0-199c-0c41-489d-f67535a086e9",
+      "createdTimestamp": 1655204051927,
+      "username": "dl@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "8fc83683-80a7-3c97-3fa4-aca8c21ad3e6",
+      "createdTimestamp": 1655204051927,
+      "username": "KHfzOfjVwD@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "c5476167-a906-d677-e19b-42df74026fb2",
+      "createdTimestamp": 1655204051927,
+      "username": "F@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "01cfa8d3-54dd-ac41-d024-b57f52d08226",
+      "createdTimestamp": 1655204051927,
+      "username": "e@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "d9c08c36-23da-092d-5960-d0a217c6d00a",
+      "createdTimestamp": 1655204051927,
+      "username": "iQ@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "254d7724-ac8e-27a9-1f52-e144c94d0ab3",
+      "createdTimestamp": 1655204051927,
+      "username": "OOlENlq@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "bd8a27b8-8b06-f40a-97ef-f2de0b2833b2",
+      "createdTimestamp": 1655204051927,
+      "username": "abNa@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "0b0d559c-3ab1-cbbb-d5df-acc02b605ed6",
+      "createdTimestamp": 1655204051927,
+      "username": "Fi@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "58305bab-6ff4-e0f9-f531-a42892afa1c5",
+      "createdTimestamp": 1655204051927,
+      "username": "mZKK@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "26f4d431-6686-978f-42c2-be3fc374333e",
+      "createdTimestamp": 1655204051927,
+      "username": "TxAfa@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "cfc19941-a2b7-c964-c398-b3b8ee9ad287",
+      "createdTimestamp": 1655204051927,
+      "username": "wN@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "3ff78f70-da43-dcaf-9ef4-60d93c9fd658",
+      "createdTimestamp": 1655204051927,
+      "username": "cNkJaTZ@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "41efdae0-bb66-1854-3e73-d15c0afa4d83",
+      "createdTimestamp": 1655204051927,
+      "username": "RPZ@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "142d4ea1-e542-b3aa-0980-f6139736a132",
+      "createdTimestamp": 1655204051927,
+      "username": "VNuLMv@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "1f1dc269-11cb-0442-1856-d01d0af641cf",
+      "createdTimestamp": 1655204051927,
+      "username": "KsFQext@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "6073b794-6bbd-b0f8-3b94-a22d6aef3d91",
+      "createdTimestamp": 1655204051927,
+      "username": "RbVQWJMpqF@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "f9255a14-6755-7e0d-2a24-c2fd08a9a29c",
+      "createdTimestamp": 1655204051927,
+      "username": "Jyj@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "c62ee714-85f3-b331-cc30-73c92b70b639",
+      "createdTimestamp": 1655204051927,
+      "username": "IrP@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "8fa4d9e3-5f82-1973-6b5e-1efa461b151e",
+      "createdTimestamp": 1655204051927,
+      "username": "LE@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "57ccdd71-0680-1cea-1956-961a7350492f",
+      "createdTimestamp": 1655204051927,
+      "username": "Tpsam@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "739304e3-bc56-6ca4-d4a8-13d501f98a41",
+      "createdTimestamp": 1655204051927,
+      "username": "oQRtj@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "c4bcd8b0-e1c1-f895-e318-ba786eb6ec42",
+      "createdTimestamp": 1655204051927,
+      "username": "CkF@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "2ce39b0f-880d-e73f-a0a0-04c6ae75cba8",
+      "createdTimestamp": 1655204051927,
+      "username": "RsYPFxFoilE@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "4fb20642-eae7-4fca-d640-3ed156d58ad8",
+      "createdTimestamp": 1655204051927,
+      "username": "TNxYerUwT@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "13a6d7e8-5fee-7b2d-01e9-f8d698e4af58",
+      "createdTimestamp": 1655204051927,
+      "username": "ukzj@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "d084e5d2-cbd1-d6b8-daaa-a7086e4a384e",
+      "createdTimestamp": 1655204051927,
+      "username": "FRKvpncp@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "e24bb47c-ecc0-3def-83ee-af75c3336176",
+      "createdTimestamp": 1655204051927,
+      "username": "LF@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "5e62c6b6-f15b-0387-56d8-5771b38d1855",
+      "createdTimestamp": 1655204051927,
+      "username": "OElgjITYv@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "d44b4179-8d2b-7fe5-756f-3ae82df6af9f",
+      "createdTimestamp": 1655204051927,
+      "username": "VSR@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "0315b935-b74d-9a82-f5eb-23f1ce230b5e",
+      "createdTimestamp": 1655204051927,
+      "username": "bUF@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "ce3cd227-1edc-f9c9-b9f4-680013de963a",
+      "createdTimestamp": 1655204051927,
+      "username": "HUFvJeTjlY@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "e6f8f935-7f55-de13-c661-c9ba503ce2f7",
+      "createdTimestamp": 1655204051927,
+      "username": "QILvvQX@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "a9d84a13-f864-4629-dd6d-ed5c3f7140dd",
+      "createdTimestamp": 1655204051927,
+      "username": "xuVuh@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "ef77022a-dac3-4a37-ed35-e9f462d1b3d7",
+      "createdTimestamp": 1655204051927,
+      "username": "svo@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "c1a80485-efc0-74f6-3c85-320862a57c5a",
+      "createdTimestamp": 1655204051927,
+      "username": "GsulGj@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "914e64bd-7e08-4cc5-fb3e-93d58e68b15b",
+      "createdTimestamp": 1655204051927,
+      "username": "GiXWrv@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "b888da69-d262-b20d-5387-db2ac0f83b46",
+      "createdTimestamp": 1655204051927,
+      "username": "nMGbyaMPFZE@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "5bf32ee5-1f29-b171-9df5-19217342cf0b",
+      "createdTimestamp": 1655204051927,
+      "username": "yxkQdzqsq@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "bfafdf6a-34dd-bf86-87e5-6022cc10d30a",
+      "createdTimestamp": 1655204051927,
+      "username": "BFqFZG@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "dd9bc899-648c-8f51-5af8-9f44a593326f",
+      "createdTimestamp": 1655204051927,
+      "username": "FIeGN@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "b4576078-b915-cd9b-38ac-2e75a237ef0b",
+      "createdTimestamp": 1655204051927,
+      "username": "ccXUytrt@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    },
+    {
+      "id": "554dfd9b-65af-e717-ed16-54a0535b6911",
+      "createdTimestamp": 1655204051927,
+      "username": "CodxNBZN@example.com",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups" : [ "/AAAAAAAAAAAAAAAAAAAAAA" ]
+    }
+  ],
+  "scopeMappings": [
+    {
+      "clientScope": "offline_access",
+      "roles": [
+        "offline_access"
+      ]
+    }
+  ],
+  "clientScopeMappings": {
+    "account": [
+      {
+        "client": "account-console",
+        "roles": [
+          "manage-account"
+        ]
+      }
+    ]
+  },
+  "clients": [
+    {
+      "id": "b8ec1d55-d94d-4628-afdc-a2fccfae6d78",
+      "clientId": "account",
+      "name": "${client_account}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/integration/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/realms/integration/account/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {},
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "ec4101e1-4c75-4c7c-858d-d57fa73bf45a",
+      "clientId": "account-console",
+      "name": "${client_account-console}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/integration/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/realms/integration/account/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "5da390e3-7e97-425f-aeb6-bba83b7a0a0a",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "c76fac7c-9c9e-40ab-b821-8ea4e8a02b65",
+      "clientId": "admin-cli",
+      "name": "${client_admin-cli}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {},
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "5467d9a7-2468-4d11-82b2-219e35c50882",
+      "clientId": "broker",
+      "name": "${client_broker}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {},
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "9f3f7f8a-0c91-4d0f-834b-5fbba5a1d696",
+      "clientId": "info-service-client",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "3cafe5b6-805e-4bcd-a8ef-633fa6a5287f",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "id.token.as.detached.signature": "false",
+        "saml.assertion.signature": "false",
+        "saml.force.post.binding": "false",
+        "saml.multivalued.roles": "false",
+        "saml.encrypt": "false",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "backchannel.logout.revoke.offline.tokens": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "use.refresh.tokens": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "saml.artifact.binding": "false",
+        "backchannel.logout.session.required": "false",
+        "client_credentials.use_refresh_token": "false",
+        "saml_force_name_id_format": "false",
+        "require.pushed.authorization.requests": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "1cadb8b6-f7c4-49b0-8893-56405920c247",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "01e77c85-e964-4cdd-bcd1-e69d2d65f5a4",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "94d5ee50-07db-498f-9f0d-7370bcebac72",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "8d716a4a-2a37-4bb4-88d5-d55aa0f7c46f",
+      "clientId": "realm-management",
+      "name": "${client_realm-management}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {},
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "3b7ba327-31e9-4058-b9e8-4b4dd4199153",
+      "clientId": "security-admin-console",
+      "name": "${client_security-admin-console}",
+      "rootUrl": "${authAdminUrl}",
+      "baseUrl": "/admin/integration/console/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/admin/integration/console/*"
+      ],
+      "webOrigins": [
+        "+"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "8e5e8e15-7965-4fc2-9b85-b1a687405924",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    }
+  ],
+  "clientScopes": [
+    {
+      "id": "7f9699ac-f06f-46a0-a369-440d967390c4",
+      "name": "address",
+      "description": "OpenID Connect built-in scope: address",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${addressScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "37271949-1326-42d7-9e00-5ccedce5005e",
+          "name": "address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-address-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute.formatted": "formatted",
+            "user.attribute.country": "country",
+            "user.attribute.postal_code": "postal_code",
+            "userinfo.token.claim": "true",
+            "user.attribute.street": "street",
+            "id.token.claim": "true",
+            "user.attribute.region": "region",
+            "access.token.claim": "true",
+            "user.attribute.locality": "locality"
+          }
+        }
+      ]
+    },
+    {
+      "id": "29faa568-37a7-4453-a175-7e8f4281c46e",
+      "name": "role_list",
+      "description": "SAML role list",
+      "protocol": "saml",
+      "attributes": {
+        "consent.screen.text": "${samlRoleListScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "468147c8-08b8-4f86-add1-55017b9d3ba8",
+          "name": "role list",
+          "protocol": "saml",
+          "protocolMapper": "saml-role-list-mapper",
+          "consentRequired": false,
+          "config": {
+            "single": "false",
+            "attribute.nameformat": "Basic",
+            "attribute.name": "Role"
+          }
+        }
+      ]
+    },
+    {
+      "id": "7aab0a7f-2ce4-495f-aa3a-2be260025af0",
+      "name": "web-origins",
+      "description": "OpenID Connect scope for add allowed web origins to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false",
+        "consent.screen.text": ""
+      },
+      "protocolMappers": [
+        {
+          "id": "60010119-b9a8-4114-8c3d-8fc9b530ba50",
+          "name": "allowed web origins",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-allowed-origins-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ]
+    },
+    {
+      "id": "a5bb403c-4400-41d9-969f-b99aed8ca17a",
+      "name": "phone",
+      "description": "OpenID Connect built-in scope: phone",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${phoneScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "4d1aa072-e092-4952-9f81-d57416ed0e2a",
+          "name": "phone number",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumber",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "def7de6e-5929-4fae-9a14-2b4b52d54bd0",
+          "name": "phone number verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumberVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number_verified",
+            "jsonType.label": "boolean"
+          }
+        }
+      ]
+    },
+    {
+      "id": "d97cf28b-6c37-4cf3-a4a7-e1dbf7fcbead",
+      "name": "profile",
+      "description": "OpenID Connect built-in scope: profile",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${profileScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "fb7e7936-b845-4845-bd26-d19addd5049f",
+          "name": "middle name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "middleName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "middle_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "a7a4d919-d9ec-412d-847b-f1d96b3131b3",
+          "name": "gender",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "gender",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "gender",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "fa0e480b-99c8-47ff-8738-3f489bb433d0",
+          "name": "nickname",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "nickname",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "nickname",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "f2812912-f240-4aae-84d7-5fb33ef5c179",
+          "name": "profile",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "profile",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "profile",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "293a33ac-2480-40e7-9f14-8b142fb23057",
+          "name": "picture",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "picture",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "picture",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "54fcc5bd-29db-472a-bb4e-9c60584ce513",
+          "name": "birthdate",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "birthdate",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "birthdate",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "364d9f4c-bdff-4888-94af-736481a51420",
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "lastName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "family_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "fd77ceee-a0be-4497-9a31-a5b55fc3ea56",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "af6982d9-fe7f-40c0-adaf-43341b1fa20d",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "fe75a63e-b65b-41ce-921f-d13ec1866d88",
+          "name": "zoneinfo",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "zoneinfo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "zoneinfo",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "8234bfca-d060-43f2-b5b5-d33d8c0b3292",
+          "name": "updated at",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "updatedAt",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "updated_at",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "e867d7fd-cd23-4021-a2ca-9d123d53296d",
+          "name": "website",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "website",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "website",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "cfb72cb8-e7ab-4fae-9b97-2c763df9f263",
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "4f76fcdb-5b86-4782-bd7c-1ea0a793a34a",
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "firstName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "given_name",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "cd1dea75-58b2-4378-9155-7ef43cc3c9f3",
+      "name": "microprofile-jwt",
+      "description": "Microprofile - JWT built-in scope",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "024734b9-aa28-4524-8684-77cc7a84e9ae",
+          "name": "upn",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "upn",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "c4a7eac6-0347-4c75-8e0c-d80579cad9f5",
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "multivalued": "true",
+            "user.attribute": "foo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "88890b28-f332-4fd9-b58f-6100bf63e6b0",
+      "name": "email",
+      "description": "OpenID Connect built-in scope: email",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${emailScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "b1ac9864-a355-4839-b870-f2bf11887c00",
+          "name": "email verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "emailVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email_verified",
+            "jsonType.label": "boolean"
+          }
+        },
+        {
+          "id": "50a443a6-5813-4d62-b8e6-b8848b4a1439",
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "428e259a-cdd9-4d74-a90e-93b1e36b5124",
+      "name": "roles",
+      "description": "OpenID Connect scope for add user roles to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${rolesScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "ce23e012-53e1-4f41-9fd1-259a19d7ce54",
+          "name": "client roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-client-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "access.token.claim": "true",
+            "claim.name": "resource_access.${client_id}.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        },
+        {
+          "id": "8c5d5a86-e40c-4b32-bcc4-173f5adb1619",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {}
+        },
+        {
+          "id": "a16ad98b-28aa-4980-821c-a17590dd220c",
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "access.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "9db2d10d-6170-46ba-99df-51a838663179",
+      "name": "offline_access",
+      "description": "OpenID Connect built-in scope: offline_access",
+      "protocol": "openid-connect",
+      "attributes": {
+        "consent.screen.text": "${offlineAccessScopeConsentText}",
+        "display.on.consent.screen": "true"
+      }
+    }
+  ],
+  "defaultDefaultClientScopes": [
+    "role_list",
+    "roles",
+    "web-origins",
+    "email",
+    "profile"
+  ],
+  "defaultOptionalClientScopes": [
+    "address",
+    "offline_access",
+    "phone",
+    "microprofile-jwt"
+  ],
+  "browserSecurityHeaders": {
+    "contentSecurityPolicyReportOnly": "",
+    "xContentTypeOptions": "nosniff",
+    "xRobotsTag": "none",
+    "xFrameOptions": "SAMEORIGIN",
+    "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "xXSSProtection": "1; mode=block",
+    "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer": {},
+  "eventsEnabled": false,
+  "eventsListeners": [
+    "jboss-logging"
+  ],
+  "enabledEventTypes": [],
+  "adminEventsEnabled": false,
+  "adminEventsDetailsEnabled": false,
+  "identityProviders": [],
+  "identityProviderMappers": [],
+  "components": {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
+      {
+        "id": "46702c93-3490-479a-9d6e-da32a777214d",
+        "name": "Consent Required",
+        "providerId": "consent-required",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "2c68225e-af07-4e34-abe0-7e404626368c",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "f90a0b2e-fde4-4886-9f27-fcc72754cf8a",
+        "name": "Full Scope Disabled",
+        "providerId": "scope",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "8e753621-6064-4afc-bcd9-8971abda584a",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "oidc-address-mapper",
+            "saml-role-list-mapper",
+            "saml-user-property-mapper",
+            "oidc-full-name-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "saml-user-attribute-mapper",
+            "oidc-usermodel-property-mapper",
+            "oidc-sha256-pairwise-sub-mapper"
+          ]
+        }
+      },
+      {
+        "id": "bac20b9a-c0d0-431c-b2e4-e8d321b021ad",
+        "name": "Max Clients Limit",
+        "providerId": "max-clients",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "max-clients": [
+            "200"
+          ]
+        }
+      },
+      {
+        "id": "199b514c-9082-4f4f-96b3-2f8d019857f1",
+        "name": "Trusted Hosts",
+        "providerId": "trusted-hosts",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "host-sending-registration-request-must-match": [
+            "true"
+          ],
+          "client-uris-must-match": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "d4299322-f5a0-4f37-b905-47460ad64317",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "19a825bb-826a-4bd9-afa2-4d2810a9a603",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "oidc-usermodel-attribute-mapper",
+            "oidc-address-mapper",
+            "oidc-full-name-mapper",
+            "saml-role-list-mapper",
+            "oidc-usermodel-property-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "saml-user-attribute-mapper",
+            "saml-user-property-mapper"
+          ]
+        }
+      }
+    ],
+    "org.keycloak.keys.KeyProvider": [
+      {
+        "id": "a74d6593-6f5d-468f-ac0e-1e5be4adfd0d",
+        "name": "hmac-generated",
+        "providerId": "hmac-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ],
+          "algorithm": [
+            "HS256"
+          ]
+        }
+      },
+      {
+        "id": "0672f212-3802-4d91-aaa0-5f94a812c42e",
+        "name": "aes-generated",
+        "providerId": "aes-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ]
+        }
+      },
+      {
+        "id": "29d09831-125b-4f40-bd10-4ee767308d64",
+        "name": "rsa-generated",
+        "providerId": "rsa-generated",
+        "subComponents": {},
+        "config": {
+          "keyUse": [
+            "sig"
+          ],
+          "priority": [
+            "100"
+          ]
+        }
+      },
+      {
+        "id": "f8554707-b44d-4523-9d6b-8f75412470ae",
+        "name": "rsa-enc-generated",
+        "providerId": "rsa-generated",
+        "subComponents": {},
+        "config": {
+          "keyUse": [
+            "enc"
+          ],
+          "priority": [
+            "100"
+          ]
+        }
+      }
+    ]
+  },
+  "internationalizationEnabled": false,
+  "supportedLocales": [],
+  "authenticationFlows": [
+    {
+      "id": "fb1e9e1a-f4b6-4f65-b9f4-35daa0a8b3b7",
+      "alias": "Account verification options",
+      "description": "Method with which to verity the existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-email-verification",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "flowAlias": "Verify Existing Account by Re-authentication",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "f14cab0a-5543-486f-b76d-30e7724e4967",
+      "alias": "Authentication Options",
+      "description": "Authentication options.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "basic-auth",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "basic-auth-otp",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-spnego",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 30,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "fc260a34-e579-45f0-aa5c-b4d98a7d2dee",
+      "alias": "Browser - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "d1726ccb-417e-4185-a9b7-69eecbadffe0",
+      "alias": "Direct Grant - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "direct-grant-validate-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "6fb09a10-9000-48a2-b98d-89c201625f7f",
+      "alias": "First broker login - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "7cc02f83-1aa0-4c28-8d7c-5006cf9e1c4f",
+      "alias": "Handle Existing Account",
+      "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-confirm-link",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "flowAlias": "Account verification options",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "c5fa6209-765d-4337-8954-bb3125db91e1",
+      "alias": "Reset - Conditional OTP",
+      "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "reset-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "4b7793ac-03de-49ad-be77-407cabd03e68",
+      "alias": "User creation or linking",
+      "description": "Flow for the existing/non-existing user alternatives",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "create unique user config",
+          "authenticator": "idp-create-user-if-unique",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "flowAlias": "Handle Existing Account",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "35a7fe45-f644-4eb0-9eea-a85450cd36b7",
+      "alias": "Verify Existing Account by Re-authentication",
+      "description": "Reauthentication of existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "flowAlias": "First broker login - Conditional OTP",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "1fc148b1-052d-41d7-8794-643e7b3b0b11",
+      "alias": "browser",
+      "description": "browser based authentication",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-cookie",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-spnego",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "identity-provider-redirector",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 25,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "flowAlias": "forms",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "0f7d7754-00c8-43f1-b81f-0c678d8aaa10",
+      "alias": "clients",
+      "description": "Base authentication for clients",
+      "providerId": "client-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "client-secret",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "client-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "client-secret-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "client-x509",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 40,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "ec830f0c-68b7-4789-abee-f7bfab9e60ef",
+      "alias": "direct grant",
+      "description": "OpenID Connect Resource Owner Grant",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "direct-grant-validate-username",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "direct-grant-validate-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 30,
+          "flowAlias": "Direct Grant - Conditional OTP",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "4b3080d8-86da-403d-b8bb-469c0174df5f",
+      "alias": "docker auth",
+      "description": "Used by Docker clients to authenticate against the IDP",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "docker-http-basic-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "df0a0728-492f-4c2b-9994-4c9d3a397b05",
+      "alias": "first broker login",
+      "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "review profile config",
+          "authenticator": "idp-review-profile",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "flowAlias": "User creation or linking",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "e2999e54-86c5-44a3-a268-19becf60c356",
+      "alias": "forms",
+      "description": "Username, password, otp and other auth forms.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "flowAlias": "Browser - Conditional OTP",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "2058750d-4a1a-42cd-b6ff-c446964d6e56",
+      "alias": "http challenge",
+      "description": "An authentication flow based on challenge-response HTTP Authentication Schemes",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "no-cookie-redirect",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "flowAlias": "Authentication Options",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "b70c25f1-70c9-4a29-9e4a-522ca96cfbc9",
+      "alias": "registration",
+      "description": "registration flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-page-form",
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "flowAlias": "registration form",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "a192bd36-14e2-403c-8529-35c6e23eaf88",
+      "alias": "registration form",
+      "description": "registration form",
+      "providerId": "form-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-user-creation",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "registration-profile-action",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 40,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "registration-password-action",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 50,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "registration-recaptcha-action",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 60,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "5a152f56-3cbb-4685-a926-03ac61503348",
+      "alias": "reset credentials",
+      "description": "Reset credentials for a user if they forgot their password or something",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "reset-credentials-choose-user",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "reset-credential-email",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "reset-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 30,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 40,
+          "flowAlias": "Reset - Conditional OTP",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "d4fcb108-14d8-401e-a3a2-ea894f481c71",
+      "alias": "saml ecp",
+      "description": "SAML ECP Profile Authentication Flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "http-basic-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    }
+  ],
+  "authenticatorConfig": [
+    {
+      "id": "030f686c-cf67-40c8-8d0b-98ccb032b78f",
+      "alias": "create unique user config",
+      "config": {
+        "require.password.update.after.registration": "false"
+      }
+    },
+    {
+      "id": "15d6fea6-5931-48b0-bcb9-cb46c47ab579",
+      "alias": "review profile config",
+      "config": {
+        "update.profile.on.first.login": "missing"
+      }
+    }
+  ],
+  "requiredActions": [
+    {
+      "alias": "CONFIGURE_TOTP",
+      "name": "Configure OTP",
+      "providerId": "CONFIGURE_TOTP",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 10,
+      "config": {}
+    },
+    {
+      "alias": "terms_and_conditions",
+      "name": "Terms and Conditions",
+      "providerId": "terms_and_conditions",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 20,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PASSWORD",
+      "name": "Update Password",
+      "providerId": "UPDATE_PASSWORD",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 30,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PROFILE",
+      "name": "Update Profile",
+      "providerId": "UPDATE_PROFILE",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 40,
+      "config": {}
+    },
+    {
+      "alias": "VERIFY_EMAIL",
+      "name": "Verify Email",
+      "providerId": "VERIFY_EMAIL",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 50,
+      "config": {}
+    },
+    {
+      "alias": "delete_account",
+      "name": "Delete Account",
+      "providerId": "delete_account",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 60,
+      "config": {}
+    },
+    {
+      "alias": "update_user_locale",
+      "name": "Update User Locale",
+      "providerId": "update_user_locale",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 1000,
+      "config": {}
+    }
+  ],
+  "browserFlow": "browser",
+  "registrationFlow": "registration",
+  "directGrantFlow": "direct grant",
+  "resetCredentialsFlow": "reset credentials",
+  "clientAuthenticationFlow": "clients",
+  "dockerAuthenticationFlow": "docker auth",
+  "attributes": {
+    "cibaBackchannelTokenDeliveryMode": "poll",
+    "cibaExpiresIn": "120",
+    "cibaAuthRequestedUserHint": "login_hint",
+    "oauth2DeviceCodeLifespan": "600",
+    "oauth2DevicePollingInterval": "5",
+    "parRequestUriLifespan": "60",
+    "cibaInterval": "5"
+  },
+  "keycloakVersion": "15.0.2",
+  "userManagedAccessAllowed": false,
+  "clientProfiles": {
+    "profiles": []
+  },
+  "clientPolicies": {
+    "policies": []
+  }
+}


### PR DESCRIPTION
Upgrade the Keycloak instance to the latest production value to enable
maximum compatibility. This also updates the docker-compose to start up
the same version.

Paginating 100 users at a time is causing quite the overhead in Keycloak
due to the use of Redis caching implementation. This change passes
through `-1` for the size to return all. This removes multiple calls to
keycloak to zip them together.