### PR TITLE
HOCS-5057 Fix MLA lookup

### DIFF
--- a/kube/kd/deployment.yaml
+++ b/kube/kd/deployment.yaml
@@ -187,7 +187,9 @@ spec:
           env:
             - name: JAVA_OPTS
               value: >-
-                -Dhttp.nonProxyHosts=*.{{.KUBE_NAMESPACE}}.svc.cluster.local
+                -Dhttp.proxyHost=hocs-outbound-proxy.{{.KUBE_NAMESPACE}}.svc.cluster.local
+                -Dhttp.proxyPort=31290
+                -Dhttps.nonProxyHosts=*.{{.KUBE_NAMESPACE}}.svc.cluster.local
                 -Dhttps.proxyHost=hocs-outbound-proxy.{{.KUBE_NAMESPACE}}.svc.cluster.local
                 -Dhttps.proxyPort=31290
                 -Djavax.net.ssl.trustStore=/etc/keystore/truststore.jks

--- a/kube/kd/deployment.yaml
+++ b/kube/kd/deployment.yaml
@@ -186,7 +186,13 @@ spec:
                 name: hocs-queue-config
           env:
             - name: JAVA_OPTS
-              value: '-Xms768m -Xmx768m -Djavax.net.ssl.trustStore=/etc/keystore/truststore.jks -Dhttps.proxyHost=hocs-outbound-proxy.{{.KUBE_NAMESPACE}}.svc.cluster.local -Dhttps.proxyPort=31290 -Dhttp.nonProxyHosts=*.{{.KUBE_NAMESPACE}}.svc.cluster.local'
+              value: >-
+                -Dhttp.nonProxyHosts=*.{{.KUBE_NAMESPACE}}.svc.cluster.local
+                -Dhttps.proxyHost=hocs-outbound-proxy.{{.KUBE_NAMESPACE}}.svc.cluster.local
+                -Dhttps.proxyPort=31290
+                -Djavax.net.ssl.trustStore=/etc/keystore/truststore.jks
+                -Xms768m
+                -Xmx768m
             - name: JDK_TRUST_FILE
               value: '/etc/keystore/truststore.jks'
             - name: SERVER_PORT


### PR DESCRIPTION
The NI Assembly data service info-service looks up is only available via
plain old HTTP (:80) and 404s if you try HTTPS (:443). Prior to this
commit hocs-info-service was configured to route outbound HTTPS requests
through the outbound proxy, but not HTTP requests, meaning that the NI
Assembly request times out.

This commit tells hocs-info-service explicitly to go via the outbound
proxy for HTTP requests as well.

This commit also fixes a typo in the config: the non-proxy host list
only applied to HTTP but was probably meant to apply only to HTTPS.