### PR TITLE
Move drone concurrency limit

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -195,8 +195,6 @@ trigger:
   branch:
     - main
     - support/*
-concurrency:
-  limit: 1
 
 environment:
   KEYCLOAK_SERVER_ROOT: http://keycloak:8080
@@ -374,6 +372,8 @@ trigger:
     - main
 depends_on:
   - tag data
+concurrency:
+  limit: 1
 
 steps:
   - name: deploy to cs-dev


### PR DESCRIPTION
To ensure that multiple tags aren't released at the same time we use a
concurrency limit of 1 within the drone `build tag` step. While this
works it blocks over release candidates (after quick merge) from
starting until the previous job is complete. While this isn't
necessarily wrong there is no reason why a tag cannot be build and its
necessary data builds also built. This change moves the concurrency to
the deploy step to speed up things when multiple changes have been
merged in a short amount of time.