### PR TITLE
HOCS-5281: deprecate non-required classes

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/SchemaResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/SchemaResource.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @RestController
+@Deprecated(forRemoval = true)
 public class SchemaResource {
 
     private final SchemaService schemaService;
@@ -33,7 +34,6 @@ public class SchemaResource {
         return ResponseEntity.ok(from);
     }
 
-    @Deprecated(forRemoval = true)
     @GetMapping(value = "/schema/caseType/{caseType}", params = { "stages" }, produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<List<SchemaDto>> getAllSchemasForCaseType(@PathVariable String caseType,
                                                                     @RequestParam("stages") String stages) {
@@ -41,7 +41,6 @@ public class SchemaResource {
         return ResponseEntity.ok(schemas.stream().map(SchemaDto::from).collect(Collectors.toList()));
     }
 
-    @Deprecated(forRemoval = true)
     @GetMapping(value = "/schema/{schemaType}/fields", produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<List<FieldDto>> getFieldsBySchemaType(@PathVariable String schemaType) {
         List<FieldDto> fields = schemaService.getFieldsBySchemaType(schemaType);

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/SchemaService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/SchemaService.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 
 @Service
 @Slf4j
+@Deprecated(forRemoval = true)
 public class SchemaService {
 
     private final FieldRepository fieldRepository;
@@ -46,7 +47,6 @@ public class SchemaService {
         }
     }
 
-    @Deprecated(forRemoval = true)
     Set<Schema> getAllSchemasForCaseTypeAndStage(String caseType, String stages) {
         log.debug("Getting all Forms for stages {} and CaseType {}", stages, caseType);
         List<String> stagesList = new ArrayList<>(Arrays.asList(stages.split(",")));
@@ -55,7 +55,6 @@ public class SchemaService {
         return caseTypeSchemas;
     }
 
-    @Deprecated(forRemoval = true)
     public List<FieldDto> getFieldsBySchemaType(String schemaType) {
         log.debug("Getting all Fields for schema {}", schemaType);
         List<Field> fields = fieldRepository.findAllBySchemaType(schemaType);

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/FieldDto.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/FieldDto.java
@@ -17,6 +17,7 @@ import java.util.UUID;
 @AllArgsConstructor(access = lombok.AccessLevel.PRIVATE)
 @Getter
 @Slf4j
+@Deprecated(forRemoval = true)
 public class FieldDto {
 
     @JsonProperty("uuid")
@@ -51,7 +52,6 @@ public class FieldDto {
             field.getLabel(), field.getProps(), field.isActive(), childField);
     }
 
-    @Deprecated(forRemoval = true)
     public static FieldDto fromWithDecoratedProps(final Field field, ObjectMapper mapper) {
         final FieldDto childField = field.getChild() != null ? FieldDto.from(field.getChild()) : null;
 

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/SchemaDto.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/SchemaDto.java
@@ -1,7 +1,10 @@
 package uk.gov.digital.ho.hocs.info.api.dto;
 
-import com.fasterxml.jackson.annotation.*;
-import lombok.*;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRawValue;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import uk.gov.digital.ho.hocs.info.domain.model.Schema;
 
 import java.util.List;
@@ -10,6 +13,7 @@ import java.util.stream.Collectors;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
+@Deprecated(forRemoval = true)
 public class SchemaDto {
 
     @JsonProperty("uuid")

--- a/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/SecondaryActionDto.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/api/dto/SecondaryActionDto.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
+@Deprecated(forRemoval = true)
 public class SecondaryActionDto {
 
     @JsonProperty("uuid")

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/FieldScreen.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/FieldScreen.java
@@ -4,7 +4,12 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 import java.io.Serializable;
 import java.util.UUID;
 
@@ -14,6 +19,7 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Deprecated(forRemoval = true)
 public class FieldScreen implements Serializable {
 
     @Id

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/Schema.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/Schema.java
@@ -4,7 +4,16 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.OneToMany;
+import javax.persistence.OrderBy;
+import javax.persistence.Table;
 import java.io.Serializable;
 import java.util.List;
 import java.util.UUID;
@@ -14,6 +23,7 @@ import java.util.stream.Collectors;
 @Table(name = "screen_schema")
 @NoArgsConstructor
 @AllArgsConstructor
+@Deprecated(forRemoval = true)
 public class Schema implements Serializable {
 
     @Id

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/SecondaryAction.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/SecondaryAction.java
@@ -4,7 +4,11 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
 import java.io.Serializable;
 import java.util.UUID;
 
@@ -12,6 +16,7 @@ import java.util.UUID;
 @Table(name = "secondary_action")
 @NoArgsConstructor
 @AllArgsConstructor
+@Deprecated(forRemoval = true)
 public class SecondaryAction implements Serializable {
 
     @Id

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/FieldRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/FieldRepository.java
@@ -6,9 +6,9 @@ import uk.gov.digital.ho.hocs.info.domain.model.Field;
 
 import java.util.List;
 
+@Deprecated(forRemoval = true)
 public interface FieldRepository extends CrudRepository<Field, String> {
 
-    @Deprecated(forRemoval = true)
     @Query(value = "SELECT * from field f LEFT JOIN field_screen fs ON f.uuid = fs.field_uuid LEFT JOIN screen_schema ss ON ss.uuid = fs.schema_uuid WHERE ss.type = ?1 ORDER BY sort_order ASC",
            nativeQuery = true)
     List<Field> findAllBySchemaType(String schemaType);

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/SchemaRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/repository/SchemaRepository.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Set;
 
 @Repository
+@Deprecated(forRemoval = true)
 public interface SchemaRepository extends CrudRepository<Schema, String> {
 
     Set<Schema> findAll();
@@ -17,7 +18,6 @@ public interface SchemaRepository extends CrudRepository<Schema, String> {
            nativeQuery = true)
     Schema findByType(String type);
 
-    @Deprecated(forRemoval = true)
     @Query(value = "SELECT ss.*, fi.*, cts.stage_type FROM screen_schema ss " + "JOIN field_screen fs ON ss.uuid = fs.schema_uuid JOIN field fi on fs.field_uuid = fi.uuid " + "JOIN case_type_schema cts ON ss.uuid = cts.schema_uuid AND cts.case_type = ?1 AND ss.active = TRUE " + "JOIN stage_type st ON cts.stage_type = st.type " + "WHERE st.type IN (?2) " + "AND st.can_display_stage = true " + "ORDER BY st.display_stage_order",
            nativeQuery = true)
     Set<Schema> findAllActiveFormsByCaseTypeAndStages(String caseType, List<String> stages);


### PR DESCRIPTION
Mark all classes linked to Screens, Fields and SecondaryActions as deprecated as no longer required due to refactoring.