### PR TITLE
HOCS-5279: deprecate custom export view methods

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/ExportViewResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/ExportViewResource.java
@@ -12,6 +12,7 @@ import java.util.List;
 import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
 
 @RestController
+@Deprecated(forRemoval = true)
 public class ExportViewResource {
 
     private final ExportViewService exportViewService;

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/ExportViewService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/ExportViewService.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 
 @Service
 @Slf4j
+@Deprecated(forRemoval = true)
 public class ExportViewService {
 
     private final ExportViewRepository exportViewRepository;

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/ExportViewDto.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/ExportViewDto.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 @Getter
 @AllArgsConstructor
+@Deprecated(forRemoval = true)
 public class ExportViewDto {
 
     private Long id;

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/ExportViewFieldAdapterDto.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/ExportViewFieldAdapterDto.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+@Deprecated(forRemoval = true)
 public class ExportViewFieldAdapterDto {
 
     private Long id;

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/ExportViewFieldDto.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/ExportViewFieldDto.java
@@ -8,6 +8,7 @@ import java.util.List;
 @java.lang.SuppressWarnings("squid:S1068")
 @Getter
 @AllArgsConstructor
+@Deprecated(forRemoval = true)
 public class ExportViewFieldDto {
 
     private Long id;

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/ExportView.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/ExportView.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @javax.persistence.Entity
 @Table(name = "export_view")
+@Deprecated(forRemoval = true)
 public class ExportView implements Serializable {
 
     @Id

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/ExportViewRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/ExportViewRepository.java
@@ -7,6 +7,7 @@ import uk.gov.digital.ho.hocs.info.domain.model.ExportView;
 import java.util.List;
 
 @Repository
+@Deprecated(forRemoval = true)
 public interface ExportViewRepository extends CrudRepository<ExportView, Long> {
 
     List<ExportView> findAll();


### PR DESCRIPTION
Deprecate all methods related to custom export views as is longer
required due to a refactor.