### PR TITLE
HOCS-5271: reintroduce hocs-data tag hack

### DIFF
--- a/.github/workflows/semver-data.yml
+++ b/.github/workflows/semver-data.yml
@@ -14,14 +14,50 @@ on:
 
 jobs:
   semver:
-    name: Manual SemVer Tag
+    name: 'Manual SemVer Tag'
     runs-on: ubuntu-latest
     steps:
-      - uses: UKHomeOffice/semver-tag-action@v2
+
+      - name: Calculate SemVer increment
+        id: increment
+        uses: UKHomeOffice/semver-tag-action@v2
         with:
           increment: ${{ github.event.inputs.increment }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_use_head_tag: true
+          dry_run: true
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_ROBOT_USER_NAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+      - name: Calculate metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ inputs.images }}
+          tags: |
+            type=raw,value=${{steps.increment.outputs.version}}
+            type=raw,value=latest,enable=true
+
+      - name: Build container
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Tag repository with SemVer
+        uses: UKHomeOffice/semver-tag-action@v2
+        with:
+          tag: ${{steps.increment.outputs.version}}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_use_head_tag: true
+
       - name: Post failure to Slack channel
         id: slack
         uses: slackapi/slack-github-action@v1.19.0


### PR DESCRIPTION
When we make a change in hocs-data or wcs-data we CURL back to hocs-info service to trigger a new build, I'm not a fan of this behaviour but we should not regress the behaviour for now.

This was caused by a restriction in github actions, where an event raised by a GH action (Tag) can't trigger another GU action (docker-build-on-tag), so we must temporarily duplicate the docker build behaviour.  