### PR TITLE
HOCS-2141: Use a smaller container for cron job.

### DIFF
--- a/kube/kd/refreshmembers.yaml
+++ b/kube/kd/refreshmembers.yaml
@@ -18,7 +18,7 @@ spec:
               securityContext:
                 runAsNonRoot: true
                 runAsUser: 1000
-              image: quay.io/ukhomeofficedigital/openjdk11:v11.0.5_10
+              image: quay.io/ukhomeofficedigital/hocs-base-image:latest
               env:
                 - name: HOCS_BASICAUTH
                   valueFrom:
@@ -27,5 +27,5 @@ spec:
                       key: plaintext
               command: ["/bin/sh", "-c"]
               args:
-                - http_status=$( curl -vk -u ${HOCS_BASICAUTH} -w '%{http_code}' https://hocs-info-service.{{.KUBE_NAMESPACE}}.svc.cluster.local/admin/member/refresh ); if [[ $http_status -eq 200 ]]; then exit 0; else exit 1; fi
+                - http_status=$( wget --no-check-certificate --spider -S "https://${HOCS_BASICAUTH}@hocs-info-service.{{.KUBE_NAMESPACE}}.svc.cluster.local/admin/member/refresh" 2>&1 | grep "HTTP/" | awk '{print $2}' ); if [[ $http_status -eq 200 ]]; then exit 0; else exit 1; fi
           restartPolicy: OnFailure


### PR DESCRIPTION
This container is still a java container, but it is the base (actually parent) image for our services, so should already be present in the cluster level registry and will be maintained by us. Either way it's only 45Mb vs 400Mb