### PR TITLE
HOCS-5363: support summary screen column

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/SchemaResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/SchemaResource.java
@@ -59,6 +59,7 @@ public class SchemaResource {
         return ResponseEntity.ok(fields);
     }
 
+    @Deprecated(forRemoval = true)
     @GetMapping(value = "/schema/{schemaType}/fields", produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<List<FieldDto>> getFieldsBySchemaType(@PathVariable String schemaType) {
         List<FieldDto> fields = schemaService.getFieldsBySchemaType(schemaType);

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/SchemaService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/SchemaService.java
@@ -89,6 +89,7 @@ public class SchemaService {
         return caseTypeSchemas;
     }
 
+    @Deprecated(forRemoval = true)
     public List<FieldDto> getFieldsBySchemaType(String schemaType) {
         log.debug("Getting all Fields for schema {}", schemaType);
         List<Field> fields = fieldRepository.findAllBySchemaType(schemaType);

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/FieldDto.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/FieldDto.java
@@ -66,6 +66,7 @@ public class FieldDto {
                 childField);
     }
 
+    @Deprecated(forRemoval = true)
     public static FieldDto fromWithDecoratedProps(final Field field, ObjectMapper mapper) {
         final FieldDto childField = field.getChild() != null ? FieldDto.from(field.getChild()) : null;
 

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/SchemaDto.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/SchemaDto.java
@@ -42,11 +42,14 @@ public class SchemaDto {
     @JsonProperty("validation")
     private String validation;
 
+    @JsonRawValue
+    private String summary;
+
     public static SchemaDto from(Schema schema) {
         List<FieldDto> fieldDtos = schema.getFields().stream().map(FieldDto::from).collect(Collectors.toList());
         List<SecondaryActionDto> secondaryActionsDtos = schema.getSecondaryActions().stream().map(SecondaryActionDto::from).collect(Collectors.toList());
 
         return new SchemaDto(schema.getUuid(), schema.getStageType(), schema.getType(), schema.getTitle(), schema.getActionLabel(),
-                schema.isActive(), fieldDtos, secondaryActionsDtos, schema.getProps(), schema.getValidation());
+                schema.isActive(), fieldDtos, secondaryActionsDtos, schema.getProps(), schema.getValidation(), schema.getSummary());
     }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/Schema.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/Schema.java
@@ -68,6 +68,10 @@ public class Schema implements Serializable {
     @Column(name = "validation")
     private String validation;
 
+    @Getter
+    @Column(name = "summary")
+    private String summary;
+
     public List<Field> getFields() {
         return fieldScreens.stream()
                 .map(e -> e.getField())

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/FieldRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/FieldRepository.java
@@ -12,6 +12,7 @@ public interface FieldRepository extends CrudRepository<Field, String> {
     @Query(value = "SELECT * FROM field fi WHERE fi.summary = TRUE AND fi.uuid IN (SELECT field_uuid FROM field_screen fs INNER JOIN screen_schema ss ON ss.uuid = fs.schema_uuid INNER JOIN case_type_schema cts ON cts.schema_uuid = ss.uuid WHERE fs.field_uuid = fi.uuid AND ss.active = TRUE AND cts.case_type = ?1) ORDER BY fi.id", nativeQuery = true)
     List<Field> findAllSummaryFields(String caseType);
 
+    @Deprecated(forRemoval = true)
     @Query(value = "SELECT * from field f LEFT JOIN field_screen fs ON f.uuid = fs.field_uuid LEFT JOIN screen_schema ss ON ss.uuid = fs.schema_uuid WHERE ss.type = ?1 ORDER BY sort_order ASC", nativeQuery = true)
     List<Field> findAllBySchemaType(String schemaType);
 

--- a/src/main/resources/db/postgresql/V1_57__5363_AddSummaryToScreenSchema.sql
+++ b/src/main/resources/db/postgresql/V1_57__5363_AddSummaryToScreenSchema.sql
@@ -1,0 +1,4 @@
+ALTER TABLE screen_schema
+    ADD COLUMN summary JSONB NULL;
+
+COMMENT ON COLUMN screen_schema.summary IS 'JSONB array of objects containing label, case data lookup and optional renderer.'

--- a/src/test/java/uk/gov/digital/ho/hocs/info/api/SchemaServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/info/api/SchemaServiceTest.java
@@ -67,7 +67,7 @@ public class SchemaServiceTest {
                 new FieldScreen(schemaUUID, field2.getUuid(), 2L, field2));
 
 
-        Schema testSchema = new Schema(20L, schemaUUID, "type", "schemaTitle", "save", true, "stageType", fields, null, null, null);
+        Schema testSchema = new Schema(20L, schemaUUID, "type", "schemaTitle", "save", true, "stageType", fields, null, null, null, null);
 
         when(schemaRepository.findExtractOnlySchema()).thenReturn(testSchema);
 
@@ -117,8 +117,8 @@ public class SchemaServiceTest {
                 new FieldScreen(schema2UUID, field3.getUuid(), 1L, field3),
                 new FieldScreen(schema2UUID, field4.getUuid(), 2L, field4));
 
-        Schema schema1 = new Schema(21L, UUID.randomUUID(), "type1", "schemaTitle1", "save", true, "stageType", fields1, null, null, null);
-        Schema schema2 = new Schema(22L, UUID.randomUUID(), "type2", "schemaTitle2", "save", true, "stageType", fields2, null, null, null);
+        Schema schema1 = new Schema(21L, UUID.randomUUID(), "type1", "schemaTitle1", "save", true, "stageType", fields1, null, null, null, null);
+        Schema schema2 = new Schema(22L, UUID.randomUUID(), "type2", "schemaTitle2", "save", true, "stageType", fields2, null, null, null, null);
 
         when(schemaRepository.findAllActiveFormsByCaseType(caseType)).thenReturn(Set.of(schema1, schema2));
 
@@ -149,7 +149,7 @@ public class SchemaServiceTest {
     public void getSchemaByType() {
         String type = "TEST_TYPE";
         UUID uuid = UUID.randomUUID();
-        Schema testSchema = new Schema(1L, uuid, type, "schemaTitle", "save", true, "stageType", null, null, null, null);
+        Schema testSchema = new Schema(1L, uuid, type, "schemaTitle", "save", true, "stageType", null, null, null, null, null);
 
         when(schemaRepository.findByType(type)).thenReturn(testSchema);
 


### PR DESCRIPTION
To support screens that can have a summary after the submit button this
change allows for the return of the `screen_schema.summary` column from
the database. As this is a JSONB value, we flag that this should return
the JSON raw value.