### PR TITLE
HOCS-5279: deprecate reporting methods

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/ExtractService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/ExtractService.java
@@ -17,6 +17,7 @@ public class ExtractService {
         this.schemaService = schemaService;
     }
 
+    @Deprecated(forRemoval = true)
     public List<String> getAllReportingFieldsForCaseType(String caseType) {
         Stream<Field> sortedFields = Stream.concat(schemaService.getExtractOnlyFields().stream(),
                 schemaService.getAllReportingFieldsForCaseType(caseType).sorted(Comparator.comparingLong(Field::getId)));

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/SchemaResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/SchemaResource.java
@@ -53,6 +53,7 @@ public class SchemaResource {
         return ResponseEntity.ok(fields.stream().map(FieldDto::from).collect(Collectors.toList()));
     }
 
+    @Deprecated(forRemoval = true)
     @GetMapping(value = "/schema/caseType/{caseType}/reporting", produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<List<String>> getAllReportingFieldsForCaseType(@PathVariable String caseType) {
         List<String> fields = extractService.getAllReportingFieldsForCaseType(caseType);

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/SchemaService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/SchemaService.java
@@ -50,6 +50,7 @@ public class SchemaService {
         }
     }
 
+    @Deprecated(forRemoval = true)
     Set<Schema> getAllSchemasForCaseType(String caseType) {
         log.debug("Getting all Forms for CaseType {}", caseType);
         Set<Schema> caseTypeSchemas = schemaRepository.findAllActiveFormsByCaseType(caseType);
@@ -64,12 +65,14 @@ public class SchemaService {
         return summaryFields;
     }
 
+    @Deprecated(forRemoval = true)
     public Stream<Field> getAllReportingFieldsForCaseType(String caseType) {
         Set<Schema> caseTypeSchemas = getAllSchemasForCaseType(caseType);
         log.debug("Filtering to reporting only.");
         return caseTypeSchemas.stream().flatMap(f -> f.getFields().stream()).filter(Field::isReporting);
     }
 
+    @Deprecated(forRemoval = true)
     public List<Field> getExtractOnlyFields() {
         Schema extractOnlySchema = schemaRepository.findExtractOnlySchema();
 

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/SchemaRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/SchemaRepository.java
@@ -11,6 +11,7 @@ import java.util.Set;
 @Repository
 public interface SchemaRepository extends CrudRepository<Schema, String> {
 
+    @Deprecated(forRemoval = true)
     @Query(value = "SELECT ss.*, fi.*, cts.stage_type FROM screen_schema ss JOIN field_screen fs ON ss.uuid = fs.schema_uuid JOIN field fi on fs.field_uuid = fi.uuid JOIN case_type_schema cts ON ss.uuid = cts.schema_uuid AND cts.case_type = ?1 AND ss.active = TRUE", nativeQuery = true)
     Set<Schema> findAllActiveFormsByCaseType(String caseType);
 
@@ -19,6 +20,7 @@ public interface SchemaRepository extends CrudRepository<Schema, String> {
     @Query(value = "SELECT ss.*, '' as stage_type FROM screen_schema ss WHERE ss.type = ?1 AND ss.active = TRUE", nativeQuery = true)
     Schema findByType(String type);
 
+    @Deprecated(forRemoval = true)
     @Query(value = "SELECT ss.*, '' as stage_type FROM screen_schema ss WHERE ss.type = 'EXTRACT_ONLY'", nativeQuery = true)
     Schema findExtractOnlySchema();
 


### PR DESCRIPTION
Deprecate all methods related to reporting as it is no longer used due
to a refactor.