### PR TITLE
HOCS-5284 Revert non-proxy hosts config change

### DIFF
--- a/kube/kd/deployment.yaml
+++ b/kube/kd/deployment.yaml
@@ -187,9 +187,9 @@ spec:
           env:
             - name: JAVA_OPTS
               value: >-
+                -Dhttp.nonProxyHosts=*.{{.KUBE_NAMESPACE}}.svc.cluster.local
                 -Dhttp.proxyHost=hocs-outbound-proxy.{{.KUBE_NAMESPACE}}.svc.cluster.local
                 -Dhttp.proxyPort=31290
-                -Dhttps.nonProxyHosts=*.{{.KUBE_NAMESPACE}}.svc.cluster.local
                 -Dhttps.proxyHost=hocs-outbound-proxy.{{.KUBE_NAMESPACE}}.svc.cluster.local
                 -Dhttps.proxyPort=31290
                 -Djavax.net.ssl.trustStore=/etc/keystore/truststore.jks


### PR DESCRIPTION
When the HTTPS non-proxy host is set and HTTP non-proxy host is unset,
the info-service casework call for DCU primary topic fails because it
gets routed incorrectly via the outbound proxy.

I don't understand why that's the case, or why it would only affect
primary topics, but this commit reverts the change I made, as HTTP
non-proxy hosts are clearly more loadbearing than I had assumed.