### PR TITLE
[HOCS-7068] Update Welsh members API domain

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/info/client/ingest/ListConsumerService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/client/ingest/ListConsumerService.java
@@ -41,7 +41,7 @@ public class ListConsumerService {
 
     private final String apiNorthernIrelandAssembly;
 
-    private final String apiWelshParliament;
+    private final String apiWelshSenedd;
 
     private final String countriesJsonFilename;
 
@@ -55,7 +55,7 @@ public class ListConsumerService {
     public ListConsumerService(@Value("${api.uk.parliament}") String apiUkParliament,
                                @Value("${api.scottish.parliament}") String apiScottishParliament,
                                @Value("${api.ni.assembly}") String apiNorthernIrelandAssembly,
-                               @Value("${api.welsh.assembly}") String apiWelshParliament,
+                               @Value("${api.welsh.senedd}") String apiWelshSenedd,
                                @Value("${country.json.filename}") String countriesJsonFilename,
                                @Value("${territory.json.filename}") String territoriesJsonFilename,
                                HouseAddressRepository houseAddressRepository,
@@ -63,7 +63,7 @@ public class ListConsumerService {
         this.apiUkParliament = apiUkParliament;
         this.apiScottishParliament = apiScottishParliament;
         this.apiNorthernIrelandAssembly = apiNorthernIrelandAssembly;
-        this.apiWelshParliament = apiWelshParliament;
+        this.apiWelshSenedd = apiWelshSenedd;
         this.countriesJsonFilename = countriesJsonFilename;
         this.territoriesJsonFilename = territoriesJsonFilename;
         this.houseAddressRepository = houseAddressRepository;
@@ -159,9 +159,9 @@ public class ListConsumerService {
     public Set<Member> createFromWelshParliamentAPI() {
         log.info("Updating Welsh Parliament");
         try {
-            final HouseAddress houseAddress = retrieveHouseAddress(HouseCodes.WELSH_ASSEMBLY);
+            final HouseAddress houseAddress = retrieveHouseAddress(HouseCodes.WELSH_SENEDD);
 
-            WelshWards welshWards = getDataFromAPI(apiWelshParliament, MediaType.APPLICATION_XML, WelshWards.class);
+            WelshWards welshWards = getDataFromAPI(apiWelshSenedd, MediaType.APPLICATION_XML, WelshWards.class);
 
             if (welshWards.getWards() != null) {
                 Set<WelshMembers> welshMembers = welshWards.getWards().stream().map(WelshWard::getMembers).collect(
@@ -208,18 +208,18 @@ public class ListConsumerService {
         headers.setAccept(Collections.singletonList(mediaType));
         HttpEntity<String> entity = new HttpEntity<>("parameters", headers);
 
-        ResponseEntity<T> response = null;
         try {
             log.info("Attempting to hit endpoint {}, returning type {} of class {}", apiEndpoint, mediaType,
                 returnClass.getName());
-            response = restTemplate.exchange(apiEndpoint, HttpMethod.GET, entity, returnClass);
+            ResponseEntity<T> response = restTemplate.exchange(apiEndpoint, HttpMethod.GET, entity, returnClass);
             log.info("Response to endpoint {} is {}", apiEndpoint, response);
+
+            return response.getBody();
         } catch (Exception e) {
-            log.info("exchange call exception : " + e.getMessage());
+            log.info("exchange call exception : {}", e.getMessage());
             throw new ApplicationExceptions.IngestException(
-                "ListConsumerService exchange exception : " + e.getMessage() + " endpoint : " + apiEndpoint + " headers : " + headers.toString() + " media type : " + mediaType.toString());
+                "ListConsumerService exchange exception : " + e.getMessage() + " endpoint : " + apiEndpoint + " headers : " + headers + " media type : " + mediaType.toString());
         }
-        return response.getBody();
     }
 
     private String getFormattedUkEndpoint(@NonNull final String house) {

--- a/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/enums/HouseCodes.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/info/domain/model/enums/HouseCodes.java
@@ -8,7 +8,7 @@ public enum HouseCodes {
     HOUSE_OF_COMMONS("HC"),
     HOUSE_OF_LORDS("HL"),
     SCOTTISH_PARLIAMENT("SP"),
-    WELSH_ASSEMBLY("WA");
+    WELSH_SENEDD("WA");
 
     @Getter
     private final String houseCode;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,10 +20,11 @@ spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 api.uk.parliament=https://data.parliament.uk/membersdataplatform/services/mnis/members/query/house=%s
 api.scottish.parliament=https://data.parliament.scot/api/members
 api.ni.assembly=https://data.niassembly.gov.uk/members.asmx/GetAllCurrentMembers
-api.welsh.assembly=https://senedd.assembly.wales/mgwebservice.asmx/GetCouncillorsByWard
+api.welsh.senedd=https://business.senedd.wales/mgwebservice.asmx/GetCouncillorsByWard
 country.json.filename=countries-list.json
 territory.json.filename=territories-list.json
 
+# suppress inspection "SpringBootApplicationProperties"
 hocs.url=http://localhost:8080
 hocs.case-service=http://localhost:8082
 hocs.document-service=http://localhost:8083


### PR DESCRIPTION
`senedd.assembly.wales` redirects to `business.senedd.wales`. The second domain was being blocked by the squid proxy (see https://github.com/UKHomeOffice/hocs-helm-charts/pull/154). Now that is updated `senedd.assembly.wales` is no longer allowlisted, so it won't be able to make the request and be redirected.

https://collaboration.homeoffice.gov.uk/jira/browse/HOCS-7068