### PR TITLE
HOCS-5363: mark case config as deprecated

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/CaseTypeResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/CaseTypeResource.java
@@ -49,6 +49,7 @@ public class CaseTypeResource {
         return ResponseEntity.ok(CaseTypeDto.from(caseType));
     }
 
+    @Deprecated(forRemoval = true)
     @GetMapping(value = "/caseType/{type}/config", produces = APPLICATION_JSON_UTF8_VALUE)
     ResponseEntity<CaseConfigDto> getCaseConfig(@PathVariable String type) {
         CaseConfig caseConfig = caseTypeService.getCaseConfig(type);

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/CaseTypeService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/CaseTypeService.java
@@ -102,6 +102,7 @@ public class CaseTypeService {
         }
     }
 
+    @Deprecated(forRemoval = true)
     CaseConfig getCaseConfig(String type) {
         log.debug("Getting CaseConfig for type {}", type);
         List<CaseTab> tabs = caseTabRepository.findTabsByType(type);

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/CaseConfigDto.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/CaseConfigDto.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Deprecated(forRemoval = true)
 public class CaseConfigDto {
 
     String type;

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/CaseConfig.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/CaseConfig.java
@@ -1,26 +1,13 @@
 package uk.gov.digital.ho.hocs.info.domain.model;
 
 import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.Table;
-import java.io.Serializable;
 import java.util.List;
-import java.util.UUID;
 
 @AllArgsConstructor
 @Getter
+@Deprecated(forRemoval = true)
 public class CaseConfig {
     @Getter
     private final String type;

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/CaseTabRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/CaseTabRepository.java
@@ -4,12 +4,11 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 import uk.gov.digital.ho.hocs.info.domain.model.CaseTab;
-import uk.gov.digital.ho.hocs.info.domain.model.CaseType;
 
 import java.util.List;
-import java.util.Set;
 
 @Repository
+@Deprecated(forRemoval = true)
 public interface CaseTabRepository extends CrudRepository<CaseTab, String> {
 
     @Query(value = "SELECT ctab.uuid, ctab.tab_name, ctab.tab_label, ctab.tab_screen FROM case_type_tab ctt JOIN case_type ctype on ctt.case_type_uuid = ctype.uuid JOIN case_tab ctab on ctt.case_tab_uuid = ctab.uuid WHERE ctype.type = ?1 ORDER BY ctt.sort_order", nativeQuery=true)


### PR DESCRIPTION
As case tabs are now served from a frontend configuration file, this
change marks all related functionality as deprecated pending future
removal.