### PR TITLE
HOCS-4656: deprecate PriorityPolicy

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/PriorityPolicyResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/PriorityPolicyResource.java
@@ -12,6 +12,7 @@ import java.util.List;
 import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
 
 @RestController
+@Deprecated(forRemoval = true)
 public class PriorityPolicyResource {
 
     private final PriorityPolicyService priorityPolicyService;
@@ -21,6 +22,7 @@ public class PriorityPolicyResource {
         this.priorityPolicyService = priorityPolicyService;
     }
 
+    @Deprecated(forRemoval = true)
     @GetMapping(value = "/priority/policy/{caseType}", produces = APPLICATION_JSON_UTF8_VALUE)
     public ResponseEntity<List<PriorityPolicyDto>> getByCaseType(@PathVariable String caseType) {
         return ResponseEntity.ok(priorityPolicyService.getByCaseType(caseType));

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/PriorityPolicyService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/PriorityPolicyService.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 
 @Service
 @Slf4j
+@Deprecated(forRemoval = true)
 public class PriorityPolicyService {
 
     private final PriorityPolicyRepository priorityPolicyRepository;
@@ -21,6 +22,7 @@ public class PriorityPolicyService {
         this.priorityPolicyRepository = priorityPolicyRepository;
     }
 
+    @Deprecated(forRemoval = true)
     public List<PriorityPolicyDto> getByCaseType(String caseType) {
         log.debug("Getting Priority Policies for {}", caseType);
         List<PriorityPolicy> policies = priorityPolicyRepository.findAllByCaseType(caseType);

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/PriorityPolicyRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/PriorityPolicyRepository.java
@@ -6,8 +6,11 @@ import uk.gov.digital.ho.hocs.info.domain.model.PriorityPolicy;
 
 import java.util.List;
 
+@Deprecated(forRemoval = true)
 @Repository
 public interface PriorityPolicyRepository extends CrudRepository<PriorityPolicy, Long> {
 
+    @Deprecated(forRemoval = true)
     List<PriorityPolicy> findAllByCaseType(String caseType);
+
 }


### PR DESCRIPTION
Add the deprecation flag to all code around PriorityPolicy as this has
been migrated over to `hocs-casework`.